### PR TITLE
chore(tooling): add VS Code format-on-save settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "cSpell.import": ["cspell.json"],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.vscode/settings.json` (prettier as default formatter, format on save and on paste, per-language formatter pins for markdown, JSON, and YAML, and `cSpell.import` of the repo `cspell.json`) and `.vscode/extensions.json` recommending the prettier and Code Spell Checker extensions. Keeps markdown files consistently formatted while editing.

Repo-wide prettier enforcement (CI and pre-commit, plus formatting for shell scripts) is tracked separately as an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)