### PR TITLE
fix(scenario): prefer OAuth setup and keep API keys out of agent-run commands

### DIFF
--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -12,18 +12,12 @@ Scenario (scenario.com) generates AI images, video, 3D, and audio across 500+ mo
 
 ## Setup
 
-Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Two auth methods, same endpoint:
-
-- OAuth (recommended): add the URL and sign in with a Scenario account.
-- API key: from app.scenario.com/settings/api, sent as `Authorization: Basic base64(key:secret)`.
+Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Prefer OAuth: add the URL, sign in with a Scenario account, and no credentials pass through the conversation.
 
 Claude Code:
 
 ```bash
 claude mcp add --transport http scenario https://mcp.scenario.com/mcp
-# API key variant:
-claude mcp add --transport http scenario https://mcp.scenario.com/mcp \
-  --header "Authorization: Basic $(echo -n 'KEY:SECRET' | base64)"
 ```
 
 Cursor / VSCode (`mcp.json`):
@@ -32,7 +26,7 @@ Cursor / VSCode (`mcp.json`):
 { "mcpServers": { "scenario": { "url": "https://mcp.scenario.com/mcp" } } }
 ```
 
-For API key auth, add `"headers": {"Authorization": "Basic <base64 key:secret>"}`.
+For headless or CI use, the same endpoint accepts API keys (`Authorization: Basic base64(key:secret)`, keys from app.scenario.com/settings/api). Build the header per the [connection guide](https://mcp.scenario.com/docs) and keep it out of the conversation: reference an environment variable in the client config (`--header "Authorization: Basic $SCENARIO_MCP_AUTH"`) or edit the config file directly. Never ask an agent to collect, encode, or echo a key or secret.
 
 The default toolset is the core loop below. Reconnect with `https://mcp.scenario.com/mcp?toolsets=full` to expose everything, or reach any tool at runtime via `scenario_tools_search` plus the `scenario_tool_execute_read` / `write` / `delete` executors.
 


### PR DESCRIPTION
## Why

skills.sh runs three independent security audits on every published skill (Gen Agent Trust Hub, Socket, Snyk). The `scenario` skill currently shows **Snyk: High Risk** ([audit details](https://www.skills.sh/scenario-labs/skills/scenario/security/snyk)), driven by finding W007 (HIGH, 0.90): the setup section embedded a literal `KEY:SECRET` base64 encoding inside an agent-runnable command, which teaches agents to handle and output secret values verbatim. Gen and Socket pass the skill; W007 is the only HIGH finding.

## What changed

- Setup now leads with OAuth as the preferred method: no credentials pass through the conversation.
- The API-key path stays (headless/CI is a real audience) but delegates the mechanics to the official [connection guide](https://mcp.scenario.com/docs): the example references an environment variable (`$SCENARIO_MCP_AUTH`) instead of a literal secret.
- New explicit rule for agents: never collect, encode, or echo a key or secret.

The remaining Snyk findings (W011 prompt-injection exposure, W012 remote MCP endpoint) are inherent to a remote-MCP skill, so the realistic post-rescan level is Medium, matching `scenario-video`.

## Validation

- `pnpm validate` green (style, prettier, skill-files, cspell, `skills-ref validate`).
- Body word count 620 (was 598; hard cap 900). The added words are the agent-facing secret-handling rule.
- Application test (per AGENTS.md protocol): a fresh planning-only agent given just this SKILL.md and a trap task (headless CI setup with a pasted API key, then a sprite generation) produced a correct plan: refused to echo or encode the pasted secret and flagged it as burned, routed credentials through env vars, discovered the model via `search`, ran `model_schema_get` before `model_run`, re-called `jobs_wait` with `pending_job_ids`, saved via `asset_download` + `curl -L`, and flagged unknowns instead of guessing. Graded against the [tool reference](https://mcp.scenario.com/docs/tools) fetched fresh; no invented tools or parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBCpPWA3MXthKHXz2LLzjw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a66d329878265e5cd1be08fd875d0514a5817e64. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->