### PR TITLE
feat(scenario-workflows): add the workflows skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | [scenario-audio](skills/scenario-audio/SKILL.md)                               | Music, sound effects, voice and speech generation, video scoring, audio utilities                                 |
 | [scenario-seedance-music-video](skills/scenario-seedance-music-video/SKILL.md) | Turning a song into a finished music video: beat-aligned shots, lyric transcription, verified ffmpeg assembly     |
 | [scenario-model-training](skills/scenario-model-training/SKILL.md)             | Training custom models for style, character, or product consistency, and generating with them                     |
+| [scenario-workflows](skills/scenario-workflows/SKILL.md)                       | Running saved workflows (apps): building the run inputs, dry-run pricing, publishing drafts, approval gates       |
 
 ## Example prompts
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -18,3 +18,4 @@ shfmt
 tripo
 upscales
 veed
+wflow

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -31,6 +31,11 @@
       "title": "Custom models",
       "description": "Train custom models on your own art for style, character, or product consistency.",
       "skills": ["scenario-model-training"]
+    },
+    {
+      "title": "Workflows and apps",
+      "description": "Discover and run saved Scenario workflows, the multi-step pipelines users call apps.",
+      "skills": ["scenario-workflows"]
     }
   ]
 }

--- a/skills/scenario-workflows/SKILL.md
+++ b/skills/scenario-workflows/SKILL.md
@@ -26,7 +26,7 @@ Ids are prefixed `wflow_`, not `workflow_` as the tool-doc examples show, so cop
 
 ## Cap every list call
 
-Each record carries the compiled `flow` and the whole `editorInfo` node graph, and no compact flag exists. Live records ran 5,500 to 22,000 characters each, so the default `limit=20` returns a few hundred thousand. Cap `limit`, then read only `id`, `name`, `hasFlow` and `inputs`.
+Each record carries the compiled `flow` and the whole `editorInfo` node graph, and no compact flag exists. Live records ran 5,500 to 22,000 characters each, so the default `limit=20` returns a few hundred thousand. Cap `limit` at 3 or fewer, then read only `id`, `name`, `hasFlow` and `inputs`, paging with `page_token` set to the previous reply's `nextPaginationToken`.
 
 Only `draft` and `ready` filter server-side. Any other status filters the returned page client-side and the reply flags `_workflowListStatusFilter`, so an empty array beside a `nextPaginationToken` means none on this page.
 
@@ -43,9 +43,9 @@ Only `draft` and `ready` filter server-side. Any other status filters the return
 
 1. `workflows_list` with `status="ready"`, `limit=3`, plus `team_id` and `project_id`. Read `id`, `name` and `inputs` off each record; ignore `flow` and `editorInfo`.
 2. Take the target's `inputs[]` and key off each entry's `name`. One exposing `{"name": "text1", "label": "Text 1", "required": {"always": false}}` runs with `{"text1": "..."}`.
-3. `workflow_run` with `workflow_id`, `dry_run=true`, and the full `inputs` object. The reply carries the cost and an empty job, and it runs the real validator, so it doubles as a pre-flight check.
+3. `workflow_run` with `workflow_id`, `dry_run=true`, and the full `inputs` object. The reply is `creativeUnitsCost`, `creativeUnitsDiscount` and an empty `job`, so no job is created; quote that cost before running. It also runs the real validator, so it doubles as a pre-flight check.
 4. Repeat without `dry_run`, then `jobs_wait` on the returned job, re-called with `pending_job_ids` while it is in progress.
-5. `asset_display` the output assets.
+5. `asset_display` each output asset, one call per id.
 
 ## Common mistakes
 
@@ -54,5 +54,5 @@ Only `draft` and `ready` filter server-side. Any other status filters the return
 - Treating `required` as a boolean, so every input reads as mandatory.
 - Skipping the dry run because `ready` looks like proof: at authoring time two of three ready workflows failed validation there with correctly named inputs. Report that error rather than blaming the payload.
 - Running a draft: it carries `flow: []` and `hasFlow: false` while `editorInfo` and `inputs` look complete. `workflow_create` and `workflow_update` only persist a draft; `workflow_publish` compiles it.
-- Calling `workflow_approve` or `workflow_reject` without `node_id`: the gate is per node. A run parked on an approval node never finishes on its own, however long `jobs_wait` runs.
+- Calling `workflow_approve` or `workflow_reject` with fewer than all three of `workflow_id`, `workflow_job_id` and `node_id`: the gate is per node. A run parked on an approval node never finishes on its own, however long `jobs_wait` runs.
 - Sending `workflow_id` to `workflow_copy`: its parameter is `source_workflow_id`.

--- a/skills/scenario-workflows/SKILL.md
+++ b/skills/scenario-workflows/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: scenario-workflows
+description: "Use when a task involves a Scenario workflow through MCP, including anything the user calls a Scenario app, a saved pipeline, or a multi-step generation graph. Triggers include listing or running workflows, building the inputs object for workflow_run, pricing a run with a dry run, publishing a draft so it becomes runnable, approving or rejecting a paused approval node, copying a workflow, or a workflows_list reply that flooded the context. Keywords: workflow, app, pipeline, node graph, approval gate."
+license: MIT
+---
+
+# Scenario Workflows
+
+## Overview
+
+A Scenario workflow is a saved node graph that chains several models into one call. Users say "app" and mean a workflow whose status is `ready`. Running one is `workflow_run`, which returns a job tracked like any other generation.
+
+Only `workflows_list`, `workflow_get` and `workflow_run` are listed by default; the create, update, publish, copy, approve, reject and delete verbs run through `scenario_tools_search` plus the executor matching their lane. Connection and the core loop: see the `scenario` skill in this repo.
+
+## Quick reference
+
+| Step                  | Call                               | Notes                          |
+| --------------------- | ---------------------------------- | ------------------------------ |
+| 1. List               | `workflows_list` `status="ready"`  | Always cap `limit`             |
+| 2. Read the contract  | the record's `inputs[]`            | `name` is the run key          |
+| 3. Price and validate | `workflow_run` with `dry_run=true` | Returns cost, creates no job   |
+| 4. Run                | `workflow_run` with `inputs`       | Returns a job                  |
+| 5. Wait               | `jobs_wait`                        | Re-call with `pending_job_ids` |
+
+Ids are prefixed `wflow_`, not `workflow_` as the tool-doc examples show, so copy them from `workflows_list`. `search` with `target="workflows"` returned 403 at authoring time.
+
+## Cap every list call
+
+Each record carries the compiled `flow` and the whole `editorInfo` node graph, and no compact flag exists. Live records ran 5,500 to 22,000 characters each, so the default `limit=20` returns a few hundred thousand. Cap `limit`, then read only `id`, `name`, `hasFlow` and `inputs`.
+
+Only `draft` and `ready` filter server-side. Any other status filters the returned page client-side and the reply flags `_workflowListStatusFilter`, so an empty array beside a `nextPaginationToken` means none on this page.
+
+## The input contract
+
+`workflow_run`'s `inputs` object is keyed by `inputs[].name`, taken verbatim from the record. Names are authored per workflow: some semantic (`characterDescription`, `line1`), some positional (`text2`, `text3`), and positional names are neither contiguous nor ordered. One live workflow exposes only `text2` and `text3` while its graph still contains a `text1` node.
+
+- `label` and `description` carry the human intent, not the key. A field labelled "Source Image" is still keyed `image1`.
+- Never harvest keys from `editorInfo.nodes[].data.name`: on one live workflow seven input nodes all carried the stale value `text1`.
+- `required` is an object. Test `required.always === true`, because a truthiness check reads `{"always": false}` as required too.
+- `workflow_get` returns the definition as `inputs_definition` and `editor_info` wrapped in `workflow`; `workflows_list` returns the same data as `inputs` and `editorInfo` wrapped in `workflows`. Use the names belonging to the tool you called.
+
+## Worked example: run a saved app
+
+1. `workflows_list` with `status="ready"`, `limit=3`, plus `team_id` and `project_id`. Read `id`, `name` and `inputs` off each record; ignore `flow` and `editorInfo`.
+2. Take the target's `inputs[]` and key off each entry's `name`. One exposing `{"name": "text1", "label": "Text 1", "required": {"always": false}}` runs with `{"text1": "..."}`.
+3. `workflow_run` with `workflow_id`, `dry_run=true`, and the full `inputs` object. The reply carries the cost and an empty job, and it runs the real validator, so it doubles as a pre-flight check.
+4. Repeat without `dry_run`, then `jobs_wait` on the returned job, re-called with `pending_job_ids` while it is in progress.
+5. `asset_display` the output assets.
+
+## Common mistakes
+
+- Calling `workflows_list` with no `limit`: the node graphs alone can fill a context window.
+- Guessing input keys from labels, or rebuilding them from the node graph instead of reading `inputs[]`.
+- Treating `required` as a boolean, so every input reads as mandatory.
+- Skipping the dry run because `ready` looks like proof: at authoring time two of three ready workflows failed validation there with correctly named inputs. Report that error rather than blaming the payload.
+- Running a draft: it carries `flow: []` and `hasFlow: false` while `editorInfo` and `inputs` look complete. `workflow_create` and `workflow_update` only persist a draft; `workflow_publish` compiles it.
+- Calling `workflow_approve` or `workflow_reject` without `node_id`: the gate is per node. A run parked on an approval node never finishes on its own, however long `jobs_wait` runs.
+- Sending `workflow_id` to `workflow_copy`: its parameter is `source_workflow_id`.

--- a/skills/scenario-workflows/SKILL.md
+++ b/skills/scenario-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-workflows
-description: "Use when a task involves a Scenario workflow through MCP, including anything the user calls a Scenario app, a saved pipeline, or a multi-step generation graph. Triggers include listing or running workflows, building the inputs object for workflow_run, pricing a run with a dry run, publishing a draft so it becomes runnable, approving or rejecting a paused approval node, copying a workflow, or a workflows_list reply that flooded the context. Keywords: workflow, app, pipeline, node graph, approval gate."
+description: "Use when a task involves a Scenario workflow through MCP, including anything the user calls a Scenario app, a saved pipeline, or a multi-step generation graph. Triggers include listing or running workflows, building the inputs object for workflow_run, pricing a run with a dry run, publishing a draft so it becomes runnable, approving or rejecting a paused approval node, copying a workflow, or a workflows_list reply that flooded the context. Keywords: workflow, app, pipeline, approval gate."
 license: MIT
 ---
 
@@ -8,9 +8,9 @@ license: MIT
 
 ## Overview
 
-A Scenario workflow is a saved node graph that chains several models into one call. Users say "app" and mean a workflow whose status is `ready`. Running one is `workflow_run`, which returns a job tracked like any other generation.
+A Scenario workflow is a saved node graph chaining several models into one call; users say "app" and mean one whose status is `ready`. `workflow_run` runs it and returns a job tracked like any other generation.
 
-Only `workflows_list`, `workflow_get` and `workflow_run` are listed by default; the create, update, publish, copy, approve, reject and delete verbs run through `scenario_tools_search` plus the executor matching their lane. Connection and the core loop: see the `scenario` skill in this repo.
+Only `workflows_list`, `workflow_get` and `workflow_run` are listed by default; create, update, publish, copy, approve, reject and delete run through `scenario_tools_search` plus the executor matching their lane. Connection and the core loop: see the `scenario` skill.
 
 ## Quick reference
 
@@ -26,33 +26,32 @@ Ids are prefixed `wflow_`, not `workflow_` as the tool-doc examples show, so cop
 
 ## Cap every list call
 
-Each record carries the compiled `flow` and the whole `editorInfo` node graph, and no compact flag exists. Live records ran 5,500 to 22,000 characters each, so the default `limit=20` returns a few hundred thousand. Cap `limit` at 3 or fewer, then read only `id`, `name`, `hasFlow` and `inputs`, paging with `page_token` set to the previous reply's `nextPaginationToken`.
+Each record carries the compiled `flow` and the whole `editorInfo` node graph with no compact flag, and live records ran 5,500 to 22,000 characters each. Cap `limit` at 3 or fewer, read only `id`, `name`, `hasFlow` and `inputs`, and page with `page_token` set to the previous reply's `nextPaginationToken`.
 
-Only `draft` and `ready` filter server-side. Any other status filters the returned page client-side and the reply flags `_workflowListStatusFilter`, so an empty array beside a `nextPaginationToken` means none on this page.
+Only `draft` and `ready` filter server-side; other statuses filter each page client-side (the reply flags `_workflowListStatusFilter`), so an empty page beside a `nextPaginationToken` means keep paging.
 
 ## The input contract
 
-`workflow_run`'s `inputs` object is keyed by `inputs[].name`, taken verbatim from the record. Names are authored per workflow: some semantic (`characterDescription`, `line1`), some positional (`text2`, `text3`), and positional names are neither contiguous nor ordered. One live workflow exposes only `text2` and `text3` while its graph still contains a `text1` node.
+`workflow_run`'s `inputs` object is keyed by `inputs[].name`, taken verbatim from the record. Names are authored per workflow, some semantic (`characterDescription`), some positional (`text2`), and positional names are neither contiguous nor ordered: one live workflow exposes only `text2` and `text3`.
 
 - `label` and `description` carry the human intent, not the key. A field labelled "Source Image" is still keyed `image1`.
-- Never harvest keys from `editorInfo.nodes[].data.name`: on one live workflow seven input nodes all carried the stale value `text1`.
+- Never harvest keys from `editorInfo.nodes[].data.name`; node names go stale.
 - `required` is an object. Test `required.always === true`, because a truthiness check reads `{"always": false}` as required too.
-- `workflow_get` returns the definition as `inputs_definition` and `editor_info` wrapped in `workflow`; `workflows_list` returns the same data as `inputs` and `editorInfo` wrapped in `workflows`. Use the names belonging to the tool you called.
+- `workflow_get` wraps the definition in `workflow` as `inputs_definition` and `editor_info`; `workflows_list` wraps it in `workflows` as `inputs` and `editorInfo`.
 
 ## Worked example: run a saved app
 
 1. `workflows_list` with `status="ready"`, `limit=3`, plus `team_id` and `project_id`. Read `id`, `name` and `inputs` off each record; ignore `flow` and `editorInfo`.
-2. Take the target's `inputs[]` and key off each entry's `name`. One exposing `{"name": "text1", "label": "Text 1", "required": {"always": false}}` runs with `{"text1": "..."}`.
-3. `workflow_run` with `workflow_id`, `dry_run=true`, and the full `inputs` object. The reply is `creativeUnitsCost`, `creativeUnitsDiscount` and an empty `job`, so no job is created; quote that cost before running. It also runs the real validator, so it doubles as a pre-flight check.
-4. Repeat without `dry_run`, then `jobs_wait` on the returned job, re-called with `pending_job_ids` while it is in progress.
+2. An `inputs[]` entry `{"name": "text1", "label": "Text 1", "required": {"always": false}}` runs with `{"text1": "..."}`.
+3. `workflow_run` with `workflow_id`, `dry_run=true`, and the full `inputs` object. The reply is `creativeUnitsCost`, `creativeUnitsDiscount` and an empty `job`; quote the cost first. It also runs the real validator, doubling as a pre-flight check.
+4. Repeat without `dry_run`, then `jobs_wait` on the returned job, re-calling with `pending_job_ids` while it runs.
 5. `asset_display` each output asset, one call per id.
 
 ## Common mistakes
 
-- Calling `workflows_list` with no `limit`: the node graphs alone can fill a context window.
-- Guessing input keys from labels, or rebuilding them from the node graph instead of reading `inputs[]`.
+- Guessing input keys from labels or the node graph instead of reading `inputs[]`.
 - Treating `required` as a boolean, so every input reads as mandatory.
-- Skipping the dry run because `ready` looks like proof: at authoring time two of three ready workflows failed validation there with correctly named inputs. Report that error rather than blaming the payload.
-- Running a draft: it carries `flow: []` and `hasFlow: false` while `editorInfo` and `inputs` look complete. `workflow_create` and `workflow_update` only persist a draft; `workflow_publish` compiles it.
-- Calling `workflow_approve` or `workflow_reject` with fewer than all three of `workflow_id`, `workflow_job_id` and `node_id`: the gate is per node. A run parked on an approval node never finishes on its own, however long `jobs_wait` runs.
+- Skipping the dry run because `ready` looks like proof: two of three ready workflows failed its validation with correctly named inputs. Report that error rather than blaming the payload.
+- Running a draft: it carries `flow: []` and `hasFlow: false` while `inputs` looks complete. `workflow_create` and `workflow_update` only persist a draft; `workflow_publish` compiles it.
+- Calling `workflow_approve` or `workflow_reject` with fewer than all three of `workflow_id`, `workflow_job_id` and `node_id`: the gate is per node, and a run parked on one never finishes on its own.
 - Sending `workflow_id` to `workflow_copy`: its parameter is `source_workflow_id`.


### PR DESCRIPTION
## Why this skill

Visual workflows are the largest untaught surface in the repo. Ten tools exist, and three of them (`workflows_list`, `workflow_get`, `workflow_run`) sit in the **default listed toolset that every connected agent already sees**. Grepping the ten shipped `SKILL.md` files for those tool names returns zero hits, so an agent asked to "run my Scenario app" improvises against a strict validator.

Every claim below was verified against the live server. Several traps only appear on real workflow data, not in the schemas.

## The three facts an agent cannot guess

**1. Never call `workflows_list` bare.** Each record carries the compiled `flow` and the whole `editorInfo` node graph, and the schema has no compact or fields flag: the only lever is `limit`. Measured on live records:

| workflow | approx. size |
| --- | --- |
| a 16-node avatar pipeline | ~19,000 chars |
| a 6-node character pipeline | ~17,500 chars |
| a 1-node coloring-book workflow | ~5,500 chars |
| a 16-node draft | ~22,000 chars |

The default `limit=20` therefore returns a few hundred thousand characters of React-Flow canvas coordinates and signed CDN blobs. One verification call was rejected outright for exceeding the token budget.

**2. The input contract.** `workflow_run`'s `inputs` object is keyed by `inputs[].name`, and those names are authored per workflow. Live examples include semantic names (`characterDescription`, `line1`) and positional ones (`text2`, `text3`) — and the positional ones are neither contiguous nor ordered. One workflow exposes **only** `text2` and `text3` while its graph still contains a `text1` node that is not an input, so a plausible `{"text1": ...}` payload silently misses both real inputs.

Two further traps in the same area:
- `required` is an object (`{"always": false}`), not a boolean. `if (input.required)` is truthy for both values, so the obvious check marks every input mandatory.
- `editorInfo.nodes[].data.name` is unreliable as a key source: on one live workflow, seven separate input nodes all carried the stale value `text1`. The skill says to read `inputs[]` and nothing else.

**3. `dry_run` is a pre-flight check, not just a price.** It returns the cost with an empty `job` object and runs the real input validator. At authoring time **two of three `ready` workflows failed validation at dry run with correctly named, fully populated inputs** (one on a stale compiled flow, one on a missing referenced asset). `status: "ready"` is not proof a workflow will run, and the skill tells the agent to report that error rather than blaming its own payload.

## Also covered

- Drafts carry `flow: []` and `hasFlow: false` while `editorInfo` and `inputs` look complete, so they read as runnable. `workflow_create` / `workflow_update` only persist a draft; `workflow_publish` compiles it.
- `workflow_approve` / `workflow_reject` require `node_id` as well as the workflow and job ids, because the gate is per node. A run parked on an approval node never finishes on its own.
- `workflow_copy` keys on `source_workflow_id` while every sibling tool uses `workflow_id`.
- Only `draft` and `ready` filter server-side; any other status filters the returned page client-side and flags `_workflowListStatusFilter`, so an empty array beside a `nextPaginationToken` means "none on this page".
- Ids are prefixed `wflow_`, while every id example in the tool docs reads `workflow_xxx`.

## Two paths deliberately not taught

- `search` with `target="workflows"` returned **403** on both teams tested, in the same session where `target="models"` worked, so the failure is target-specific rather than an auth problem. The skill routes discovery through `workflows_list` and says the 403 was observed at authoring time, so an agent that hits it does not start an auth debugging loop.
- `workflow_get` returns the definition as `inputs_definition` / `editor_info` wrapped in `workflow`, while `workflows_list` returns the same data as `inputs` / `editorInfo` wrapped in `workflows`. Rather than pick one, the skill names both and says to use the names belonging to the tool you actually called.

## Notes for review

- Body is 666 words against a 400-600 soft budget (existing skills run 563-620, hard cap 900). This surface carries more non-obvious traps than most; happy to cut the `_workflowListStatusFilter` paragraph or the `workflow_copy` bullet if you would rather hold the line.
- Adds a **Workflows and apps** grouping to `skills.sh.json`. If another new-skill PR merges first, this file needs a trivial rebase.
- `wflow` added to `project-words.txt`.
- `pnpm validate` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9bewbCswpgTqVp6Q1FKKf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6946dcfd561d390013b63f769f890c2d34e83897. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->