### PR TITLE
fix(skills): correct the asset_download claim for video and audio

### DIFF
--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -19,7 +19,7 @@ Scenario generates audio through the same loop as images: discover a model, read
 | Generate       | `model_run`                                                                              | schema-conformant parameters; wait=false for long jobs                    |
 | Wait           | `jobs_wait`                                                                              | blocks server-side; re-call passing pending_job_ids as job_ids on timeout |
 | Listen         | `asset_display`                                                                          | renders an inline audio player                                            |
-| Save           | `asset_get`                                                                              | file URL, then `curl -L -o out.mp3 "<url>"`                               |
+| Save           | `asset_download`                                                                         | returns a download URL: `curl -L -o out.mp3 "<url>"`                      |
 
 Find existing audio assets with `search` target="assets", filters={kind: "audio"}. OAuth callers pass team_id and project_id on every call (discover them with `teams_list`; see the `scenario` skill).
 
@@ -38,7 +38,7 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 3. `model_run` model_id="model_elevenlabs-sound-effects-v2", parameters={"prompt": "heavy wooden treasure chest creaking open, single event, dry, no music"}.
 4. If the response is status='in_progress', `jobs_wait` job_ids=["job_xxx"]. Timeout is not an error; re-call with the returned pending_job_ids as job_ids.
 5. `asset_display` asset_id="asset_xxx" to play it inline.
-6. `asset_get` asset_id="asset_xxx", then save its file URL with `curl -L`.
+6. `asset_download` asset_id="asset_xxx" with no `format`, then save the returned URL with `curl -L`.
 
 Prompting tips:
 
@@ -52,6 +52,6 @@ Prompting tips:
 - Skipping `model_schema_get`: one audio model's parameters will not fit another (voices, durations, and lyric fields all differ).
 - Polling `job_get` in a loop: music jobs can run minutes. Use `jobs_wait`; on timeout re-call with pending_job_ids.
 - Pasting raw asset URLs into chat: use `asset_display` to play audio.
-- Saving audio with `asset_download`: image conversion only; take the file URL from `asset_get`.
+- Passing `format` to `asset_download` for audio: it converts image formats only, so omit it.
 - Putting voice direction inside TTS text ("say this angrily"): direction can end up spoken. Use the schema's emotion or voice fields.
 - Sending image parameters (width, height) to audio models: their schemas do not accept them.

--- a/skills/scenario-seedance-music-video/SKILL.md
+++ b/skills/scenario-seedance-music-video/SKILL.md
@@ -56,5 +56,5 @@ Each shot runs until the next starts and the last to the master's end, so gaps a
 - Prompting an opening state in reference mode: it will not appear; pass a first-frame `image`.
 - Judging a clip from a sparse contact sheet: a continuous camera move looks like a hard cut; measure first (see [references/shots.md](references/shots.md)).
 - Trusting the beat grid: sections and cut candidates are suggestions; check them against what you hear.
-- Downloading clips with `asset_download`: image conversion only; take each file URL from `asset_get` and `curl -L` it.
+- Passing `format` to `asset_download` for a clip: it converts image formats only, so omit it and `curl -L` the returned URL.
 - Calling it done without watching the delivery with sound, then muted.

--- a/skills/scenario-seedance-music-video/references/shots.md
+++ b/skills/scenario-seedance-music-video/references/shots.md
@@ -32,4 +32,5 @@ The auto-caption on a returned asset describes what the model thinks it made and
 
 - `model_run` with `dry_run: true` returns the estimate and creates no job; dry-run before a batch. Duration, resolution, and reference videos carry cost (the schema flags `cost_impact`); reference images and audio do not.
 - Reference audio above about 100KB goes up with the multipart `upload_asset` flow: PUT each part with no added checksum headers, then `upload_asset_complete`.
-- For video and audio files, `asset_download` converts image formats only: take the file URL from `asset_get` and fetch it with `curl -L`.
+- `asset_download` returns a download URL for any asset kind; its `format` parameter converts image formats only, so omit it for video and audio. Fetch with `curl -L`: the URL may redirect.
+- `asset_get` carries a `url` too, plus measured `properties` (`duration`, `frameRate`, `nbFrames`, `width`, `height`, `codecName`). That is the cheap way to check a clip's real length before laying it into a timeline: a model asked for eight seconds does not always return exactly eight.

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -38,7 +38,7 @@ In reference mode, frame one anchors to the base state of the reference world, a
 3. `upload_asset` the product stills (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": false}}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
 5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
-6. `asset_display` the output. For a file, take the URL from `asset_get` and fetch it with `curl -L` (`asset_download` converts image formats only).
+6. `asset_display` the output. For a file, `asset_download` with no `format` returns a download URL; fetch it with `curl -L` (`format` converts image formats only).
 
 ## Common mistakes
 

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -14,15 +14,15 @@ Connection and the core generation loop: see the `scenario` skill in this repo.
 
 ## Quick reference
 
-| Step           | Tool                          | Notes                                                                                                      |
-| -------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| Find a model   | `search`                      | `target="models"`, `public=true`, query `"image to video"`, `"video upscale"`, `"lipsync"`, `"video edit"` |
-| Inspect inputs | `model_schema_get`            | Always before `model_run`; video schemas differ widely (duration, aspect ratio, frame anchors)             |
-| Upload source  | `upload_asset`                | A local still or clip becomes an `asset_id`; never pass file paths                                         |
-| Refine prompt  | `prompt_spark`                | Optional; rewrites a thin motion idea into an on-model prompt                                              |
-| Generate       | `model_run`                   | `wait=false` for video; `dry_run=true` to estimate cost first                                              |
-| Wait           | `jobs_wait`                   | Re-call with the returned `pending_job_ids` until done                                                     |
-| Review         | `asset_display` / `asset_get` | Display inline; save video from the `asset_get` URL with `curl -L`                                         |
+| Step           | Tool                               | Notes                                                                                                      |
+| -------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Find a model   | `search`                           | `target="models"`, `public=true`, query `"image to video"`, `"video upscale"`, `"lipsync"`, `"video edit"` |
+| Inspect inputs | `model_schema_get`                 | Always before `model_run`; video schemas differ widely (duration, aspect ratio, frame anchors)             |
+| Upload source  | `upload_asset`                     | A local still or clip becomes an `asset_id`; never pass file paths                                         |
+| Refine prompt  | `prompt_spark`                     | Optional; rewrites a thin motion idea into an on-model prompt                                              |
+| Generate       | `model_run`                        | `wait=false` for video; `dry_run=true` to estimate cost first                                              |
+| Wait           | `jobs_wait`                        | Re-call with the returned `pending_job_ids` until done                                                     |
+| Review         | `asset_display` / `asset_download` | Display inline; `asset_download` returns the file URL, save it with `curl -L`                              |
 
 ## Worked example: animate a key art still into a short ad clip
 
@@ -31,7 +31,7 @@ Connection and the core generation loop: see the `scenario` skill in this repo.
 3. `upload_asset` the still; it returns `asset_id="asset_abc"`.
 4. `model_run` with `parameters={"image": "asset_abc", "prompt": "slow dolly-in, steam rising from the mug, shallow depth of field"}` and `wait=false`. Returns a `job_id`.
 5. `jobs_wait` with `job_ids=["job_xyz"]`. On `status="in_progress"`, call again, passing the returned `pending_job_ids` as `job_ids`.
-6. `asset_display` the output video; save the file from the `asset_get` URL with `curl -L`.
+6. `asset_display` the output video; `asset_download` (no `format`) returns the file URL, save it with `curl -L`.
 
 Iterating on motion: the source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several image-to-video models also accept first and last frame anchors or keyframe sequences (Kling, Veo 3.1, Seedance, Luma Ray 3.2); take exact parameter names from `model_schema_get`, never from memory.
 
@@ -52,4 +52,4 @@ All editing is `model_run` on a video-input model; discover each with `search`:
 - Polling `job_get` in a loop: use `jobs_wait`; its ~180s timeout is not an error; re-call with `pending_job_ids`.
 - Treating search hits as stable: catalogs evolve, so re-run `search` and prefer non-deprecated hits (many deprecated models carry a `deprecated:<replacement_id>` tag pointing at the successor; some only a bare tag).
 - Pasting raw CDN URLs into chat: use `asset_display` for inline preview.
-- Downloading video with `asset_download`: image conversion only; take the file URL from `asset_get`.
+- Passing `format` to `asset_download` for a video: it converts image formats only, so omit it.


### PR DESCRIPTION
## What

Four skills and one supporting file tell agents that `asset_download` is "image conversion only" and that video and audio file URLs must come from `asset_get` instead. That claim is false. This PR replaces it with the accurate, narrower fact.

## Why it matters

The claim appears in `scenario-audio`, `scenario-video`, `scenario-seedance`, `scenario-seedance-music-video` and `references/shots.md`, while `scenario`, `scenario-3d`, `scenario-textures` and `scenario-skyboxes` already teach `asset_download` as the download path. An agent with the core skill plus any video or audio skill installed is holding two contradictory instructions about the most common final step of every run.

## Verification

Called `asset_download` on a public video asset with no `format`, then fetched the returned URL:

```
HTTP 200 | type=video/mp4 | bytes=2513074
dl_test.mp4: ISO Media, MP4 Base Media v1 [ISO 14496-12:2003]
```

`bytes` matches the asset record's `metadata.size` exactly, so the original file is served rather than a conversion. Supporting evidence from the [tool reference](https://mcp.scenario.com/docs/tools): `asset_download` is documented as "Request a download URL for an asset, optionally converting to a target format" with no restriction by asset kind, and `asset_display`'s own description points at `asset_download` as the way to obtain a file URL.

What is actually image-specific is the `format` parameter, which maps to the API's `targetFormat` and takes `png` (default), `webp` or `jpg`. Omitting it serves the original file.

## Changes

- `scenario-audio`: Quick reference row, worked example step 6, and the Common mistakes bullet.
- `scenario-video`: Quick reference row, worked example step 6, and the Common mistakes bullet.
- `scenario-seedance`: worked example step 6.
- `scenario-seedance-music-video`: Common mistakes bullet.
- `references/shots.md`: the corrected fact, plus the `asset_get` detail that earns its place in an assembly context. `asset_get` carries measured `properties` (`duration`, `frameRate`, `nbFrames`, `width`, `height`, `codecName`), which is the cheap way to check a clip's real length before laying it into a timeline. A model asked for eight seconds does not always return exactly eight.

`curl -L` guidance is unchanged: transform URLs still redirect.

## Notes for review

- Bodies stay inside the 900-word hard cap. The four touched skills were already sitting at 600-603 words before this change and land at 602-607, a net increase of 2 to 5 words each. Trimming them back under the 600 soft budget means cutting the generic Common mistakes bullets that every skill repeats, which is a deliberate editorial change rather than a correction, so it is left out of this PR.
- `pnpm validate` passes (house style, prettier, supporting files, groupings, cspell, `skills-ref validate`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9bewbCswpgTqVp6Q1FKKf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c603557a915e21c04c4eb28a6ae730b66c27e3af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->