### PR TITLE
fix(ci): bump astral-sh/setup-uv from v6 to v10.0.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10.0.0
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Summary

Every run of the `validate` workflow currently emits a deprecation warning (e.g. [run 31646158441](https://github.com/scenario-labs/skills/actions/runs/31646158441)):

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: astral-sh/setup-uv@v6.

- Bump `astral-sh/setup-uv` from `v6` to `v10.0.0` in `.github/workflows/validate.yml`. The action runs on Node 24 since v7.0.0, which clears the warning.
- Pinned to the immutable `v10.0.0` tag rather than `@v10`: setup-uv stopped publishing floating major/minor tags in v8.0.0 for supply-chain-security reasons, so a `v10` tag does not exist.
- The step passes no inputs, so the other breaking changes between v6 and v10 (new `manifest-file` format, `prune-cache` defaulting to `false`, automatic cache disabled on `pull_request_target`/`workflow_run`/`release` events) do not affect this workflow.

## Test plan

- [x] `pnpm validate` passes locally (also runs `uvx ... skills-ref validate` via `pnpm spec`, the same command this action provisions uv for in CI)
- [ ] `validate` workflow on this PR completes without the Node.js 20 deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1acad74530ec0296828bcffa923f4997b82cac79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->