### PR TITLE
feat(scenario-report): add the reporting skill and public issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,9 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        This issue is public and permanent. Before you submit, remove API keys, signed asset URLs, team and project ids, emails, local paths with your username, and any artwork or prompt you do not want published.
+        This issue is public and permanent. Before you submit, remove API keys, signed asset URLs, emails, local paths with your username, and any artwork or prompt you do not want published. Team and project ids identify your account: leave them out unless we ask, and share them by email rather than here.
 
-        Account, billing, credit, and security problems do not belong here: use in-app support at https://app.scenario.com.
+        Would rather not post in public? Send the same fields to support@scenario.com instead. Account, billing, credit, and security problems always go there, or to in-app support at https://app.scenario.com.
   - type: textarea
     id: summary
     attributes:
@@ -93,5 +93,5 @@ body:
       options:
         - label: I searched open and closed issues for a duplicate.
           required: true
-        - label: This report contains no keys, tokens, signed asset URLs, team or project ids, or personal data.
+        - label: This report contains no keys, tokens, signed asset URLs, or personal data, and any team or project id in it is one I chose to make public.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,97 @@
+name: Bug report
+description: Something in a skill, the MCP server, or a generation behaves wrong
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue is public and permanent. Before you submit, remove API keys, signed asset URLs, team and project ids, emails, local paths with your username, and any artwork or prompt you do not want published.
+
+        Account, billing, credit, and security problems do not belong here: use in-app support at https://app.scenario.com.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened
+      description: One or two sentences. The symptom, not the suspected cause.
+      placeholder: jobs_wait keeps returning the same texture upscale job in pending_job_ids, 20 minutes after model_run accepted it.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where
+      options:
+        - A skill in this repository (guidance wrong, missing, or misleading)
+        - Scenario MCP server (tool errors, schemas, auth, jobs)
+        - Model or generation output
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps as exact tool calls with their arguments. Say which `search` call found the model id, and whether that model is public. Substitute a public prompt for a confidential one and say that you did.
+      placeholder: |
+        1. search target="models" query="texture upscale" public=true, picked <model id>
+        2. model_schema_get model_id="<model id>"
+        3. model_run model_id="<model id>" parameters={"image": "asset_...", "upscaleFactor": 4}
+        4. jobs_wait job_ids=["job_..."], re-called 5 times with the returned pending_job_ids
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: The verbatim error or response. Paste it as text, not a screenshot, so it is searchable.
+    validations:
+      required: true
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often
+      options:
+        - Every time
+        - Intermittent
+        - Once so far
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Trace ids from `diagnostics_run`, job ids, model ids, and the UTC timestamp of the failing call. No signed asset URLs, they are credentials. Screenshots welcome.
+      placeholder: |
+        trace ids: mcpt_..., mcpt_...
+        job id: job_...
+        when: 2026-08-13T15:43:24Z
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: "From `diagnostics_run`, copy only these fields. Do not paste the whole report: it lists your teams and projects."
+      placeholder: |
+        version: 0.25.0
+        endpoint: prod
+        auth_type: oauth
+        self_test.layer: tenant-scope
+        agent and OS: Claude Code on macOS 15
+      render: shell
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues for a duplicate.
+          required: true
+        - label: This report contains no keys, tokens, signed asset URLs, team or project ids, or personal data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/change-request.yml
+++ b/.github/ISSUE_TEMPLATE/change-request.yml
@@ -6,6 +6,8 @@ body:
     attributes:
       value: |
         This issue is public and permanent. Before you submit, remove API keys, team and project ids, emails, and any unreleased project detail you do not want published.
+
+        Would rather not post in public? Send the same fields to support@scenario.com instead.
   - type: textarea
     id: problem
     attributes:
@@ -52,5 +54,5 @@ body:
       options:
         - label: I searched open and closed issues for a duplicate.
           required: true
-        - label: This request contains no keys, tokens, team or project ids, or personal data.
+        - label: This request contains no keys, tokens, or personal data, and any team or project id in it is one I chose to make public.
           required: true

--- a/.github/ISSUE_TEMPLATE/change-request.yml
+++ b/.github/ISSUE_TEMPLATE/change-request.yml
@@ -1,0 +1,56 @@
+name: Change request
+description: A missing capability, unclear guidance, or a workflow that costs more than it should
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue is public and permanent. Before you submit, remove API keys, team and project ids, emails, and any unreleased project detail you do not want published.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to get done, and what stops you today? Describe the goal, not the solution.
+      placeholder: I generate icon batches for a live game and cannot tell which model produced which batch three weeks later.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where
+      options:
+        - A skill in this repository
+        - Scenario MCP server
+        - Models and generation
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: today
+    attributes:
+      label: What you do now
+      description: The current workaround and what it costs, in steps, minutes, or credits.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like instead
+      description: Optional. A shape you have in mind, and any alternative you already rejected and why.
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: How often this comes up and who it affects. Say if it blocks you outright.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues for a duplicate.
+          required: true
+        - label: This request contains no keys, tokens, team or project ids, or personal data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Email support instead
+    url: mailto:support@scenario.com
+    about: Same report, private channel. The right place for anything you would rather not publish, including your team and project ids.
   - name: Account, billing, credits, or a security report
     url: https://app.scenario.com
-    about: Anything tied to your account is private. Use in-app support, not a public issue.
+    about: Anything tied to your account is private. Use in-app support or support@scenario.com, not a public issue.
   - name: Scenario documentation
     url: https://docs.scenario.com
     about: Guides and product documentation.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Account, billing, credits, or a security report
+    url: https://app.scenario.com
+    about: Anything tied to your account is private. Use in-app support, not a public issue.
+  - name: Scenario documentation
+    url: https://docs.scenario.com
+    about: Guides and product documentation.
+  - name: Scenario MCP tool reference
+    url: https://mcp.scenario.com/docs/tools
+    about: Every MCP tool with its parameters, worth a look before filing.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | [scenario-seedance-music-video](skills/scenario-seedance-music-video/SKILL.md) | Turning a song into a finished music video: beat-aligned shots, lyric transcription, verified ffmpeg assembly     |
 | [scenario-model-training](skills/scenario-model-training/SKILL.md)             | Training custom models for style, character, or product consistency, and generating with them                     |
 | [scenario-workflows](skills/scenario-workflows/SKILL.md)                       | Running saved workflows (apps): building the run inputs, dry-run pricing, publishing drafts, approval gates       |
+| [scenario-report](skills/scenario-report/SKILL.md)                             | Reporting a bug or change request as a reproducible, redacted issue on this repository's public tracker           |
 
 ## Example prompts
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -37,6 +37,11 @@
       "title": "Workflows and apps",
       "description": "Discover and run saved Scenario workflows, the multi-step pipelines users call apps.",
       "skills": ["scenario-workflows"]
+    },
+    {
+      "title": "Feedback",
+      "description": "Turn a blocked session into a reproducible public issue, redacted and approved before it is posted.",
+      "skills": ["scenario-report"]
     }
   ]
 }

--- a/skills/scenario-report/SKILL.md
+++ b/skills/scenario-report/SKILL.md
@@ -52,7 +52,7 @@ Name the model id and whether `search` finds it with `public=true`, the exact `p
 ## Posting
 
 - With GitHub tooling: search `repo:scenario-labs/skills` for duplicates, then create the issue with the label `bug` or `enhancement`, mirroring the form headings in the body.
-- Browser only: build `https://github.com/scenario-labs/skills/issues/new?template=bug.yml&summary=...&repro=...`, percent-encoding each value. Parameter names are the form field ids: `summary`, `area`, `repro`, `expected`, `actual`, `evidence`, `env`, `frequency`; change requests use `problem`, `area`, `today`, `proposal`, `impact`. The user ticks the confirmation boxes and submits. Past about 8000 characters the URL returns 414: drop `evidence`.
+- Browser only: build `https://github.com/scenario-labs/skills/issues/new?template=bug.yml&summary=...&repro=...`, percent-encoding each value. Parameter names are the form field ids: `summary`, `area`, `repro`, `expected`, `actual`, `evidence`, `env`, `frequency`; change requests switch to `template=change-request.yml` and use `problem`, `area`, `today`, `proposal`, `impact` (a param matching no field id on the selected form is dropped silently). The user ticks the confirmation boxes and submits. Past about 8000 characters the URL returns 414: drop `evidence`.
 - By email: `support@scenario.com`, subject `[bug] <title>` or `[change request] <title>`, body carrying those same fields as labeled lines. Whatever was withheld from a public issue (team id, project id, account email) travels safely here.
 
 ## Common mistakes

--- a/skills/scenario-report/SKILL.md
+++ b/skills/scenario-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-report
-description: "Use when a Scenario user wants to report a bug or request a change on the public issue tracker at github.com/scenario-labs/skills: turning a failed generation, MCP tool error, or unclear skill into a reproducible report, collecting trace ids with diagnostics_run, stripping keys, team ids, signed asset URLs, and personal data before posting, searching for duplicates, or building a prefilled issue URL when the agent cannot call GitHub. Keywords: file an issue, feature request, feedback."
+description: "Use when a Scenario user wants to report a bug or request a change, on the public tracker at github.com/scenario-labs/skills or by email to support@scenario.com: turning a failed generation, MCP tool error, or unclear skill into a reproducible report, collecting trace ids with diagnostics_run, stripping keys, signed asset URLs, and personal data, asking before sharing a team or project id, or building a prefilled issue URL. Keywords: file an issue, feature request, feedback."
 license: MIT
 ---
 
@@ -8,56 +8,57 @@ license: MIT
 
 ## Overview
 
-Public tracker: `https://github.com/scenario-labs/skills/issues`, forms `bug.yml` and `change-request.yml`.
+Public tracker: `https://github.com/scenario-labs/skills/issues`, forms `bug.yml` and `change-request.yml`. Offer `support@scenario.com` as the private alternative, and let the user pick.
 
-Two constraints. The issue is public and permanent, so redact first and post only after the user approves the exact text. The reader has no access to the user's account, so the report must carry everything needed to reproduce from outside.
+Two constraints. A public issue is permanent, so redact first and post only after the user approves the exact text. The reader has no access to the user's account, so the report must carry everything needed to reproduce from outside.
 
 Connection and the core generation loop: see the `scenario` skill in this repo.
 
-Account, billing, credit, quota, sign-in, and security problems never go in a public issue: send those to in-app support at `app.scenario.com`.
+Account, billing, credit, quota, sign-in, and security problems never go in a public issue: send those to `support@scenario.com` or in-app support at `app.scenario.com`.
 
 ## Quick reference
 
-| Step     | Do                                              | Notes                             |
-| -------- | ----------------------------------------------- | --------------------------------- |
-| Classify | bug or change request                           | One problem per issue             |
-| Gather   | failing call, verbatim error, `diagnostics_run` | In the session that failed        |
-| Redact   | strip identity and secrets                      | Not optional                      |
-| Dedupe   | search open and closed issues                   | Comment on a match, do not refile |
-| Draft    | fill every form field                           | Label guesses as guesses          |
-| Approve  | show the final title and body                   | Never post silently               |
-| Post     | GitHub tool or prefilled URL                    | Both below                        |
+| Step     | Do                                                                |
+| -------- | ----------------------------------------------------------------- |
+| Classify | bug or change request, one problem each                           |
+| Gather   | failing call, verbatim error, `diagnostics_run` from that session |
+| Redact   | strip identity and secrets; ask before any team or project id     |
+| Dedupe   | search open and closed issues, comment on a match                 |
+| Draft    | fill every field, label guesses as guesses                        |
+| Approve  | show the final text, post only on a yes                           |
+| Post     | GitHub tool, prefilled URL, or email                              |
 
 ## Redact before drafting
 
-Never include API keys or tokens, signed URLs from `asset_download` (the URL is a credential), team or project ids and names, emails, local paths containing a username, or unreleased art, prompts, and model names the user has not agreed to publish.
+Never include API keys or tokens, signed URLs from `asset_download` (the URL is a credential), account emails or names, local paths containing a username, or unreleased art, prompts, and model names the user has not agreed to publish.
+
+Team and project ids identify the account, so strip them by default. Ask for one only when it changes the diagnosis (a Forbidden or scope error, a model only one team can see): quote the id you would post, and treat anything short of a yes as no. Email is the better home for it.
 
 `diagnostics_run` is the best evidence and the biggest leak: `self_test.detail` can enumerate every team and project the user belongs to, and `tenant` can encode their account. Copy only `version`, `endpoint`, `auth_type`, `self_test.layer`, `self_test.latencyMs`, `generated_at`, and the ids under `confirmed_trace_ids` and `candidate_trace_ids`. Nothing else from that report.
 
-Job, asset, and model ids let support match the report to a server-side request: include them once the user agrees. Signed download URLs, never.
+Job, asset, and model ids match the report to a server-side request: include them with the user's agreement. Signed download URLs, never.
 
 ## Make it reproducible
 
-Name the model id and whether `search` finds it with `public=true`, the exact `parameters` sent to `model_run`, the verbatim error, the UTC timestamp, and at least one trace id. Substitute a short public prompt for a confidential one, and say that you did. Say when a model is team-private: the reader will reproduce against a public equivalent.
+Name the model id and whether `search` finds it with `public=true`, the exact `parameters` sent to `model_run`, the verbatim error, the UTC timestamp, and at least one trace id. Substitute a short public prompt for a confidential one and say so. Say when a model is team-private: the reader reproduces against a public equivalent.
 
 ## Worked example: a texture upscale that never finishes
 
-1. `diagnostics_run` in the failing session: keep the fields listed above and the trace ids, discard the rest.
-2. Re-run the failing call once, capturing the arguments, the verbatim response, and the UTC time.
-3. `search` with `public=true`: is the upscaler public, so the reader can run the same call?
-4. Search the tracker, open and closed, for `jobs_wait pending`.
-5. Draft. Title: `jobs_wait keeps returning the same texture upscale job in pending_job_ids for 20 minutes`. Steps: the `model_schema_get`, `model_run`, and repeated `jobs_wait` calls with their arguments. Expected: the job completes or fails. Actual: `status` stays `in_progress`, `pending_job_ids` unchanged. Evidence: job id, trace ids, timestamp.
-6. Show the user the full text, and post only on a yes.
+1. `diagnostics_run` in the failing session, keeping only the fields listed above and the trace ids.
+2. Re-run the failing call once: arguments, verbatim response, UTC time. Check with `search` whether the upscaler is public, so the reader can run it too, then search the tracker, open and closed, for `jobs_wait pending`.
+3. Draft. Title: `jobs_wait keeps returning the same texture upscale job in pending_job_ids for 20 minutes`. Steps: the `model_schema_get`, `model_run`, and repeated `jobs_wait` calls with their arguments. Expected: the job completes or fails. Actual: `status` stays `in_progress`, `pending_job_ids` unchanged. Evidence: job id, trace ids, timestamp.
+4. Show the user the full text, and post only on a yes.
 
 ## Posting
 
 - With GitHub tooling: search `repo:scenario-labs/skills` for duplicates, then create the issue with the label `bug` or `enhancement`, mirroring the form headings in the body.
-- Browser only: build `https://github.com/scenario-labs/skills/issues/new?template=bug.yml&summary=...&repro=...`, percent-encoding each value. Parameter names are the form field ids: `summary`, `area`, `repro`, `expected`, `actual`, `evidence`, `env`, `frequency`; change requests use `problem`, `area`, `today`, `proposal`, `impact`. The user ticks the confirmation boxes and submits. Past about 8000 characters the URL returns 414: drop `evidence` and let the user paste it in.
+- Browser only: build `https://github.com/scenario-labs/skills/issues/new?template=bug.yml&summary=...&repro=...`, percent-encoding each value. Parameter names are the form field ids: `summary`, `area`, `repro`, `expected`, `actual`, `evidence`, `env`, `frequency`; change requests use `problem`, `area`, `today`, `proposal`, `impact`. The user ticks the confirmation boxes and submits. Past about 8000 characters the URL returns 414: drop `evidence`.
+- By email: `support@scenario.com`, subject `[bug] <title>` or `[change request] <title>`, body carrying those same fields as labeled lines. Whatever was withheld from a public issue (team id, project id, account email) travels safely here.
 
 ## Common mistakes
 
-- Posting before the user has read the final text.
 - Pasting the whole `diagnostics_run` output, which leaks the team and project list.
+- Publishing a team or project id nobody asked for, or asking for one the diagnosis does not need.
 - A title like "generation is broken": name the surface, the symptom, and the condition.
 - Three problems in one issue: each needs its own reproduction and its own close.
 - Reporting the hypothesis ("the API is down") instead of the observation. Observation first, hypothesis last and marked as one.

--- a/skills/scenario-report/SKILL.md
+++ b/skills/scenario-report/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: scenario-report
+description: "Use when a Scenario user wants to report a bug or request a change on the public issue tracker at github.com/scenario-labs/skills: turning a failed generation, MCP tool error, or unclear skill into a reproducible report, collecting trace ids with diagnostics_run, stripping keys, team ids, signed asset URLs, and personal data before posting, searching for duplicates, or building a prefilled issue URL when the agent cannot call GitHub. Keywords: file an issue, feature request, feedback."
+license: MIT
+---
+
+# Reporting Scenario bugs and change requests
+
+## Overview
+
+Public tracker: `https://github.com/scenario-labs/skills/issues`, forms `bug.yml` and `change-request.yml`.
+
+Two constraints. The issue is public and permanent, so redact first and post only after the user approves the exact text. The reader has no access to the user's account, so the report must carry everything needed to reproduce from outside.
+
+Connection and the core generation loop: see the `scenario` skill in this repo.
+
+Account, billing, credit, quota, sign-in, and security problems never go in a public issue: send those to in-app support at `app.scenario.com`.
+
+## Quick reference
+
+| Step     | Do                                              | Notes                             |
+| -------- | ----------------------------------------------- | --------------------------------- |
+| Classify | bug or change request                           | One problem per issue             |
+| Gather   | failing call, verbatim error, `diagnostics_run` | In the session that failed        |
+| Redact   | strip identity and secrets                      | Not optional                      |
+| Dedupe   | search open and closed issues                   | Comment on a match, do not refile |
+| Draft    | fill every form field                           | Label guesses as guesses          |
+| Approve  | show the final title and body                   | Never post silently               |
+| Post     | GitHub tool or prefilled URL                    | Both below                        |
+
+## Redact before drafting
+
+Never include API keys or tokens, signed URLs from `asset_download` (the URL is a credential), team or project ids and names, emails, local paths containing a username, or unreleased art, prompts, and model names the user has not agreed to publish.
+
+`diagnostics_run` is the best evidence and the biggest leak: `self_test.detail` can enumerate every team and project the user belongs to, and `tenant` can encode their account. Copy only `version`, `endpoint`, `auth_type`, `self_test.layer`, `self_test.latencyMs`, `generated_at`, and the ids under `confirmed_trace_ids` and `candidate_trace_ids`. Nothing else from that report.
+
+Job, asset, and model ids let support match the report to a server-side request: include them once the user agrees. Signed download URLs, never.
+
+## Make it reproducible
+
+Name the model id and whether `search` finds it with `public=true`, the exact `parameters` sent to `model_run`, the verbatim error, the UTC timestamp, and at least one trace id. Substitute a short public prompt for a confidential one, and say that you did. Say when a model is team-private: the reader will reproduce against a public equivalent.
+
+## Worked example: a texture upscale that never finishes
+
+1. `diagnostics_run` in the failing session: keep the fields listed above and the trace ids, discard the rest.
+2. Re-run the failing call once, capturing the arguments, the verbatim response, and the UTC time.
+3. `search` with `public=true`: is the upscaler public, so the reader can run the same call?
+4. Search the tracker, open and closed, for `jobs_wait pending`.
+5. Draft. Title: `jobs_wait keeps returning the same texture upscale job in pending_job_ids for 20 minutes`. Steps: the `model_schema_get`, `model_run`, and repeated `jobs_wait` calls with their arguments. Expected: the job completes or fails. Actual: `status` stays `in_progress`, `pending_job_ids` unchanged. Evidence: job id, trace ids, timestamp.
+6. Show the user the full text, and post only on a yes.
+
+## Posting
+
+- With GitHub tooling: search `repo:scenario-labs/skills` for duplicates, then create the issue with the label `bug` or `enhancement`, mirroring the form headings in the body.
+- Browser only: build `https://github.com/scenario-labs/skills/issues/new?template=bug.yml&summary=...&repro=...`, percent-encoding each value. Parameter names are the form field ids: `summary`, `area`, `repro`, `expected`, `actual`, `evidence`, `env`, `frequency`; change requests use `problem`, `area`, `today`, `proposal`, `impact`. The user ticks the confirmation boxes and submits. Past about 8000 characters the URL returns 414: drop `evidence` and let the user paste it in.
+
+## Common mistakes
+
+- Posting before the user has read the final text.
+- Pasting the whole `diagnostics_run` output, which leaks the team and project list.
+- A title like "generation is broken": name the surface, the symptom, and the condition.
+- Three problems in one issue: each needs its own reproduction and its own close.
+- Reporting the hypothesis ("the API is down") instead of the observation. Observation first, hypothesis last and marked as one.


### PR DESCRIPTION
## Summary

- Adds `skills/scenario-report/SKILL.md`: turns a blocked session into a report someone else can act on, without leaking the user's account into a public repository. Redaction is the first step, not a footnote: never API keys, signed `asset_download` URLs (the URL is a credential), account emails or names, username-bearing local paths, or unreleased art and prompts.
- Adds `.github/ISSUE_TEMPLATE/` forms (`bug.yml`, `change-request.yml`) plus the chooser `config.yml`. The skill and the forms share field ids, so they are one system rather than two descriptions of the same form; the chooser routes account, billing, credit, and security reports to `support@scenario.com` and in-app support instead of the public tracker.
- Treats team and project ids as a consent decision, not a ban: stripped by default, asked for only when they change the diagnosis, quoting the exact id that would become public, and anything short of a yes is a no. `diagnostics_run` is both the best evidence and the biggest leak, so the skill lists the seven fields worth copying and forbids the rest.
- Teaches three posting routes so the skill works whatever the agent can reach: GitHub tooling, a prefilled `issues/new` URL keyed by the form field ids (`template=bug.yml` or `template=change-request.yml` per form, with the URL length ceiling called out), or email carrying the same fields plus anything withheld from the public issue.
- Review fix (both bots caught it): change requests now switch the `template` parameter together with the field ids, since a param matching no field id on the selected form is dropped silently.

## Validation

- [x] `pnpm validate` passes: house style, prettier formatting, supporting-file checks, groupings, cspell, and `skills-ref` spec validation across all 14 skills
- [x] Rebased onto `main`; `skills.sh.json` (new Feedback grouping) and the README table merged with the groups added by #19, #20, and #21
- [x] All CI checks green on the current head (`fc3be0e`)
- [x] Both open review comments fixed and answered in thread

## Stats

- 6 files changed, 239 insertions: one new skill (`scenario-report`), three issue-template files, plus `README.md` and `skills.sh.json` registrations

---
_Generated by [Claude Code](https://claude.ai/code)_