### PR TITLE
feat(scenario-consistency): add the consistency skill

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -6,6 +6,7 @@ kling
 krea
 loras
 luma
+mlsd
 mux
 muxed
 muxes

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -29,9 +29,9 @@
       ]
     },
     {
-      "title": "Custom models",
-      "description": "Train custom models on your own art for style, character, or product consistency.",
-      "skills": ["scenario-model-training"]
+      "title": "Consistency and custom models",
+      "description": "Hold one character, product, or style across a whole set, and train custom models on your own art.",
+      "skills": ["scenario-consistency", "scenario-model-training"]
     },
     {
       "title": "Workflows and apps",

--- a/skills/scenario-consistency/SKILL.md
+++ b/skills/scenario-consistency/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-"Make variant two look exactly like variant one except for X" is the most repeated creative ask, and agents reach for seeds, which do not solve it. Consistency comes from what you feed the model, in this order of durability: an exhaustive prompt baseline, then reference images, then a structural control map, then a trained model. Connection and the core loop: see the `scenario` skill in this repo; training: see `scenario-model-training`.
+"Make variant two look exactly like variant one except for X" is the most repeated creative ask, and agents reach for seeds, which do not solve it. Consistency comes from what you feed the model, in rising order of durability: an exhaustive prompt baseline, reference images, a structural control map, a trained model. Connection and the core loop: see the `scenario` skill; training: see `scenario-model-training`.
 
 ## Quick reference
 
@@ -20,30 +20,31 @@ license: MIT
 | Seed reuse                 | one image's exact roll      | low    | re-rolling a single generation         |
 | Trained LoRA               | a house style at scale      | high   | repeated brand work, not one character |
 
-Scenario's own pipeline guidance is explicit that LoRA training "is for repeated brand-style work at scale, not single character runs", and that you should "generate one strong reference image, then pass it as an image input to every scene generation", preferring models with the most reference-image slots when the request mentions consistency.
+Scenario's published pipeline guidance says to "generate one strong reference image, then pass it as an image input to every scene generation", to prefer models with the most reference-image slots, and that LoRA training "is for repeated brand-style work at scale, not single character runs".
 
 ## The baseline-plus-delta prompt
 
-The technique that actually works, and the one agents skip: write out everything that must **not** change, exhaustively, then put the single change in a final clause. Keep the whole prompt byte-identical between runs and edit only that last clause.
+The technique that works, and the one agents skip: write out everything that must **not** change, exhaustively, then put the single change in a final clause. Keep the prompt byte-identical between runs and edit only that clause.
 
-Enumerate specifics rather than gesturing at them: subject geometry, camera height and angle, subject size and position in frame, lighting direction, each named sub-element and where it sits, palette by name or hex, and any embedded text. Vague anchors drift, so name the exact shade rather than writing "auburn".
+Enumerate specifics rather than gesturing at them: subject geometry, camera height and angle, subject size and position in frame, lighting direction, each named sub-element and where it sits, palette by name or hex, and any embedded text. Look at the baseline first (`asset_display`): you cannot enumerate a shade you have not seen, and vague anchors drift, so name the shade rather than writing "auburn".
 
-Attach the approved baseline as a reference image alongside it. Reference parameters are array-typed, so one asset still goes in as `["asset_..."]` and a bare string is dropped silently. Take the exact name and cap from `model_schema_get`, and state each reference's role in the prompt rather than relying on positional tags.
+Attach the approved baseline as a reference image alongside it. Reference parameters are array-typed, so one asset still goes in as `["asset_..."]` and a bare string is dropped silently. Take the exact name and cap from `model_schema_get`, and state each reference's role in the prompt.
+
+A set takes one `model_run` per item. A batch-count field repeats one prompt, so it cannot carry a per-item delta clause; use it only to re-roll a single prompt.
 
 ## Locking structure with a control map
 
-When the layout must survive, generate the control map and pass it as a conditioning input.
+Generate the control map and pass it as a conditioning input. Never extract the map for the attribute that is the delta: a pose map from the approved image locks the very pose you were asked to change, so a pose set needs its map from a target-pose image, or none at all.
 
-`asset_detect` takes an `asset_id` and a `modality` from `canny`, `depth`, `grayscale`, `lineart_anime`, `mlsd`, `normal`, `pose`, `scribble`, `segmentation` and `sketch`, with `remove_background` defaulting to true. It is catalog-only, so reach it through `scenario_tools_search` plus `scenario_tool_execute_write`.
+`asset_detect` takes an `asset_id` and a `modality` from `canny`, `depth`, `grayscale`, `lineart_anime`, `mlsd`, `normal`, `pose`, `scribble`, `segmentation` and `sketch` (`remove_background` defaults to true). It is catalog-only: reach it via `scenario_tools_search` plus `scenario_tool_execute_write`.
 
-Models that accept control input expose `controlImage`, `controlModality`, `controlStrength`, `controlStart` and `controlEnd`. The two vocabularies are not the same list: `controlModality` allows `canny`, `tile`, `depth`, `blur`, `pose`, `gray` and `low-quality`, so only canny, depth and pose map straight across, and `grayscale` becomes `gray`. `controlStrength` defaults to 0.7, with a recommended range of 0.3 to 0.8: near 0.7 for canny, depth and tile, 0.8 to 0.9 for pose, gray and blur, and rigid above 0.9. Strength is how much the map applies; `controlStart` and `controlEnd` are when. Lowering `controlEnd` to around 0.65 locks composition early, then releases so the prompt can refine detail.
+Models taking control input expose `controlImage`, `controlModality`, `controlStrength`, `controlStart` and `controlEnd`. The two vocabularies differ: `controlModality` allows `canny`, `tile`, `depth`, `blur`, `pose`, `gray` and `low-quality`, so only canny, depth and pose map across, and `grayscale` becomes `gray`. `controlStrength` defaults to 0.7 with a recommended 0.3 to 0.8 band: near 0.7 for canny, depth and tile, 0.8 to 0.9 for pose, gray and blur, rigid above 0.9. Strength is how much, `controlStart` and `controlEnd` are when: lowering `controlEnd` to about 0.65 locks composition early, then releases so the prompt can refine detail.
 
 ## Common mistakes
 
-- Reaching for a seed to make two different prompts match. A seed reproduces one generation, it does not transfer identity.
-- Writing "same as before". The model has no memory between calls; the baseline has to be restated in full every time.
-- Passing one reference asset as a bare string instead of an array: it is dropped silently, and the output simply ignores it.
+- Reaching for a seed to make two different prompts match: it reproduces one generation and transfers nothing. Across a set leave it unset; set one only to re-roll a single unchanged prompt.
+- Writing "same as before": there is no memory between calls, so restate the baseline in full every time.
 - Piling on references: attribution gets less reliable as the count grows.
-- Chaining a set by feeding each output into the next generation: drift compounds. Anchor every item to the same approved baseline.
-- Training a LoRA for one character: train for a house style used across many assets. A trained LoRA also cannot be run by its own id (see the `scenario` skill).
+- Chaining a set output to output: drift compounds. Anchor every item to the same approved baseline.
+- Training a LoRA for one character: train for a house style spanning many assets. A trained LoRA also cannot be run by its own id (see `scenario`).
 - Assuming `asset_detect` modality names are valid `controlModality` values.

--- a/skills/scenario-consistency/SKILL.md
+++ b/skills/scenario-consistency/SKILL.md
@@ -28,7 +28,7 @@ The technique that works, and the one agents skip: write out everything that mus
 
 Enumerate specifics rather than gesturing at them: subject geometry, camera height and angle, subject size and position in frame, lighting direction, each named sub-element and where it sits, palette by name or hex, and embedded text. Look at the baseline first (`asset_display`): you cannot enumerate a shade you have not seen, and vague anchors drift.
 
-Attach the approved baseline as a reference image alongside it. Current image models converge on `referenceImages`, but the cap varies (5 to 14) and some require it, so read `model_schema_get`. It is array-typed, so one asset still goes in as `["asset_..."]` and a bare string is dropped silently. State each reference's role in the prompt.
+Attach the approved baseline as a reference image alongside it. Current image models converge on `referenceImages`, but the cap varies (5 to 14) and some require it, so read `model_schema_get`. It is array-typed, so one asset still goes in as `["asset_..."]` and a bare string is dropped silently. State each reference's role in the prompt. A pool of approved on-model shots fills the remaining slots: curate it as a collection (`collection_create`, `collection_add_assets`, catalog tools on the write lane) and retrieve it with `search` `filters={"collection_ids": [...]}`.
 
 A set takes one `model_run` per item: a batch-count field repeats one prompt, so it cannot carry a per-item delta clause.
 

--- a/skills/scenario-consistency/SKILL.md
+++ b/skills/scenario-consistency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-consistency
-description: "Use when one look must hold across many Scenario generations: the same character across scenes or a turnaround, the same product across angles and colorways, the same style across an icon set or tileset, or a variant that matches an approved baseline except for one change. Triggers include make this match, same character, keep it consistent, character sheet, reference sheet, style bible, on-model, locked pose, and asking whether to train a LoRA. Keywords: consistency, identity, reference image, control map, ControlNet, seed."
+description: "Use when one look must hold across many Scenario generations: the same character across scenes or a turnaround, the same product across angles and colorways, the same style across an icon set or tileset, or a variant that matches an approved baseline except for one change. Triggers include make this match, same character, keep it consistent, character sheet, reference sheet, on-model, and whether to train a LoRA. Keywords: consistency, identity, reference image, control map, ControlNet, seed."
 license: MIT
 ---
 
@@ -40,10 +40,17 @@ Generate the control map and pass it as a conditioning input. Never extract the 
 
 The control block (`controlImage`, `controlModality`, `controlStrength`, `controlStart`, `controlEnd`) exists only on models listing `controlnet` in `capabilities`, so check that before planning around it; models without it take reference images instead. The two vocabularies differ: `controlModality` allows `canny`, `tile`, `depth`, `blur`, `pose`, `gray` and `low-quality`, so only canny, depth and pose map across, and `grayscale` becomes `gray`. `controlStrength` defaults to 0.7 with a recommended 0.3 to 0.8 band: near 0.7 for canny, depth and tile, 0.8 to 0.9 for pose, gray and blur, rigid above 0.9. Strength is how much, `controlStart` and `controlEnd` are when: `controlEnd` near 0.65 locks composition early, then releases so the prompt refines detail.
 
+## Worked example: five poses of one mascot
+
+1. `asset_display` the approved hero (`asset_hero`) and write its baseline: the full must-not-change enumeration above.
+2. `search` (`target="models"`, `public=true`) for an image model, preferring reference-image slots, then `model_schema_get`: the reference field's exact name, cap, and whether it is required.
+3. One `model_run` per pose, five in all: the byte-identical baseline, the pose alone in the final clause, the hero as `referenceImages: ["asset_hero"]` (array, even alone). No seed. No control map: a pose map from the hero locks the very pose being changed.
+4. `jobs_wait` on the five job ids, re-calling with `pending_job_ids` until done. `asset_display` each against the hero; fix drift by tightening the enumeration, not by chaining outputs.
+
 ## Common mistakes
 
 - Reaching for a seed to make two different prompts match: it reproduces one generation and transfers nothing. Across a set leave it unset; set one only to re-roll a single unchanged prompt.
 - Writing "same as before": there is no memory between calls, so restate the baseline in full every time.
 - Chaining a set output to output: drift compounds. Anchor every item to the same approved baseline.
-- Training a LoRA for one character: train for a house style spanning many assets. A trained LoRA also cannot be run by its own id (see `scenario`).
+- Training a LoRA for one character: train for a house style spanning many assets. A trained LoRA also never runs by its own id: its schema's `runs_as` and `run_with` carry the base-model call (see `scenario`).
 - Assuming `asset_detect` modality names are valid `controlModality` values.

--- a/skills/scenario-consistency/SKILL.md
+++ b/skills/scenario-consistency/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: scenario-consistency
+description: "Use when one look must hold across many Scenario generations: the same character across scenes or a turnaround, the same product across angles and colorways, the same style across an icon set or tileset, or a variant that matches an approved baseline except for one change. Triggers include make this match, same character, keep it consistent, character sheet, reference sheet, style bible, on-model, locked pose, and asking whether to train a LoRA. Keywords: consistency, identity, reference image, control map, ControlNet, seed."
+license: MIT
+---
+
+# Scenario Consistency
+
+## Overview
+
+"Make variant two look exactly like variant one except for X" is the most repeated creative ask, and agents reach for seeds, which do not solve it. Consistency comes from what you feed the model, in this order of durability: an exhaustive prompt baseline, then reference images, then a structural control map, then a trained model. Connection and the core loop: see the `scenario` skill in this repo; training: see `scenario-model-training`.
+
+## Quick reference
+
+| Technique                  | Holds                       | Effort | Reach for it when                      |
+| -------------------------- | --------------------------- | ------ | -------------------------------------- |
+| Baseline-plus-delta prompt | identity, framing, palette  | low    | always, it is the floor                |
+| Reference image input      | identity and world          | low    | a set of scenes or angles              |
+| `asset_detect` control map | pose, geometry, composition | medium | the layout must not move               |
+| Seed reuse                 | one image's exact roll      | low    | re-rolling a single generation         |
+| Trained LoRA               | a house style at scale      | high   | repeated brand work, not one character |
+
+Scenario's own pipeline guidance is explicit that LoRA training "is for repeated brand-style work at scale, not single character runs", and that you should "generate one strong reference image, then pass it as an image input to every scene generation", preferring models with the most reference-image slots when the request mentions consistency.
+
+## The baseline-plus-delta prompt
+
+The technique that actually works, and the one agents skip: write out everything that must **not** change, exhaustively, then put the single change in a final clause. Keep the whole prompt byte-identical between runs and edit only that last clause.
+
+Enumerate specifics rather than gesturing at them: subject geometry, camera height and angle, subject size and position in frame, lighting direction, each named sub-element and where it sits, palette by name or hex, and any embedded text. Vague anchors drift, so name the exact shade rather than writing "auburn".
+
+Attach the approved baseline as a reference image alongside it. Reference parameters are array-typed, so one asset still goes in as `["asset_..."]` and a bare string is dropped silently. Take the exact name and cap from `model_schema_get`, and state each reference's role in the prompt rather than relying on positional tags.
+
+## Locking structure with a control map
+
+When the layout must survive, generate the control map and pass it as a conditioning input.
+
+`asset_detect` takes an `asset_id` and a `modality` from `canny`, `depth`, `grayscale`, `lineart_anime`, `mlsd`, `normal`, `pose`, `scribble`, `segmentation` and `sketch`, with `remove_background` defaulting to true. It is catalog-only, so reach it through `scenario_tools_search` plus `scenario_tool_execute_write`.
+
+Models that accept control input expose `controlImage`, `controlModality`, `controlStrength`, `controlStart` and `controlEnd`. The two vocabularies are not the same list: `controlModality` allows `canny`, `tile`, `depth`, `blur`, `pose`, `gray` and `low-quality`, so only canny, depth and pose map straight across, and `grayscale` becomes `gray`. `controlStrength` defaults to 0.7, with a recommended range of 0.3 to 0.8: near 0.7 for canny, depth and tile, 0.8 to 0.9 for pose, gray and blur, and rigid above 0.9. Strength is how much the map applies; `controlStart` and `controlEnd` are when. Lowering `controlEnd` to around 0.65 locks composition early, then releases so the prompt can refine detail.
+
+## Common mistakes
+
+- Reaching for a seed to make two different prompts match. A seed reproduces one generation, it does not transfer identity.
+- Writing "same as before". The model has no memory between calls; the baseline has to be restated in full every time.
+- Passing one reference asset as a bare string instead of an array: it is dropped silently, and the output simply ignores it.
+- Piling on references: attribution gets less reliable as the count grows.
+- Chaining a set by feeding each output into the next generation: drift compounds. Anchor every item to the same approved baseline.
+- Training a LoRA for one character: train for a house style used across many assets. A trained LoRA also cannot be run by its own id (see the `scenario` skill).
+- Assuming `asset_detect` modality names are valid `controlModality` values.

--- a/skills/scenario-consistency/SKILL.md
+++ b/skills/scenario-consistency/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-"Make variant two look exactly like variant one except for X" is the most repeated creative ask, and agents reach for seeds, which do not solve it. Consistency comes from what you feed the model, in rising order of durability: an exhaustive prompt baseline, reference images, a structural control map, a trained model. Connection and the core loop: see the `scenario` skill; training: see `scenario-model-training`.
+"Make variant two look exactly like variant one except for X" is the most repeated creative ask, and agents reach for seeds, which do not solve it. Consistency comes from what you feed the model, in rising order of durability: a prompt baseline, reference images, a control map, a trained model. Connection and the core loop: see the `scenario` skill; training: see `scenario-model-training`.
 
 ## Quick reference
 
@@ -24,27 +24,26 @@ Scenario's published pipeline guidance says to "generate one strong reference im
 
 ## The baseline-plus-delta prompt
 
-The technique that works, and the one agents skip: write out everything that must **not** change, exhaustively, then put the single change in a final clause. Keep the prompt byte-identical between runs and edit only that clause.
+The technique that works, and the one agents skip: write out everything that must **not** change, then put the single change in a final clause. Keep the prompt byte-identical between runs and edit only that clause.
 
-Enumerate specifics rather than gesturing at them: subject geometry, camera height and angle, subject size and position in frame, lighting direction, each named sub-element and where it sits, palette by name or hex, and any embedded text. Look at the baseline first (`asset_display`): you cannot enumerate a shade you have not seen, and vague anchors drift, so name the shade rather than writing "auburn".
+Enumerate specifics rather than gesturing at them: subject geometry, camera height and angle, subject size and position in frame, lighting direction, each named sub-element and where it sits, palette by name or hex, and embedded text. Look at the baseline first (`asset_display`): you cannot enumerate a shade you have not seen, and vague anchors drift.
 
-Attach the approved baseline as a reference image alongside it. Reference parameters are array-typed, so one asset still goes in as `["asset_..."]` and a bare string is dropped silently. Take the exact name and cap from `model_schema_get`, and state each reference's role in the prompt.
+Attach the approved baseline as a reference image alongside it. Current image models converge on `referenceImages`, but the cap varies (5 to 14) and some require it, so read `model_schema_get`. It is array-typed, so one asset still goes in as `["asset_..."]` and a bare string is dropped silently. State each reference's role in the prompt.
 
-A set takes one `model_run` per item. A batch-count field repeats one prompt, so it cannot carry a per-item delta clause; use it only to re-roll a single prompt.
+A set takes one `model_run` per item: a batch-count field repeats one prompt, so it cannot carry a per-item delta clause.
 
 ## Locking structure with a control map
 
 Generate the control map and pass it as a conditioning input. Never extract the map for the attribute that is the delta: a pose map from the approved image locks the very pose you were asked to change, so a pose set needs its map from a target-pose image, or none at all.
 
-`asset_detect` takes an `asset_id` and a `modality` from `canny`, `depth`, `grayscale`, `lineart_anime`, `mlsd`, `normal`, `pose`, `scribble`, `segmentation` and `sketch` (`remove_background` defaults to true). It is catalog-only: reach it via `scenario_tools_search` plus `scenario_tool_execute_write`.
+`asset_detect` takes an `asset_id` and a `modality` from `canny`, `depth`, `grayscale`, `lineart_anime`, `mlsd`, `normal`, `pose`, `scribble`, `segmentation`, `sketch` (`remove_background` defaults true). Catalog-only and write lane, despite the docs page grouping it under Analysis: run it via `scenario_tool_execute_write`.
 
-Models taking control input expose `controlImage`, `controlModality`, `controlStrength`, `controlStart` and `controlEnd`. The two vocabularies differ: `controlModality` allows `canny`, `tile`, `depth`, `blur`, `pose`, `gray` and `low-quality`, so only canny, depth and pose map across, and `grayscale` becomes `gray`. `controlStrength` defaults to 0.7 with a recommended 0.3 to 0.8 band: near 0.7 for canny, depth and tile, 0.8 to 0.9 for pose, gray and blur, rigid above 0.9. Strength is how much, `controlStart` and `controlEnd` are when: lowering `controlEnd` to about 0.65 locks composition early, then releases so the prompt can refine detail.
+The control block (`controlImage`, `controlModality`, `controlStrength`, `controlStart`, `controlEnd`) exists only on models listing `controlnet` in `capabilities`, so check that before planning around it; models without it take reference images instead. The two vocabularies differ: `controlModality` allows `canny`, `tile`, `depth`, `blur`, `pose`, `gray` and `low-quality`, so only canny, depth and pose map across, and `grayscale` becomes `gray`. `controlStrength` defaults to 0.7 with a recommended 0.3 to 0.8 band: near 0.7 for canny, depth and tile, 0.8 to 0.9 for pose, gray and blur, rigid above 0.9. Strength is how much, `controlStart` and `controlEnd` are when: `controlEnd` near 0.65 locks composition early, then releases so the prompt refines detail.
 
 ## Common mistakes
 
 - Reaching for a seed to make two different prompts match: it reproduces one generation and transfers nothing. Across a set leave it unset; set one only to re-roll a single unchanged prompt.
 - Writing "same as before": there is no memory between calls, so restate the baseline in full every time.
-- Piling on references: attribution gets less reliable as the count grows.
 - Chaining a set output to output: drift compounds. Anchor every item to the same approved baseline.
 - Training a LoRA for one character: train for a house style spanning many assets. A trained LoRA also cannot be run by its own id (see `scenario`).
 - Assuming `asset_detect` modality names are valid `controlModality` values.


### PR DESCRIPTION
## Why this skill

"Make variant two look exactly like variant one except for X" is the single most repeated creative ask in the support data, across game assets, terrain tiles, character turnarounds, product catalogue angles and colorways. No skill covers it.

Worse, the repo currently points the wrong way. `scenario-game-assets` covers *style* via references and similarity search, but has nothing on holding one *identity*. And `scenario-model-training` leads its description with "consistent style, character, or product look" and its overview with "a recurring character" — routing users to training for exactly the case Scenario's own published guidance routes away from it.

## The backbone is publicly documented

From the `character_sheet` pipeline template on `mcp.scenario.com/docs/intelligence`, quoted verbatim in the skill:

> - "Generate one strong reference image, then pass it as an image input to every scene generation."
> - "Models with the most reference-image slots maintain identity best across scenes — prefer them when the request mentions consistency."
> - "LoRA training is for repeated brand-style work at scale, not single character runs."

## Structure

Techniques are ordered by durability with a "reach for it when" column, because the underlying failure is agents defaulting to seeds. **A seed reproduces one generation; it does not transfer identity between two different prompts.** That is the misconception the skill exists to correct.

The centrepiece is the baseline-plus-delta prompt: enumerate everything that must **not** change, exhaustively and by name, then put the single change in a final clause and keep the rest byte-identical between runs. This ordering is deliberate. In the support record, an automated answer that led with detector and control-scale machinery lost the user entirely ("I have no idea what you are asking for"), while the plain enumerate-then-delta approach was reproduced working. So the cheap technique leads and the machinery follows.

## The control-map numbers

These are the values an agent would otherwise guess, taken from a live schema:

- `asset_detect` modalities: `canny`, `depth`, `grayscale`, `lineart_anime`, `mlsd`, `normal`, `pose`, `scribble`, `segmentation`, `sketch` (`remove_background` defaults to true).
- Model-side `controlModality`: `canny`, `tile`, `depth`, `blur`, `pose`, `gray`, `low-quality`.

**These are not the same list.** Only canny, depth and pose map straight across, and `grayscale` becomes `gray`. An agent that produces a `segmentation` map and passes `controlModality: "segmentation"` is holding an invalid value.

`controlStrength` defaults to 0.7 with a recommended 0.3-0.8 band, starting near 0.7 for canny/depth/tile and 0.8-0.9 for pose/gray/blur, turning rigid above 0.9. `controlStart` / `controlEnd` are a separate axis: strength is *how much*, start/end is *when*, and lowering `controlEnd` to around 0.65 locks composition early then releases so the prompt can refine detail.

## Notes for review

- Body is 684 words against a 400-600 soft budget (hard cap 900). The two enum lists and the control-strength numbers are most of the overage and are the least guessable content; the Common mistakes list is the easiest place to cut if you want it tighter.
- Renames the **Custom models** grouping to **Consistency and custom models** and puts `scenario-consistency` alongside `scenario-model-training`, since the two are the same decision at different scales. If another new-skill PR merges first, `skills.sh.json` needs a trivial rebase.
- Follow-up worth considering separately, not bundled here: `scenario-model-training`'s description still triggers on the single-character case that the public guidance sends elsewhere. Narrowing it to repeated at-scale style work would stop the two skills competing for the same trigger.
- `mlsd` added to `project-words.txt`.
- `pnpm validate` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9bewbCswpgTqVp6Q1FKKf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d20aa5b3ca045ae976b50623c5c266099af8b14a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->