### PR TITLE
docs(skills): state the Agent Skills format and add MIT license frontmatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ CI enforces the mechanical parts of this contract on every push and PR: [`skills
 uvx --from "git+https://github.com/agentskills/agentskills.git#subdirectory=skills-ref" skills-ref validate skills/<name>
 ```
 
-- Frontmatter: `name` and `description` only, under 1024 characters total.
+- Frontmatter: `name`, `description`, and `license: MIT`, nothing else. The spec caps `name` at 64 characters and `description` at 1024; the other spec-optional fields (`compatibility`, `metadata`, `allowed-tools`) are not used in this repo.
 - `name`: lowercase letters, numbers, and hyphens; must equal the directory name.
 - `description`: third person, starts with "Use when", describes triggering conditions only (never a summary of the skill's workflow), under 500 characters, rich in keywords an agent would search for.
 - Body: 400-600 words (hard cap 900). Structure: Overview, Quick reference, one excellent worked example, Common mistakes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Scenario Agent Skills
 
-[Agent Skills](https://agentskills.io) that teach AI coding agents (Claude Code, Cursor, Codex, Copilot, and 70+ others) how to create production-ready content with [Scenario](https://scenario.com) through the [Scenario MCP server](https://mcp.scenario.com): images, video, audio, textures, skyboxes, 3D assets, and custom-trained models, for games, entertainment, and any creative vertical.
+Agent Skills that teach AI coding agents (Claude Code, Cursor, Codex, Copilot, and 70+ others) how to create production-ready content with [Scenario](https://scenario.com) through the [Scenario MCP server](https://mcp.scenario.com): images, video, audio, textures, skyboxes, 3D assets, and custom-trained models, for games, entertainment, and any creative vertical.
+
+Skills follow the [Agent Skills](https://agentskills.io) format.
 
 [![skills.sh](https://skills.sh/b/scenario-labs/skills)](https://skills.sh/scenario-labs/skills)
 
@@ -24,15 +26,15 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 
 ## Skills
 
-| Skill                                                            | Use it for                                                                                                       |
-| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| [scenario](skills/scenario/SKILL.md)                             | Connecting to the Scenario MCP and the core generation loop: discover, schema, run, wait, display, download       |
-| [scenario-game-assets](skills/scenario-game-assets/SKILL.md)     | Sprites, icons, props, tilesets, pixel art, concept art, transparent backgrounds, style-consistent batches        |
-| [scenario-textures](skills/scenario-textures/SKILL.md)           | Seamless and tileable textures, PBR materials, tiling-safe upscaling, engine-ready sizing                         |
-| [scenario-skyboxes](skills/scenario-skyboxes/SKILL.md)           | 360 equirectangular panoramas and skyboxes, seam-safe upscaling, engine export                                    |
-| [scenario-3d](skills/scenario-3d/SKILL.md)                       | Text or image to 3D meshes, multi-view reconstruction, retexture and remesh, inline 3D preview, GLB/FBX download  |
-| [scenario-video](skills/scenario-video/SKILL.md)                 | Text-to-video and image-to-video, motion prompting, lipsync, video editing, upscaling, cut/split/concat utilities |
-| [scenario-audio](skills/scenario-audio/SKILL.md)                 | Music, sound effects, voice and speech generation, video scoring, audio utilities                                 |
+| Skill                                                              | Use it for                                                                                                        |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| [scenario](skills/scenario/SKILL.md)                               | Connecting to the Scenario MCP and the core generation loop: discover, schema, run, wait, display, download       |
+| [scenario-game-assets](skills/scenario-game-assets/SKILL.md)       | Sprites, icons, props, tilesets, pixel art, concept art, transparent backgrounds, style-consistent batches        |
+| [scenario-textures](skills/scenario-textures/SKILL.md)             | Seamless and tileable textures, PBR materials, tiling-safe upscaling, engine-ready sizing                         |
+| [scenario-skyboxes](skills/scenario-skyboxes/SKILL.md)             | 360 equirectangular panoramas and skyboxes, seam-safe upscaling, engine export                                    |
+| [scenario-3d](skills/scenario-3d/SKILL.md)                         | Text or image to 3D meshes, multi-view reconstruction, retexture and remesh, inline 3D preview, GLB/FBX download  |
+| [scenario-video](skills/scenario-video/SKILL.md)                   | Text-to-video and image-to-video, motion prompting, lipsync, video editing, upscaling, cut/split/concat utilities |
+| [scenario-audio](skills/scenario-audio/SKILL.md)                   | Music, sound effects, voice and speech generation, video scoring, audio utilities                                 |
 | [scenario-model-training](skills/scenario-model-training/SKILL.md) | Training custom models for style, character, or product consistency, and generating with them                     |
 
 ## Example prompts
@@ -45,7 +47,7 @@ Once the skills are installed and the MCP server is connected, ask your agent th
 
 ## What is an Agent Skill?
 
-A skill is a `SKILL.md` file with procedural knowledge an agent loads on demand. The format is the open [Agent Skills specification](https://agentskills.io/specification); the `skills` CLI installs these files into 70+ agents, and the ecosystem directory lives at [skills.sh](https://www.skills.sh).
+A skill is a `SKILL.md` file with procedural knowledge an agent loads on demand, defined by the open [Agent Skills specification](https://agentskills.io/specification). The `skills` CLI installs these files into 70+ agents, and the ecosystem directory lives at [skills.sh](https://www.skills.sh).
 
 ## Contributing
 

--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-3d
 description: Use when generating or handling 3D assets through the Scenario MCP server, including text-to-3D or image-to-3D meshes, GLB, FBX, OBJ, or VOX files, PBR-textured or game-ready models, voxel models, multi-view reconstruction, retexture, remesh, UV unwrap, or rigging steps, previewing a mesh in the inline 3D viewer, capturing a viewer screenshot, or downloading a model for import into Unity, Unreal, Godot, or Blender.
+license: MIT
 ---
 
 # Scenario 3D Asset Workflows

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-audio
 description: Use when generating or handling audio on Scenario via MCP. Triggers include music tracks, background scores, soundtracks, game sound effects, SFX, foley, ambience, looping audio, voiceover, narration, speech, TTS, text-to-speech, voice cloning, re-voicing a recording, scoring or adding sound to a video, transcription, or requests to create, wait on, play, or download audio files (MP3, WAV) with Scenario tools.
+license: MIT
 ---
 
 # Scenario Audio Generation

--- a/skills/scenario-game-assets/SKILL.md
+++ b/skills/scenario-game-assets/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-game-assets
 description: Use when creating game art through the Scenario MCP, including sprites, sprite sheets, game icons, props, loot, tilesets, seamless tiles, isometric buildings, top-down maps, pixel art, and character or concept art, or when game assets need transparent backgrounds, background removal, style-consistent variation batches, upscaling, pixel-grid cleanup, or engine-ready PNG export for Unity, Godot, or Unreal.
+license: MIT
 ---
 
 # Scenario Game Assets

--- a/skills/scenario-model-training/SKILL.md
+++ b/skills/scenario-model-training/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-model-training
 description: "Use when generated assets must keep a consistent style, character, or product look and prompts or reference images stop scaling, or when a user asks to train a custom model on their images through the Scenario MCP, fine-tune a LoRA, clone a voice, upload a training dataset, configure epochs, estimate training cost, or generate with their own trained model. Keywords: custom model, fine-tune, LoRA training, dataset, training job, style consistency."
+license: MIT
 ---
 
 # Scenario Model Training

--- a/skills/scenario-skyboxes/SKILL.md
+++ b/skills/scenario-skyboxes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-skyboxes
 description: Use when a task involves generating or iterating on skyboxes, 360 panoramas, equirectangular images, environment maps, or VR backdrops through the Scenario MCP. Triggers include text-to-skybox, turning a photo into a 360 environment, restyling a panorama's mood, upscaling a skybox without breaking the seam wrap, or exporting equirectangular or cubemap layouts for game engines such as Unity, Unreal, or Godot.
+license: MIT
 ---
 
 # Scenario Skyboxes and 360 Panoramas

--- a/skills/scenario-textures/SKILL.md
+++ b/skills/scenario-textures/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-textures
 description: "Use when a task involves game textures or materials through the Scenario MCP: seamless or tileable textures, themed texture packs (brick, wood, stone, floors, hand-painted), PBR materials (albedo, metallic, roughness, normal) on 3D assets, retexturing a mesh, material iteration from reference images, texture upscaling that must preserve tiling, or sizing textures for game engines. Keywords: seamless texture, tileable, PBR, material, retexture, texture upscale, surface."
+license: MIT
 ---
 
 # Scenario texture and material workflows

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario-video
 description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (animating a still, first/last frame anchors), motion prompt iteration, lipsync and talking avatars, video upscale to 4K, prompt-based video editing, trim, split, concat, reframe, resize, extend, frame extraction, background removal, or waiting on long video jobs. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, ads, film previz, game cinematics, social clips."
+license: MIT
 ---
 
 # Scenario Video Generation and Editing

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: scenario
 description: Use when connecting a coding agent to Scenario (scenario.com) through MCP, or when a task involves generating images, video, 3D, audio, sprites, textures, or game assets with Scenario. Also when picking a Scenario model, refining a generation prompt, uploading reference images, waiting on generation jobs, checking credits or quota, hitting Scenario auth or Forbidden errors, or setting up mcp.scenario.com in Claude Code, Cursor, or VSCode.
+license: MIT
 ---
 
 # Scenario


### PR DESCRIPTION
## Summary

Quality pass against the Agent Skills standard ([agentskills.io](https://agentskills.io)):

- The README now states "Skills follow the [Agent Skills](https://agentskills.io) format." above the skills.sh badge, and the "What is an Agent Skill?" section defers to the [specification](https://agentskills.io/specification) link instead of restating the claim.
- Every skill's frontmatter gains `license: MIT`. `license` is one of the six frontmatter fields the spec and `skills-ref` allow, and the `skills` CLI copies SKILL.md files verbatim into user repos, so installed copies now carry the license.
- The AGENTS.md authoring contract lists the new field and now attributes the 1024-character cap to `description` alone (the spec's per-field limit) instead of the whole frontmatter.

Not adopted, tracked as issues instead: per-skill `metadata.json` (not part of the spec, and the `skills` CLI excludes it at install time) and the spec's optional `compatibility` field.

## Validation

`pnpm run validate` passes: house style, supporting-file checks, cspell, and `skills-ref validate` on all eight skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)