### PR TITLE
feat(scenario-seedance): add the Seedance video skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | [scenario-skyboxes](skills/scenario-skyboxes/SKILL.md)             | 360 equirectangular panoramas and skyboxes, seam-safe upscaling, engine export                                    |
 | [scenario-3d](skills/scenario-3d/SKILL.md)                         | Text or image to 3D meshes, multi-view reconstruction, retexture and remesh, inline 3D preview, GLB/FBX download  |
 | [scenario-video](skills/scenario-video/SKILL.md)                   | Text-to-video and image-to-video, motion prompting, lipsync, video editing, upscaling, cut/split/concat utilities |
+| [scenario-seedance](skills/scenario-seedance/SKILL.md)             | Seedance video: mode selection (first frame, references, edit, extend), conditioning traps, cost gating           |
 | [scenario-audio](skills/scenario-audio/SKILL.md)                   | Music, sound effects, voice and speech generation, video scoring, audio utilities                                 |
 | [scenario-model-training](skills/scenario-model-training/SKILL.md) | Training custom models for style, character, or product consistency, and generating with them                     |
 

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -36,7 +36,7 @@ In reference mode, frame one anchors to the base state of the reference world, a
 1. `search` with `target="models"`, `query="seedance"`, `public=true`. Prefer the newest non-deprecated hit, e.g. `model_bytedance-seedance-2-5` (a live hit at authoring time: re-discover each session).
 2. `model_schema_get` with that id: confirm fields, caps, and defaults first.
 3. `upload_asset` the product stills (see the `scenario` skill) to get asset ids.
-4. `model_run` with `dry_run=true` and the exact parameters, e.g. `{"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": false}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
+4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": false}}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
 5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
 6. `asset_display` the output. For a file, take the URL from `asset_get` and fetch it with `curl -L` (`asset_download` converts image formats only).
 

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: scenario-seedance
+description: "Use when generating or editing video with Seedance models on Scenario via MCP: text-to-video, image-to-video from a first frame, first and last frame anchors, reference-to-video with identity, product, or world references, prompt-based video editing, extending a clip, audio-conditioned motion, or deciding between first-frame and reference conditioning. Keywords: Seedance 2.5, ByteDance, T2V, I2V, V2V, multimodal references, video extension."
+license: MIT
+---
+
+# Scenario Seedance Video
+
+## Overview
+
+Seedance, ByteDance's video family on Scenario, folds text-to-video, first/last frame, reference-to-video, editing, and extension into one model that infers the mode from your inputs and prompt, so the conditioning inputs you pass decide more than prompt wording does. Discover it with `search` and treat `model_schema_get` as the contract: the family evolves and availability differs per team.
+
+Connection and the core generation loop: see the `scenario` skill in this repo. Model-agnostic video work: see the `scenario-video` skill in this repo.
+
+## Quick reference
+
+Mode follows from the inputs (names from the live schema):
+
+| Mode         | Inputs                          | Behavior                                                       |
+| ------------ | ------------------------------- | -------------------------------------------------------------- |
+| Text         | `prompt`                        | `aspectRatio` honored (21:9 through 9:16)    |
+| First frame  | `image` (+ `prompt`)            | opens on that frame; `aspectRatio` ignored              |
+| First + last | `image` + `lastFrameImage`      | `lastFrameImage` is only valid alongside `image`                |
+| Reference    | `referenceImages` (up to 30)    | carries identity and world, not the opening state               |
+| Edit         | `referenceVideos` + edit prompt | requires `duration: -1`; output follows the source  |
+| Extend       | `referenceVideos` + boundary prompt | continues the clip; geometry follows the source             |
+
+`image` and the reference arrays are mutually exclusive. `referenceVideos` (up to 10) and `referenceAudio` (up to 10, timing and energy conditioning) combine with `referenceImages`. Reference parameters are arrays even for one asset. Prompt tags bind by array order: `@image1` is `referenceImages[0]`; likewise `@video1`, `@audio1`. Duration: 4 to 30 seconds or -1 auto (the longest reference clip's length). Resolution: `480p` or `720p`. `generateAudio` defaults to true. No seed, mask, or camera parameter exists: camera moves live in the prompt, one dominant move per shot.
+
+## The conditioning rule
+
+In reference mode, frame one anchors to the base state of the reference world, and no prompt wording overrides it. If the shot must open in a specific state, render a still of it and pass it as `image`; use `referenceImages` when only identity, world, and palette matter. Deciding this per shot before generating is worth more than any prompt tuning.
+
+## Worked example: a product shot from references
+
+1. `search` with `target="models"`, `query="seedance"`, `public=true`. Prefer the newest non-deprecated hit, e.g. `model_bytedance-seedance-2-5` (a live hit at authoring time: re-discover each session).
+2. `model_schema_get` with that id: confirm fields, caps, and defaults first.
+3. `upload_asset` the product stills (see the `scenario` skill) to get asset ids.
+4. `model_run` with `dry_run=true` and the exact parameters, e.g. `{"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": false}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+6. `asset_display` the output. For a file, take the URL from `asset_get` and fetch it with `curl -L` (`asset_download` converts image formats only).
+
+## Common mistakes
+
+- Prompting an opening state in reference mode: it will not appear; pass it as `image`.
+- A bare string where the schema says array: one reference still goes as `["asset_x"]`.
+- Combining `image` with `referenceImages` or `referenceVideos`: mutually exclusive inputs.
+- Edit mode with a fixed duration: editing requires `duration: -1`.
+- Setting `aspectRatio` in first-frame, edit, or extend modes: ignored; geometry follows the input.
+- Leaving `generateAudio` at its default (true) when the soundtrack comes later.
+- Rendering captions, prices, logos, or UI: reserve clean space and composite text in post.


### PR DESCRIPTION
## Summary

Ports the Seedance 2.5 video skill from Emmanuel de Maistre's [scenario-seedance-2-5-video](https://github.com/edemaistre/scenario-seedance-2-5-video) into the repo's authoring contract. The text is a from-scratch rewrite grounded in a live `model_schema_get` read and the [tool reference](https://mcp.scenario.com/docs/tools); model ids are taught via `search` discovery, never asserted.

What the skill owns (complementing `scenario-video`, which keeps generic discovery, editing utilities, and upscaling):

- The six-mode table (text, first frame, first+last, reference, edit, extend) with the mutual exclusions, typed reference caps (30/10/10), `@image1`-style tag binding by array order, duration/resolution bounds, and the traps: `aspectRatio` ignored in anchored modes, edit mode requires `duration: -1`, `generateAudio` defaults to true, no seed or mask parameter.
- The conditioning rule learned across four paid failed renders: reference mode anchors frame one to the reference world's base state and no prompt wording overrides it; an opening state must be passed as `image`.
- Dry-run cost gating, `wait=false` + `jobs_wait` recovery, and video download via the `asset_get` URL (`asset_download` converts image formats only).

## Application test

Fresh planning-only agent (this skill + the `scenario` skill), task: edit an existing clip's background, then extend it 8 seconds, with cost estimates and a local file. The plan used only real tool and parameter names, discovered the model via `search`, handled edit mode (`referenceVideos` array, `duration: -1`, no `aspectRatio`), gated both paid runs behind dry runs, re-called `jobs_wait` with `pending_job_ids` without duplicating `model_run`, and saved via the `asset_get` URL. Baseline probe without the skill guessed wrong parameter names (`params`, `type`, a `path` on `asset_download`), missed `duration: -1` and reference arrays, and assumed two models plus local ffmpeg concat.

Credit: the skill distills operational knowledge measured by Emmanuel de Maistre in the source repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3c73da312f378e9cb105cba4496cba5e472199e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->