### PR TITLE
fix(skills): route video and audio downloads through asset_get

### DIFF
--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -19,7 +19,7 @@ Scenario generates audio through the same loop as images: discover a model, read
 | Generate | `model_run` | schema-conformant parameters; wait=false for long jobs |
 | Wait | `jobs_wait` | blocks server-side; re-call passing pending_job_ids as job_ids on timeout |
 | Listen | `asset_display` | renders an inline audio player |
-| Save | `asset_download` | follow redirects: `curl -L -o out.mp3 "<url>"` |
+| Save | `asset_get` | file URL, then `curl -L -o out.mp3 "<url>"` |
 
 Find existing audio assets with `search` target="assets", filters={kind: "audio"}. OAuth callers pass team_id and project_id on every call (discover them with `teams_list`; see the `scenario` skill).
 
@@ -27,30 +27,31 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 
 - Music: text-to-music models produce instrumental tracks or full songs; several accept lyrics with section tags and duration controls.
 - Sound effects: text-to-SFX models generate short clips from a description; some support seamless looping.
-- Voice and speech: text-to-speech models with preset voices, multilingual output, and emotion or pacing controls; some clone a voice from a short reference clip; speech-to-speech models re-voice an existing recording.
+- Voice and speech: text-to-speech models with preset voices, multilingual output, and emotion or pacing controls; some clone a voice from a short reference clip; speech-to-speech re-voices an existing recording.
 - Video to audio: models that score a silent video or add synchronized sound effects, taking a video asset as input.
-- Utilities: audio cut, split, and extract tools plus speech-to-text transcription; discover them with `search` query="audio" or query="tool".
+- Utilities: audio cut, split, and extract tools plus speech-to-text transcription; discover with `search` query="audio" or query="tool".
 
 ## Worked example: a game sound effect
 
 1. `search` target="models", query="sound effect", public=true. Returns txt2audio models such as `model_elevenlabs-sound-effects-v2` (example only; re-discover every session, catalogs differ per team).
-2. `model_schema_get` model_id="model_elevenlabs-sound-effects-v2". Returns the exact fields: the prompt plus model-specific controls such as duration or looping.
+2. `model_schema_get` model_id="model_elevenlabs-sound-effects-v2". Returns the exact fields: prompt plus model-specific controls such as duration or looping.
 3. `model_run` model_id="model_elevenlabs-sound-effects-v2", parameters={"prompt": "heavy wooden treasure chest creaking open, single event, dry, no music"}.
-4. If the response is status='in_progress', `jobs_wait` job_ids=["job_xxx"]. Timeout is not an error; call again, passing the returned pending_job_ids as job_ids.
+4. If the response is status='in_progress', `jobs_wait` job_ids=["job_xxx"]. Timeout is not an error; re-call with the returned pending_job_ids as job_ids.
 5. `asset_display` asset_id="asset_xxx" to play it inline.
-6. `asset_download` asset_id="asset_xxx", then save the URL with `curl -L`.
+6. `asset_get` asset_id="asset_xxx", then save its file URL with `curl -L`.
 
 Prompting tips:
 
 - SFX: name the source, material, action, and acoustic space, and say what to exclude ("no music", "no reverb"). One event per clip; generate variations as separate runs.
 - Music: give genre, mood, tempo, and instrumentation, and say instrumental or vocal. Lyrics-capable models expect structured sections; check the schema.
-- Speech: keep the text field to the words to speak. Voice choice, language, emotion, and pacing live in separate schema fields or inline tags depending on the model, so check the schema instead of packing direction into the text.
+- Speech: keep the text field to the words to speak. Voice choice, language, emotion, and pacing live in separate schema fields or inline tags depending on the model; check the schema instead of packing direction into the text.
 
 ## Common mistakes
 
 - Hardcoding model IDs: availability differs per team and evolves. Re-discover with `search` each session.
 - Skipping `model_schema_get`: one audio model's parameters will not fit another (voices, durations, and lyric fields all differ).
 - Polling `job_get` in a loop: music jobs can run minutes. Use `jobs_wait`; on timeout re-call with pending_job_ids.
-- Pasting raw asset URLs into chat: use `asset_display` to play audio, `asset_download` when a file URL is needed.
+- Pasting raw asset URLs into chat: use `asset_display` to play audio.
+- Saving audio with `asset_download`: image conversion only; take the file URL from `asset_get`.
 - Putting voice direction inside TTS text ("say this angrily"): direction can end up spoken. Use the schema's emotion or voice fields.
 - Sending image parameters (width, height) to audio models: their schemas do not accept them.

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -22,20 +22,18 @@ Connection and the core generation loop: see the `scenario` skill in this repo.
 | Refine prompt  | `prompt_spark`                    | Optional; rewrites a thin motion idea into an on-model prompt                                     |
 | Generate       | `model_run`                       | `wait=false` for video; `dry_run=true` to estimate cost first                                     |
 | Wait           | `jobs_wait`                       | Re-call with the returned `pending_job_ids` until done                                            |
-| Review         | `asset_display` / `asset_download` | Display inline; download with `curl -L` (URLs redirect)                                          |
+| Review         | `asset_display` / `asset_get`     | Display inline; save video from the `asset_get` URL with `curl -L`                            |
 
 ## Worked example: animate a key art still into a short ad clip
 
-The same flow serves film previz, game cinematics, and social content.
-
 1. `search` with `target="models"`, `query="image to video"`, `public=true`. Live hits include `model_kling-v2-6-i2v-pro` and `model_veo3-1-fast`; re-discover rather than hardcoding, availability shifts per team.
-2. `model_schema_get` with `model_id="model_kling-v2-6-i2v-pro"`. Note the exact image field, duration options, and any last-frame anchor.
+2. `model_schema_get` with `model_id="model_kling-v2-6-i2v-pro"`. Note the image field, duration options, and any last-frame anchor.
 3. `upload_asset` the still; it returns `asset_id="asset_abc"`.
 4. `model_run` with `parameters={"image": "asset_abc", "prompt": "slow dolly-in, steam rising from the mug, shallow depth of field"}` and `wait=false`. Returns a `job_id`.
 5. `jobs_wait` with `job_ids=["job_xyz"]`. On `status="in_progress"`, call again, passing the returned `pending_job_ids` as `job_ids`.
-6. `asset_display` the output video; `asset_download` for the file.
+6. `asset_display` the output video; save the file from the `asset_get` URL with `curl -L`.
 
-Iterating on motion: the source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several image-to-video models also accept first and last frame anchors or keyframe sequences (Kling, Veo 3.1, Seedance, Luma Ray 3.2); take the exact parameter names from `model_schema_get`, never from memory.
+Iterating on motion: the source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several image-to-video models also accept first and last frame anchors or keyframe sequences (Kling, Veo 3.1, Seedance, Luma Ray 3.2); take exact parameter names from `model_schema_get`, never from memory.
 
 ## Editing existing footage
 
@@ -45,12 +43,13 @@ All editing is `model_run` on a video-input model; discover each with `search`:
 - Lipsync and dubbing: query `"lipsync"` for video-to-video sync (Sync Lipsync, Kling Lipsync, Veed) and talking-portrait image-to-video avatars.
 - Upscaling up to 4K: query `"video upscale"` (Topaz, SeedVR2, Magnific, Flash VSR).
 - Deterministic utilities: query `"tool"` or `"video"` for trim (Video Cut), split, concat with transitions, resize, reverse, reframe to new aspect ratios, background removal, and frame extraction (Video to Image Sequence).
-- Extending a clip with new generated footage from its last frame: query `"extend video"`.
+- Extending a clip with new footage from its last frame: query `"extend video"`.
 
 ## Common mistakes
 
 - Passing a local file path as `image` or `video`: models take `asset_id`s; `upload_asset` first.
-- Calling `model_run` without `model_schema_get`: field names and duration limits differ per model, so a payload that worked on Kling will not fit Veo.
-- Polling `job_get` in a loop: use `jobs_wait`; its ~180s timeout is not an error, just re-call with `pending_job_ids`.
-- Treating search hits as stable: catalogs evolve, so re-run `search` and prefer non-deprecated hits (many deprecated models carry a `deprecated:<replacement_id>` tag pointing at the successor; some only a bare `deprecated` tag).
-- Pasting raw CDN URLs into chat: use `asset_display` for inline preview and `asset_download` to save.
+- Calling `model_run` without `model_schema_get`: field names and duration limits differ per model; a payload that worked on Kling will not fit Veo.
+- Polling `job_get` in a loop: use `jobs_wait`; its ~180s timeout is not an error; re-call with `pending_job_ids`.
+- Treating search hits as stable: catalogs evolve, so re-run `search` and prefer non-deprecated hits (many deprecated models carry a `deprecated:<replacement_id>` tag pointing at the successor; some only a bare tag).
+- Pasting raw CDN URLs into chat: use `asset_display` for inline preview.
+- Downloading video with `asset_download`: image conversion only; take the file URL from `asset_get`.


### PR DESCRIPTION
## Summary

`asset_download` performs image format conversion only (its target format defaults to `png`), so it is the wrong tool for saving video and audio files. `scenario-video` and `scenario-audio` previously taught it for exactly those downloads; both now teach taking the file URL from `asset_get` and saving with `curl -L`, matching the behavior the new `scenario-seedance` skill (#9) already documents.

- `scenario-video`: Review row, worked-example step 6, and a new Common mistakes bullet.
- `scenario-audio`: Save row, worked-example step 6, and a new Common mistakes bullet.
- A few sentences in each are tightened so both bodies stay at the word budget (600/602).

`scenario-3d` is left as is: the image-only limitation is confirmed for video and audio, not for 3D formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ad3ec1675cd8aeaeb6fce07eda3f6d1466fbdb78. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->