### PR TITLE
feat(scenario-workflow-authoring): add the workflow authoring skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .DS_Store
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | [scenario-video-assembly](skills/scenario-video-assembly/SKILL.md)             | Assembling clips into a finished video: timeline composition, concat with transitions, overlays, music, captions   |
 | [scenario-consistency](skills/scenario-consistency/SKILL.md)                   | Holding one character, product, or style across a set: baseline-plus-delta prompts, reference images, control maps |
 | [scenario-model-training](skills/scenario-model-training/SKILL.md)             | Training custom models for style, character, or product consistency, and generating with them                      |
-| [scenario-workflows](skills/scenario-workflows/SKILL.md)                       | Running saved workflows (apps): building the run inputs, dry-run pricing, publishing drafts, approval gates        |
+| [scenario-workflows](skills/scenario-workflows/SKILL.md)                       | Running saved workflows (apps): building the run inputs, dry-run pricing, unsticking approval gates                |
+| [scenario-workflow-authoring](skills/scenario-workflow-authoring/SKILL.md)     | Creating and editing workflow graphs: the editor_info grammar, node wiring, publishing drafts into runnable apps   |
 | [scenario-report](skills/scenario-report/SKILL.md)                             | Reporting a bug or change request as a reproducible, redacted issue on this repository's public tracker            |
 
 ## Example prompts

--- a/project-words.txt
+++ b/project-words.txt
@@ -18,6 +18,7 @@ retexture
 retexturing
 shfmt
 tripo
+unpublishing
 upscales
 veed
 wflow

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -35,8 +35,8 @@
     },
     {
       "title": "Workflows and apps",
-      "description": "Discover and run saved Scenario workflows, the multi-step pipelines users call apps.",
-      "skills": ["scenario-workflows"]
+      "description": "Discover, run, build, and publish Scenario workflows, the multi-step pipelines users call apps.",
+      "skills": ["scenario-workflows", "scenario-workflow-authoring"]
     },
     {
       "title": "Feedback",

--- a/skills/scenario-workflow-authoring/SKILL.md
+++ b/skills/scenario-workflow-authoring/SKILL.md
@@ -10,7 +10,7 @@ license: MIT
 
 A workflow has two representations: `editor_info` (the editable node graph: `nodes`, `edges`, `inputKeys`) and `flow` (the compiled runnable form). Authoring through MCP means writing the whole `editor_info` document: there are no per-node editing tools; every change is a read, modify, write of the full graph through `workflow_create` or `workflow_update`. Never hand-write `flow`: `workflow_publish` compiles `editor_info` into it and flips status to `ready`. Editing a ready workflow's `editor_info` leaves the stale `flow` running until you publish again.
 
-Read [references/editor-info.md](references/editor-info.md) before writing any graph: it holds the node type vocabulary, the edge direction rule, per-node data contracts, and a validated minimal example. Create, update, publish, copy and delete live in the tool catalog (`scenario_tools_search` plus the matching executor, see the `scenario` skill). Running and pricing: the `scenario-workflows` skill.
+Read [references/editor-info.md](references/editor-info.md) before writing any graph: it holds the node type vocabulary, the node choice doctrine (when an `llm` node is legitimate), the edge direction rule, per-node data contracts, and a validated minimal example. Create, update, publish, copy and delete live in the tool catalog (`scenario_tools_search` plus the matching executor, see the `scenario` skill). Running and pricing: the `scenario-workflows` skill.
 
 ## Quick reference
 
@@ -23,11 +23,7 @@ Read [references/editor-info.md](references/editor-info.md) before writing any g
 | 5. Publish        | `workflow_publish`                   | Compiles `flow`, needs input+output pins |
 | 6. Validate       | `workflow_run` with `dry_run=true`   | Prices and runs the real validator       |
 
-`workflow_create` is two calls under the hood: a failed create may still have created a draft whose id is in the error. Recover with `workflow_update` on that id; re-creating duplicates. Seed step 1 from the session itself: `search` with `target="workflows"` and `public=true` finds featured workflows, and `workflow_get` returns each full graph. [scripts/fetch_workflow_examples.py](scripts/fetch_workflow_examples.py) bulk-exports the same examples as trimmed files for maintainers (setup in its header).
-
-## Choosing nodes
-
-One `model` node per requested deliverable. Add an `llm` node only when the user asked for LLM writing, when one brief fans out to N different prompts via `forEach`, or when text must be computed at run time from an upstream asset; "refine the prompt" is not a reason. N samples of one prompt is the model's own output-count parameter, never an `llm` or `forEach` fan-out. Compose a prompt from several sources with `transformText` (CEL), not an `llm`. Tool-style models define both input and output handles, so pick the model before wiring.
+`workflow_create` is two calls under the hood: a failed create may still have created a draft whose id is in the error. Recover with `workflow_update` on that id; re-creating duplicates. Seed step 1 with `workflow_get`: it returns the full graph of any workflow whose id you have, public ones included (an id or app URL the user supplies, or your own team's from `workflows_list`). Do not hunt ids with `search`: its `workflows` target returned 403 at authoring time, with or without `public=true` (the `scenario-workflows` skill records the same). [scripts/fetch_workflow_examples.py](scripts/fetch_workflow_examples.py) bulk-exports trimmed featured-workflow graphs for maintainers (setup in its header).
 
 ## Worked example: a text-to-image app
 

--- a/skills/scenario-workflow-authoring/SKILL.md
+++ b/skills/scenario-workflow-authoring/SKILL.md
@@ -23,7 +23,7 @@ Read [references/editor-info.md](references/editor-info.md) before writing any g
 | 5. Publish        | `workflow_publish`                   | Compiles `flow`, needs input+output pins |
 | 6. Validate       | `workflow_run` with `dry_run=true`   | Prices and runs the real validator       |
 
-`workflow_create` is two calls under the hood: a failed create may still have created a draft whose id is in the error. Recover with `workflow_update` on that id; re-creating duplicates. To seed step 1 with public featured examples, run [scripts/fetch_workflow_examples.py](scripts/fetch_workflow_examples.py) with API credentials.
+`workflow_create` is two calls under the hood: a failed create may still have created a draft whose id is in the error. Recover with `workflow_update` on that id; re-creating duplicates. Seed step 1 from the session itself: `search` with `target="workflows"` and `public=true` finds featured workflows, and `workflow_get` returns each full graph. [scripts/fetch_workflow_examples.py](scripts/fetch_workflow_examples.py) bulk-exports the same examples as trimmed files for maintainers (setup in its header).
 
 ## Choosing nodes
 

--- a/skills/scenario-workflow-authoring/SKILL.md
+++ b/skills/scenario-workflow-authoring/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: scenario-workflow-authoring
+description: "Use when a task involves creating or editing a Scenario workflow graph through MCP: building a new workflow or app from a brief, adding or rewiring nodes (models, prompts, approval gates, loops), authoring editor_info, publishing a draft, unpublishing or renaming, importing an exported workflow JSON, copying a workflow to customize it, or turning a prompt chain into a reusable app. Running or pricing an existing workflow is scenario-workflows. Keywords: node graph, editor_info, publish, CEL."
+license: MIT
+---
+
+# Scenario Workflow Authoring
+
+## Overview
+
+A workflow has two representations: `editor_info` (the editable node graph: `nodes`, `edges`, `inputKeys`) and `flow` (the compiled runnable form). Authoring through MCP means writing the whole `editor_info` document: there are no per-node editing tools; every change is a read, modify, write of the full graph through `workflow_create` or `workflow_update`. Never hand-write `flow`: `workflow_publish` compiles `editor_info` into it and flips status to `ready`. Editing a ready workflow's `editor_info` leaves the stale `flow` running until you publish again.
+
+Read [references/editor-info.md](references/editor-info.md) before writing any graph: it holds the node type vocabulary, the edge direction rule, per-node data contracts, and a validated minimal example. Create, update, publish, copy and delete live in the tool catalog (`scenario_tools_search` plus the matching executor, see the `scenario` skill). Running and pricing: the `scenario-workflows` skill.
+
+## Quick reference
+
+| Step              | Call                                 | Notes                                    |
+| ----------------- | ------------------------------------ | ---------------------------------------- |
+| 1. Study a graph  | `workflow_get` on a working workflow | Copy the shape, never ids                |
+| 2. Model contract | `model_schema_get`                   | Handle names and required inputs         |
+| 3. Author         | `editor_info` + `inputs_definition`  | Per the reference file                   |
+| 4. Create         | `workflow_create`                    | Non-atomic, see below                    |
+| 5. Publish        | `workflow_publish`                   | Compiles `flow`, needs input+output pins |
+| 6. Validate       | `workflow_run` with `dry_run=true`   | Prices and runs the real validator       |
+
+`workflow_create` is two calls under the hood: a failed create may still have created a draft whose id is in the error. Recover with `workflow_update` on that id; re-creating duplicates. To seed step 1 with public featured examples, run [scripts/fetch_workflow_examples.py](scripts/fetch_workflow_examples.py) with API credentials.
+
+## Choosing nodes
+
+One `model` node per requested deliverable. Add an `llm` node only when the user asked for LLM writing, when one brief fans out to N different prompts via `forEach`, or when text must be computed at run time from an upstream asset; "refine the prompt" is not a reason. N samples of one prompt is the model's own output-count parameter, never an `llm` or `forEach` fan-out. Compose a prompt from several sources with `transformText` (CEL), not an `llm`. Tool-style models define both input and output handles, so pick the model before wiring.
+
+## Worked example: a text-to-image app
+
+1. `search` for the model, then `model_schema_get`: its input names become the model node's handle names, and `required.always === true` marks what must be wired.
+2. Author `editor_info`: `text1` with `data.isInput: true`, `model1` with `type: "model"`, `data.modelId` and `data.isOutput: true`, one edge from `model1`'s input to `text1`'s output (edges name the downstream node as `source`, see the reference), `inputKeys: ["text1"]`.
+3. `workflow_create` with `name`, `editor_info`, and `inputs_definition` naming `text1` as a string input. The published input key is the node id, which is why run inputs have names like `text1`.
+4. `workflow_publish`, then `workflow_run` with `dry_run=true` to validate and price. Fix the graph and re-publish if validation fails.
+
+## Common mistakes
+
+- Writing UI palette names as node types: persisted types are the camelCase vocabulary in the reference, and every generator is `type: "model"`.
+- Wiring edges producer to consumer: persisted edges point the other way.
+- Expecting an `editor_info` update to change a live app without re-publishing.
+- Retrying a failed `workflow_create` with a second create instead of `workflow_update` on the id from the error.
+- Publishing with no pins: at least one `data.isInput` node listed in `inputKeys` and one `data.isOutput` node.
+- Double-quoted CEL literals: they evaluate but corrupt the canvas editor, single quotes only.
+- Sending `workflow_id` to `workflow_copy`: its parameter is `source_workflow_id`; the copy inherits everything verbatim and needs its own publish.

--- a/skills/scenario-workflow-authoring/references/editor-info.md
+++ b/skills/scenario-workflow-authoring/references/editor-info.md
@@ -63,7 +63,7 @@ Common `data` fields on every node: `title` (display name), `isInput` / `isOutpu
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `text`          | `value` (the string)                                                                                                                          |
 | `asset`         | `type` (`image` \| `video` \| `audio` \| `3d`, note `3d` not `3d-model`), `value` (asset id, or array when `isMultiple: true`), `isRequired?` |
-| `model` / `llm` | `modelId`, `form` (scalar params keyed by the model's input names, e.g. `{"prompt": "..."}`)                                                  |
+| `model` / `llm` | `modelId`, `form` (scalar-only settings keyed by the model's input names, e.g. `{"guidance": 7.5}`; wired inputs like `prompt` never go here) |
 | `transformText` | `value` (a CEL expression, see below)                                                                                                         |
 | `splitText`     | `splitDelimiter` (default `,`)                                                                                                                |
 | `groupItems`    | `value` (a CEL list expression)                                                                                                               |

--- a/skills/scenario-workflow-authoring/references/editor-info.md
+++ b/skills/scenario-workflow-authoring/references/editor-info.md
@@ -1,0 +1,236 @@
+# The editor_info grammar
+
+This is the authoring grammar for Scenario workflows: the `editor_info` document that `workflow_create` and `workflow_update` accept and `workflow_get` returns, plus the `inputs_definition` array that rides with it. `workflow_publish` compiles `editor_info` into the executable `flow`; you never write `flow` by hand.
+
+`editor_info` top-level keys: `nodes` (array), `edges` (array), `inputKeys` (ordered array of node ids for workflow inputs), and optionally `nodeGroups` (a map of group id to `{title, color, locked?}`, cosmetic only). Records fetched from live workflows may carry extra UI fields on nodes (`measured`, `selected`, `dragging`, `width`, `height`); omit them when authoring.
+
+## Edge direction is inverted: read this first
+
+Persisted edges do not point the way graph intuition says. In `editor_info.edges`:
+
+- `source` is the DOWNSTREAM consumer node, and `sourceHandle` is its INPUT handle.
+- `target` is the UPSTREAM producer node, and `targetHandle` is its OUTPUT handle.
+
+Handle ids follow one scheme:
+
+| Handle side | Id format                  | Example                |
+| ----------- | -------------------------- | ---------------------- |
+| Input       | `${nodeId}-source-${name}` | `model1-source-prompt` |
+| Output      | `${nodeId}-target-${name}` | `text1-target-output`  |
+
+So "text node `text1` feeds the prompt of model node `model1`" is written:
+
+```json
+{
+  "id": "edge1",
+  "source": "model1",
+  "sourceHandle": "model1-source-prompt",
+  "target": "text1",
+  "targetHandle": "text1-target-output"
+}
+```
+
+The name segment comes from the handle's `name` field. Output handle names are commonly `output`, but live workflows also show others (a text node feeding a prompt can carry a `prompt`-named output handle), so when cloning, copy handle ids from the source record instead of assuming `output`. `ifElse` output handles are named `if1` to `ifN` plus `else`.
+
+## Node type vocabulary
+
+`nodes[].type` uses a camelCase persisted vocabulary. The workflow editor's palette names (image-generator, prompt-builder, if-else, 3d-model, video-studio) are NOT valid persisted types; creation validation refuses unknown types before any network call.
+
+| Persisted type  | Editor palette equivalent                                   |
+| --------------- | ----------------------------------------------------------- |
+| `text`          | Text                                                        |
+| `asset`         | Image, Video, Audio, 3D model (kind in `data.type`)         |
+| `model`         | Every generator, tool, and studio node (kind via `modelId`) |
+| `llm`           | LLM generator                                               |
+| `transformText` | Prompt builder (CEL)                                        |
+| `splitText`     | Split text                                                  |
+| `groupItems`    | Group items                                                 |
+| `sliceAssets`   | Slice assets                                                |
+| `ifElse`        | If/else                                                     |
+| `forEach`       | For-each loop start                                         |
+| `forEachEnd`    | For-each loop end                                           |
+| `approval`      | Approval gate                                               |
+| `aspectRatio`   | Aspect ratio preset                                         |
+| `stickyNote`    | Sticky note (annotation only, never connected)              |
+
+The webapp also persists a `modelInput` type (a generator setting exposed as its own node), but the creation validator rejects it: an export using exposed model inputs fails a `workflow_create` round-trip.
+
+## Per-type data contracts
+
+Common `data` fields on every node: `title` (display name), `isInput` / `isOutput` (workflow pin flags), `inputHandles` / `outputHandles` (arrays of `{id, name, label, type}`).
+
+| Type            | Data fields                                                                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`          | `value` (the string)                                                                                                                          |
+| `asset`         | `type` (`image` \| `video` \| `audio` \| `3d`, note `3d` not `3d-model`), `value` (asset id, or array when `isMultiple: true`), `isRequired?` |
+| `model` / `llm` | `modelId`, `form` (scalar params keyed by the model's input names, e.g. `{"prompt": "..."}`)                                                  |
+| `transformText` | `value` (a CEL expression, see below)                                                                                                         |
+| `splitText`     | `splitDelimiter` (default `,`)                                                                                                                |
+| `groupItems`    | `value` (a CEL list expression)                                                                                                               |
+| `sliceAssets`   | `from`, `count`: STRINGS, not numbers (`"0"`, `"-3"`; negative `from` counts from the end)                                                    |
+| `aspectRatio`   | `output` (exactly one of `21:9`, `16:9`, `3:2`, `4:3`, `5:4`, `1:1`, `4:5`, `3:4`, `2:3`, `9:16`, `9:21`), `quality`                          |
+| `ifElse`        | `conditionBlocks` (see below)                                                                                                                 |
+| `forEach`       | `isConcurrentRuns?` (parallel iterations; ignored on nested loops)                                                                            |
+| `forEachEnd`    | `parentNodeId` (the paired `forEach` node id)                                                                                                 |
+| `approval`      | `message` (prompt shown when paused; default "Continue ?")                                                                                    |
+
+Only `image` and `video` asset nodes support `isMultiple` with an array `value`; `audio` and `3d` asset nodes hold a single asset id, always.
+
+## Workflow inputs are pinned nodes
+
+A workflow-level input is a node flagged `data.isInput: true`, ordered by `editor_info.inputKeys`. The published input's `name` IS the node id (`text1`, `image5`), which is why run-input keys look positional and non-contiguous. Outputs are `data.isOutput: true` pins on `model`, `llm`, or `forEachEnd` nodes; publish refuses a graph where no model or llm node is reachable from an output pin (the compiled flow would be empty). The webapp UI additionally requires at least one input pin and an output example image before it publishes; keep at least one of each for a usable app.
+
+`inputs_definition` entries mirror the pinned nodes:
+
+- Pinned `text` node: `{"type": "string", "name": "<nodeId>", "label", "description", "placeholder", "required": {"always": true|false}, "prompt": true|false, "default"}`.
+- Pinned `asset` node: `{"type": "file"}` or `"file_array"` when `isMultiple`, plus `"kind"` set to the asset `data.type`.
+
+The full input `type` set observed on live workflows: `string`, `integer` (typed as `number` in some layers), `boolean`, `file`, `file_array`, `string_array`, `model_array`, `number_array`, `inputs_array`. Array-typed inputs silently drop bare scalars at run time, so declare arrays only when the input truly takes a list.
+
+## Model nodes: handles come from the model schema
+
+A model node's input handles derive from its model's input schema: handle name = input name, so the model input `prompt` becomes handle id `${nodeId}-source-prompt`. Use `model_schema_get` on the chosen model id to learn the input names, types, and required rules (`required.always === true` is unconditional; `ifDefined` / `ifNotDefined` rules are conditional). Wire every unconditionally required input or the workflow cannot run. Scalar-only settings (guidance, seed, output count) go in `data.form`, not handles. Never hardcode model ids: discover them with `search` or `recommend` per team, then schema-check. LoRA and composition model ids (`runs_as` in the schema) were not validated inside graphs at authoring time: prefer plain model ids in `data.modelId`, and dry-run to validate when using one.
+
+## CEL expressions (transformText)
+
+`transformText` composes text at run time from connected inputs via a CEL expression in `data.value`. No LLM call is involved.
+
+- Variables are named `${nodeId}_${outputHandleName}`: text node `text1` with output handle `output` is `text1_output`. A variable only resolves when the corresponding edge exists; connect first, reference second.
+- String literals must be SINGLE-quoted. Double-quoted literals evaluate in CEL but corrupt the canvas editor's rendering of the expression, observed at authoring time.
+- Concatenate with `+`: `'A portrait of ' + trim(text1_output) + ' in the style of ' + text2_output`.
+- Custom functions: `trim(string)`, `slice(list, start, end)`. Standard CEL is available (`size`, `matches`, `startsWith`, `endsWith`, `contains`, `replace`, `split`, `substring`, `lowerAscii`, `upperAscii`, and the `has` / `all` / `exists` / `map` / `filter` macros).
+- Never feed a `splitText` output (a list) into `transformText` (single text); route lists through `forEach` or `sliceAssets`.
+
+`groupItems.data.value` is also CEL, producing a list.
+
+## ifElse condition blocks
+
+```json
+{
+  "conditionBlocks": [
+    {
+      "logic": "and",
+      "conditions": [
+        { "field": "text1_output", "operator": "contains", "value": "night" }
+      ]
+    }
+  ]
+}
+```
+
+- `field` uses the same `${nodeId}_${handleName}` convention as CEL variables.
+- Operators: `isEmpty`, `isNotEmpty`, `contains`, `notContains`, `equals`, `notEquals`. Numeric comparators are not part of the authoring surface.
+- `value` is required for `contains` / `notContains` / `equals` / `notEquals` and must be omitted for `isEmpty` / `isNotEmpty`; `field` is required always.
+- Block at index i drives output handle `if(i+1)`; the `else` handle is implicit and always last. Never author an `else` block. At run time the first matching block wins.
+
+## forEach loops
+
+`forEach` iterates its list input over the loop body. In the editor the end node is auto-created; when authoring `editor_info` directly you must include BOTH nodes: the `forEach` and a `forEachEnd` whose `data.parentNodeId` is the `forEach` node's id. The loop body's terminal output feeds the end node, and downstream consumers read from the end node's outputs. `isConcurrentRuns: true` parallelizes iterations and is ignored on nested loops. Loop wiring has more moving parts than any other construct: clone a working example (see template cloning below) rather than hand-authoring your first one.
+
+## Approval gates
+
+An `approval` node has ONE input handle (type `approval`) and NO outputs. It attaches to the dedicated approval OUTPUT handle that producer nodes expose (`model`, `llm`, `transformText`, `splitText`, `groupItems`, `sliceAssets`, `ifElse`, `forEachEnd`). Downstream nodes still wire to the producer's regular output handles; the gate only pauses them. Routing data through an approval node is structurally wrong and will not compile. At run time the run reply and the job record carry `metadata.flow` with a per-node `status`; the gate shows as a pending `user-approval` entry there, and `workflow_approve` / `workflow_reject` (with `workflow_id`, `workflow_job_id`, `node_id`) resolve it; reject cancels the workflow or the containing loop iteration.
+
+## Create, update, publish
+
+- `workflow_create` params: `name` (required), `description`, `editor_info`, `inputs_definition`, `flow`. Author `editor_info` + `inputs_definition` only. `editor_info` is validated before any network call; unknown node types and missing `nodes` / `edges` are refused with nothing created.
+- Creation is two calls under the hood (a create for `name` + `description`, then an update with the content) and is not atomic: if the second step fails you have an orphan draft, and the error carries its id. Recover with `workflow_update` on that id, or `workflow_delete`; re-running `workflow_create` duplicates.
+- Create and update persist a DRAFT. Only `workflow_publish` compiles `editor_info` into `flow` and flips status to `ready`; a draft run returns "Workflow is not ready". Publish is user-consent territory: ask before publishing.
+- Updating `editor_info` on an already `ready` workflow leaves it running the STALE previously compiled flow until you publish again; the response's publish hint is the only signal.
+- Unpublish (reverting a ready app to draft) is a webapp action: the underlying API accepts a `status` field, but the MCP `workflow_update` tool does not expose one. Through MCP, fix a bad app by editing `editor_info` and publishing over the top.
+- `workflow_update` includes `name` only when non-empty (renaming to `""` silently no-ops); `description: ""` does clear.
+- Statuses are exactly `draft`, `ready`, `deleted`. "Has an app" really means `flow` is non-empty.
+- `workflow_copy` (param `source_workflow_id`) copies `flow`, `inputs`, and `editorInfo` verbatim, skipping validation: a corrupted source copies corrupted, inherited model ids stay as-is, and a copied draft still needs publish.
+
+## Import and export
+
+A webapp export file is `{"version": "1.0", "name", "description", "editorInfo": {...}, "inputs": [...], "tagSet": [...]}`. Importing one through MCP is two calls: `workflow_create` mapping `editorInfo` to `editor_info` and `inputs` to `inputs_definition`, then `workflow_publish` on the returned id. Exports drop node groups and asset values (assets must be re-added), and an export that used exposed model-input nodes fails validation on import.
+
+## Choosing nodes
+
+- Deliverables are model nodes: a brief asking for N distinct outputs gets N model nodes.
+- `llm` nodes are the top authoring failure mode. Default to none. Legitimate only when the user asked for LLM writing (captioning, rewriting, prompt variations), when fanning one brief into N different prompts via `forEach`, or when text must be computed at run time from an upstream asset. N samples of ONE prompt is one model node with its output-count parameter (name varies per model: `samples`, `nbImages`, `count`; check the schema), never an llm fan-out.
+- Composing a prompt from several outputs is `transformText`, not `llm`.
+- Tool-style models (upscale, remove background) define BOTH input and output handles, so pick the model before wiring. Studio-style composition models are fixed to their built-in model.
+
+## Layout
+
+`position: {x, y}` is metadata but keeps the canvas usable: nodes are about 340px wide, so chain left to right in x steps of about 400 and stack independent nodes in y steps of about 260, starting at `(0, 0)`.
+
+## Minimal working example
+
+This exact payload was validated live at authoring time with a real `modelId` substituted: create returned a draft with `_publishHint`, publish compiled the edge into `{"name": "prompt", "ref": {"node": "workflow", "name": "text1"}}` on the model's flow node and flipped status to `ready`, and a dry run returned `{"creativeUnitsCost": ..., "job": {}}`. One pinned text input feeding one pinned image model:
+
+```json
+{
+  "name": "prompt-to-image",
+  "description": "Minimal text to image app",
+  "editor_info": {
+    "nodes": [
+      {
+        "id": "text1",
+        "type": "text",
+        "position": { "x": 0, "y": 0 },
+        "data": {
+          "title": "Prompt",
+          "value": "A red fox in the snow",
+          "isInput": true,
+          "outputHandles": [
+            {
+              "id": "text1-target-output",
+              "name": "output",
+              "label": "Output",
+              "type": "text"
+            }
+          ]
+        }
+      },
+      {
+        "id": "model1",
+        "type": "model",
+        "position": { "x": 400, "y": 0 },
+        "data": {
+          "title": "Image generator",
+          "modelId": "<discover via search, never hardcode>",
+          "isOutput": true,
+          "form": {},
+          "inputHandles": [
+            {
+              "id": "model1-source-prompt",
+              "name": "prompt",
+              "label": "Prompt",
+              "type": "prompt"
+            }
+          ]
+        }
+      }
+    ],
+    "edges": [
+      {
+        "id": "edge1",
+        "source": "model1",
+        "sourceHandle": "model1-source-prompt",
+        "target": "text1",
+        "targetHandle": "text1-target-output"
+      }
+    ],
+    "inputKeys": ["text1"]
+  },
+  "inputs_definition": [
+    {
+      "type": "string",
+      "name": "text1",
+      "label": "Prompt",
+      "required": { "always": true },
+      "prompt": true,
+      "default": "A red fox in the snow"
+    }
+  ]
+}
+```
+
+After `workflow_create` returns the id: `workflow_publish`, then `workflow_run` with `dry_run: true` and `{"text1": "..."}` to price and validate, then run for real.
+
+## Template cloning
+
+Before authoring a first graph of any new shape, `workflow_get` a working workflow of a similar shape and copy its structure: node types, edge topology, handle id patterns, pin placement. Never reuse its node ids, asset ids, or model ids as constants. Prefer recently updated workflows as templates: the editor silently migrates older persisted shapes on load (renamed types, injected handles), but the API returns them raw, so an old workflow can teach you a grammar the validator no longer accepts.

--- a/skills/scenario-workflow-authoring/references/editor-info.md
+++ b/skills/scenario-workflow-authoring/references/editor-info.md
@@ -149,7 +149,7 @@ A webapp export file is `{"version": "1.0", "name", "description", "editorInfo":
 ## Choosing nodes
 
 - Deliverables are model nodes: a brief asking for N distinct outputs gets N model nodes.
-- `llm` nodes are the top authoring failure mode. Default to none. Legitimate only when the user asked for LLM writing (captioning, rewriting, prompt variations), when fanning one brief into N different prompts via `forEach`, or when text must be computed at run time from an upstream asset. N samples of ONE prompt is one model node with its output-count parameter (name varies per model: `samples`, `nbImages`, `count`; check the schema), never an llm fan-out.
+- `llm` nodes are the top authoring failure mode. Default to none. Legitimate only when the user asked for LLM writing (captioning, rewriting, prompt variations), when fanning one brief into N different prompts via `forEach`, or when text must be computed at run time from an upstream asset; "refine the prompt" is not a reason. N samples of ONE prompt is one model node with its output-count parameter (name varies per model: `samples`, `nbImages`, `count`; check the schema), never an `llm` or `forEach` fan-out.
 - Composing a prompt from several outputs is `transformText`, not `llm`.
 - Tool-style models (upscale, remove background) define BOTH input and output handles, so pick the model before wiring. Studio-style composition models are fixed to their built-in model.
 

--- a/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
+++ b/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
@@ -15,9 +15,9 @@ API surface per the Workflows & Apps page on https://docs.scenario.com:
 GET https://api.cloud.scenario.com/v1/workflows with HTTP Basic auth
 (base64 of key:secret), privacy=public to list public workflows, pageSize
 (max 100) plus paginationToken for paging, and a nextPaginationToken field
-in the response for the next page. Live list responses carry editorInfo
-per workflow; when one does not, the full record is fetched from
-GET /v1/workflows/{id} before the workflow is skipped.
+in the response for the next page. Public listings never include flow or
+editorInfo (the full parameter is ignored there, per the API reference),
+so each tagged hit's editor graph comes from GET /v1/workflows/{id}.
 """
 
 from __future__ import annotations
@@ -221,8 +221,9 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             trimmed = trim_workflow(workflow)
             if trimmed is None:
-                # A listing that omits the editor graph is not proof there is
-                # none: fetch the full record before deciding.
+                # Public listings never include the editor graph (the API
+                # reference: full is ignored there), so the full record is
+                # the only place to read it from.
                 try:
                     trimmed = trim_workflow(fetch_workflow(auth_header, workflow["id"]))
                 except RuntimeError as err:

--- a/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
+++ b/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Fetch public featured Scenario workflows as structural wiring examples.
+
+Lists public workflows from the Scenario REST API, keeps the ones tagged
+featured (or sc:featured) that carry an editor graph, and writes one trimmed
+JSON file per workflow. The trim keeps node types, edge wiring, and input
+keys, and drops content values (prompts, asset ids, parameter values): each
+file is a structural reference for wiring a similar workflow, never content
+to reuse.
+
+    SCENARIO_API_KEY=... SCENARIO_API_SECRET=... \\
+        python3 scripts/fetch_workflow_examples.py --output-dir workflow-examples
+
+API surface per the Workflows & Apps page on https://docs.scenario.com:
+GET https://api.cloud.scenario.com/v1/workflows with HTTP Basic auth
+(base64 of key:secret), privacy=public to list public workflows, pageSize
+(max 100) plus paginationToken for paging, and a nextPaginationToken field
+in the response for the next page.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_URL = "https://api.cloud.scenario.com/v1/workflows"
+
+# Documented maximum page size (default is 50).
+PAGE_SIZE = 100
+
+DEFAULT_TAGS = ("featured", "sc:featured")
+
+# Structural node data worth keeping. Everything else in a node's data is
+# content (prompt text, asset references, parameter values) and is dropped.
+NODE_DATA_KEYS = ("type", "modelId", "title", "isInput", "isOutput")
+
+EDGE_KEYS = ("source", "sourceHandle", "target", "targetHandle")
+
+
+def build_auth_header(key: str, secret: str) -> str:
+    token = base64.b64encode(f"{key}:{secret}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def fetch_page(auth_header: str, pagination_token: str | None = None, page_size: int = PAGE_SIZE) -> dict:
+    params = {"privacy": "public", "pageSize": str(page_size)}
+    if pagination_token:
+        params["paginationToken"] = pagination_token
+    url = f"{API_URL}?{urllib.parse.urlencode(params)}"
+    request = urllib.request.Request(
+        url,
+        headers={"Authorization": auth_header, "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as err:
+        hint = " (check SCENARIO_API_KEY / SCENARIO_API_SECRET)" if err.code in (401, 403) else ""
+        raise RuntimeError(f"GET {API_URL} failed with HTTP {err.code}{hint}") from err
+    except urllib.error.URLError as err:
+        raise RuntimeError(f"GET {API_URL} failed: {err.reason}") from err
+
+
+def iter_public_workflows(auth_header: str, max_pages: int, page_size: int = PAGE_SIZE):
+    token = None
+    for _ in range(max_pages):
+        page = fetch_page(auth_header, token, page_size)
+        yield from page.get("workflows") or []
+        token = page.get("nextPaginationToken")
+        if not token:
+            break
+
+
+def _pick(source: dict, keys: tuple[str, ...]) -> dict:
+    return {key: source[key] for key in keys if source.get(key) is not None}
+
+
+def trim_node(node: dict) -> dict:
+    trimmed = _pick(node, ("id", "type"))
+    data = node.get("data")
+    if isinstance(data, dict):
+        kept = _pick(data, NODE_DATA_KEYS)
+        if kept:
+            trimmed["data"] = kept
+    return trimmed
+
+
+def trim_edge(edge: dict) -> dict:
+    return _pick(edge, EDGE_KEYS)
+
+
+def input_keys(workflow: dict) -> list[str]:
+    keys = workflow.get("inputKeys")
+    if isinstance(keys, list) and all(isinstance(k, str) for k in keys):
+        return keys
+    # The docs show an inputs field on workflow objects without pinning its
+    # shape, so accept the likely shapes and fall back to an empty list.
+    inputs = workflow.get("inputs")
+    if isinstance(inputs, dict):
+        return list(inputs.keys())
+    if isinstance(inputs, list):
+        found = []
+        for item in inputs:
+            if isinstance(item, str):
+                found.append(item)
+            elif isinstance(item, dict):
+                for field in ("key", "name", "id"):
+                    value = item.get(field)
+                    if isinstance(value, str):
+                        found.append(value)
+                        break
+        return found
+    return []
+
+
+def trim_workflow(workflow: dict) -> dict | None:
+    """Trim a workflow to its structural wiring, or None without an editor graph."""
+    editor_info = workflow.get("editorInfo")
+    if not isinstance(editor_info, dict):
+        return None
+    nodes = editor_info.get("nodes")
+    if not isinstance(nodes, list) or not nodes:
+        return None
+    edges = editor_info.get("edges")
+    if not isinstance(edges, list):
+        edges = []
+    return {
+        "id": workflow.get("id"),
+        "name": workflow.get("name") or "",
+        "description": workflow.get("description") or "",
+        "nodes": [trim_node(node) for node in nodes if isinstance(node, dict)],
+        "edges": [trim_edge(edge) for edge in edges if isinstance(edge, dict)],
+        "inputKeys": input_keys(workflow),
+    }
+
+
+def write_example(output_dir: str, trimmed: dict) -> str:
+    os.makedirs(output_dir, exist_ok=True)
+    # Defensive: an id must never escape the output directory.
+    safe_id = str(trimmed["id"]).replace("/", "_").replace("\\", "_")
+    path = os.path.join(output_dir, f"{safe_id}.json")
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(trimmed, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    return path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--output-dir", default="./workflow-examples", help="where the trimmed JSON files go")
+    parser.add_argument("--max-pages", type=int, default=5, help="page cap for the listing (default 5)")
+    parser.add_argument(
+        "--tag",
+        action="append",
+        help="tag to keep, repeatable (default: featured and sc:featured)",
+    )
+    args = parser.parse_args(argv)
+    if args.max_pages < 1:
+        parser.error("--max-pages must be at least 1")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    key = os.environ.get("SCENARIO_API_KEY", "").strip()
+    secret = os.environ.get("SCENARIO_API_SECRET", "").strip()
+    if not key or not secret:
+        print(
+            "SCENARIO_API_KEY and SCENARIO_API_SECRET must be set: the workflows"
+            " endpoint requires HTTP Basic auth with your Scenario API key and secret.",
+            file=sys.stderr,
+        )
+        return 1
+
+    auth_header = build_auth_header(key, secret)
+    wanted = set(args.tag) if args.tag else set(DEFAULT_TAGS)
+    kept = 0
+    try:
+        for workflow in iter_public_workflows(auth_header, args.max_pages):
+            # Tag filtering happens client side: the documented tags query
+            # parameter does not state how multiple tags combine, and this
+            # needs any-of semantics.
+            if not set(workflow.get("tagSet") or []) & wanted:
+                continue
+            if not workflow.get("id"):
+                print("skipping a tagged workflow with no id", file=sys.stderr)
+                continue
+            trimmed = trim_workflow(workflow)
+            if trimmed is None:
+                print(f"skipping {workflow['id']}: tagged but has no editor graph", file=sys.stderr)
+                continue
+            path = write_example(args.output_dir, trimmed)
+            kept += 1
+            print(
+                f"{trimmed['id']}: {trimmed['name']}"
+                f" ({len(trimmed['nodes'])} nodes, {len(trimmed['edges'])} edges,"
+                f" {len(trimmed['inputKeys'])} inputs) -> {path}"
+            )
+    except RuntimeError as err:
+        print(str(err), file=sys.stderr)
+        return 1
+
+    if kept == 0:
+        print(f"No public workflows tagged {sorted(wanted)} with an editor graph were found.")
+    print(f"Wrote {kept} workflow example(s) to {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
+++ b/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
@@ -179,7 +179,10 @@ def main(argv: list[str] | None = None) -> int:
                 # the only place to read it from.
                 try:
                     trimmed = trim_workflow(client.workflows.retrieve(workflow.id).workflow)
-                except scenario_sdk.APIStatusError as err:
+                except scenario_sdk.APIError as err:
+                    # APIError also covers connection and timeout errors, which
+                    # are siblings of APIStatusError: one flaky retrieve must
+                    # skip that workflow, never abort the whole export.
                     print(f"skipping {workflow.id}: {describe_error(err)}", file=sys.stderr)
                     continue
             if trimmed is None:

--- a/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
+++ b/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
@@ -15,7 +15,9 @@ API surface per the Workflows & Apps page on https://docs.scenario.com:
 GET https://api.cloud.scenario.com/v1/workflows with HTTP Basic auth
 (base64 of key:secret), privacy=public to list public workflows, pageSize
 (max 100) plus paginationToken for paging, and a nextPaginationToken field
-in the response for the next page.
+in the response for the next page. Live list responses carry editorInfo
+per workflow; when one does not, the full record is fetched from
+GET /v1/workflows/{id} before the workflow is skipped.
 """
 
 from __future__ import annotations
@@ -36,9 +38,10 @@ PAGE_SIZE = 100
 
 DEFAULT_TAGS = ("featured", "sc:featured")
 
-# Structural node data worth keeping. Everything else in a node's data is
-# content (prompt text, asset references, parameter values) and is dropped.
-NODE_DATA_KEYS = ("type", "modelId", "title", "isInput", "isOutput")
+# Structural node data worth keeping: pin flags, model binding, and the
+# forEachEnd loop pairing. Everything else in a node's data is content
+# (prompt text, asset references, parameter values) and is dropped.
+NODE_DATA_KEYS = ("type", "modelId", "title", "isInput", "isOutput", "parentNodeId")
 
 EDGE_KEYS = ("source", "sourceHandle", "target", "targetHandle")
 
@@ -65,6 +68,24 @@ def fetch_page(auth_header: str, pagination_token: str | None = None, page_size:
         raise RuntimeError(f"GET {API_URL} failed with HTTP {err.code}{hint}") from err
     except urllib.error.URLError as err:
         raise RuntimeError(f"GET {API_URL} failed: {err.reason}") from err
+
+
+def fetch_workflow(auth_header: str, workflow_id: str) -> dict:
+    """Fetch one workflow's full record (GET /v1/workflows/{id})."""
+    url = f"{API_URL}/{urllib.parse.quote(workflow_id, safe='')}"
+    request = urllib.request.Request(
+        url,
+        headers={"Authorization": auth_header, "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as err:
+        raise RuntimeError(f"GET {url} failed with HTTP {err.code}") from err
+    except urllib.error.URLError as err:
+        raise RuntimeError(f"GET {url} failed: {err.reason}") from err
+    workflow = payload.get("workflow") if isinstance(payload, dict) else None
+    return workflow if isinstance(workflow, dict) else payload
 
 
 def iter_public_workflows(auth_header: str, max_pages: int, page_size: int = PAGE_SIZE):
@@ -96,6 +117,13 @@ def trim_edge(edge: dict) -> dict:
 
 
 def input_keys(workflow: dict) -> list[str]:
+    # The authoring grammar keeps the ordered pin list at editorInfo.inputKeys
+    # (verified against live records); check there before any fallback.
+    editor_info = workflow.get("editorInfo")
+    if isinstance(editor_info, dict):
+        keys = editor_info.get("inputKeys")
+        if isinstance(keys, list) and keys and all(isinstance(k, str) for k in keys):
+            return keys
     keys = workflow.get("inputKeys")
     if isinstance(keys, list) and all(isinstance(k, str) for k in keys):
         return keys
@@ -192,6 +220,14 @@ def main(argv: list[str] | None = None) -> int:
                 print("skipping a tagged workflow with no id", file=sys.stderr)
                 continue
             trimmed = trim_workflow(workflow)
+            if trimmed is None:
+                # A listing that omits the editor graph is not proof there is
+                # none: fetch the full record before deciding.
+                try:
+                    trimmed = trim_workflow(fetch_workflow(auth_header, workflow["id"]))
+                except RuntimeError as err:
+                    print(f"skipping {workflow['id']}: {err}", file=sys.stderr)
+                    continue
             if trimmed is None:
                 print(f"skipping {workflow['id']}: tagged but has no editor graph", file=sys.stderr)
                 continue

--- a/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
+++ b/skills/scenario-workflow-authoring/scripts/fetch_workflow_examples.py
@@ -1,37 +1,38 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["scenario-sdk"]
+# ///
 """Fetch public featured Scenario workflows as structural wiring examples.
 
-Lists public workflows from the Scenario REST API, keeps the ones tagged
-featured (or sc:featured) that carry an editor graph, and writes one trimmed
-JSON file per workflow. The trim keeps node types, edge wiring, and input
-keys, and drops content values (prompts, asset ids, parameter values): each
-file is a structural reference for wiring a similar workflow, never content
-to reuse.
+Built on the official Scenario Python SDK (scenario-sdk on PyPI): run it
+with `uv run scripts/fetch_workflow_examples.py` (uv reads the inline
+dependency block above) or `pip install scenario-sdk` first. Credentials
+come from the SDK's standard environment variables, SCENARIO_SDK_API_KEY
+and SCENARIO_SDK_API_SECRET.
 
-    SCENARIO_API_KEY=... SCENARIO_API_SECRET=... \\
-        python3 scripts/fetch_workflow_examples.py --output-dir workflow-examples
+Lists public workflows, keeps the ones tagged featured (or sc:featured),
+and writes one trimmed JSON file per workflow. Public listings never
+include flow or editorInfo (per the API reference, the full parameter is
+ignored there), so each tagged hit's editor graph comes from a per-id
+retrieve. The trim keeps node types, edge wiring, and input keys, and
+drops content values (prompts, asset ids, parameter values): each file is
+a structural reference for wiring a similar workflow, never content to
+reuse.
 
-API surface per the Workflows & Apps page on https://docs.scenario.com:
-GET https://api.cloud.scenario.com/v1/workflows with HTTP Basic auth
-(base64 of key:secret), privacy=public to list public workflows, pageSize
-(max 100) plus paginationToken for paging, and a nextPaginationToken field
-in the response for the next page. Public listings never include flow or
-editorInfo (the full parameter is ignored there, per the API reference),
-so each tagged hit's editor graph comes from GET /v1/workflows/{id}.
+    SCENARIO_SDK_API_KEY=... SCENARIO_SDK_API_SECRET=... \\
+        uv run scripts/fetch_workflow_examples.py --output-dir workflow-examples
 """
 
 from __future__ import annotations
 
 import argparse
-import base64
 import json
 import os
 import sys
-import urllib.error
-import urllib.parse
-import urllib.request
 
-API_URL = "https://api.cloud.scenario.com/v1/workflows"
+import scenario_sdk
+from scenario_sdk import Scenario
 
 # Documented maximum page size (default is 50).
 PAGE_SIZE = 100
@@ -46,56 +47,15 @@ NODE_DATA_KEYS = ("type", "modelId", "title", "isInput", "isOutput", "parentNode
 EDGE_KEYS = ("source", "sourceHandle", "target", "targetHandle")
 
 
-def build_auth_header(key: str, secret: str) -> str:
-    token = base64.b64encode(f"{key}:{secret}".encode("utf-8")).decode("ascii")
-    return f"Basic {token}"
-
-
-def fetch_page(auth_header: str, pagination_token: str | None = None, page_size: int = PAGE_SIZE) -> dict:
-    params = {"privacy": "public", "pageSize": str(page_size)}
-    if pagination_token:
-        params["paginationToken"] = pagination_token
-    url = f"{API_URL}?{urllib.parse.urlencode(params)}"
-    request = urllib.request.Request(
-        url,
-        headers={"Authorization": auth_header, "Accept": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            return json.load(response)
-    except urllib.error.HTTPError as err:
-        hint = " (check SCENARIO_API_KEY / SCENARIO_API_SECRET)" if err.code in (401, 403) else ""
-        raise RuntimeError(f"GET {API_URL} failed with HTTP {err.code}{hint}") from err
-    except urllib.error.URLError as err:
-        raise RuntimeError(f"GET {API_URL} failed: {err.reason}") from err
-
-
-def fetch_workflow(auth_header: str, workflow_id: str) -> dict:
-    """Fetch one workflow's full record (GET /v1/workflows/{id})."""
-    url = f"{API_URL}/{urllib.parse.quote(workflow_id, safe='')}"
-    request = urllib.request.Request(
-        url,
-        headers={"Authorization": auth_header, "Accept": "application/json"},
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            payload = json.load(response)
-    except urllib.error.HTTPError as err:
-        raise RuntimeError(f"GET {url} failed with HTTP {err.code}") from err
-    except urllib.error.URLError as err:
-        raise RuntimeError(f"GET {url} failed: {err.reason}") from err
-    workflow = payload.get("workflow") if isinstance(payload, dict) else None
-    return workflow if isinstance(workflow, dict) else payload
-
-
-def iter_public_workflows(auth_header: str, max_pages: int, page_size: int = PAGE_SIZE):
-    token = None
-    for _ in range(max_pages):
-        page = fetch_page(auth_header, token, page_size)
-        yield from page.get("workflows") or []
-        token = page.get("nextPaginationToken")
-        if not token:
+def iter_public_workflows(client: Scenario, max_pages: int, page_size: int = PAGE_SIZE):
+    page = client.workflows.list(privacy="public", page_size=page_size)
+    pages_walked = 1
+    while True:
+        yield from page.workflows
+        if pages_walked >= max_pages or not page.has_next_page():
             break
+        page = page.get_next_page()
+        pages_walked += 1
 
 
 def _pick(source: dict, keys: tuple[str, ...]) -> dict:
@@ -116,40 +76,24 @@ def trim_edge(edge: dict) -> dict:
     return _pick(edge, EDGE_KEYS)
 
 
-def input_keys(workflow: dict) -> list[str]:
+def input_keys(workflow, editor_info: dict) -> list[str]:
     # The authoring grammar keeps the ordered pin list at editorInfo.inputKeys
     # (verified against live records); check there before any fallback.
-    editor_info = workflow.get("editorInfo")
-    if isinstance(editor_info, dict):
-        keys = editor_info.get("inputKeys")
-        if isinstance(keys, list) and keys and all(isinstance(k, str) for k in keys):
-            return keys
-    keys = workflow.get("inputKeys")
-    if isinstance(keys, list) and all(isinstance(k, str) for k in keys):
+    keys = editor_info.get("inputKeys")
+    if isinstance(keys, list) and keys and all(isinstance(k, str) for k in keys):
         return keys
-    # The docs show an inputs field on workflow objects without pinning its
-    # shape, so accept the likely shapes and fall back to an empty list.
-    inputs = workflow.get("inputs")
-    if isinstance(inputs, dict):
-        return list(inputs.keys())
-    if isinstance(inputs, list):
-        found = []
-        for item in inputs:
-            if isinstance(item, str):
-                found.append(item)
-            elif isinstance(item, dict):
-                for field in ("key", "name", "id"):
-                    value = item.get(field)
-                    if isinstance(value, str):
-                        found.append(value)
-                        break
-        return found
-    return []
+    # Fall back to the typed inputs carried by the workflow record.
+    names = []
+    for item in getattr(workflow, "inputs", None) or []:
+        name = getattr(item, "name", None)
+        if isinstance(name, str):
+            names.append(name)
+    return names
 
 
-def trim_workflow(workflow: dict) -> dict | None:
-    """Trim a workflow to its structural wiring, or None without an editor graph."""
-    editor_info = workflow.get("editorInfo")
+def trim_workflow(workflow) -> dict | None:
+    """Trim a workflow record to its structural wiring, or None without an editor graph."""
+    editor_info = getattr(workflow, "editor_info", None)
     if not isinstance(editor_info, dict):
         return None
     nodes = editor_info.get("nodes")
@@ -159,12 +103,12 @@ def trim_workflow(workflow: dict) -> dict | None:
     if not isinstance(edges, list):
         edges = []
     return {
-        "id": workflow.get("id"),
-        "name": workflow.get("name") or "",
-        "description": workflow.get("description") or "",
+        "id": workflow.id,
+        "name": workflow.name or "",
+        "description": workflow.description or "",
         "nodes": [trim_node(node) for node in nodes if isinstance(node, dict)],
         "edges": [trim_edge(edge) for edge in edges if isinstance(edge, dict)],
-        "inputKeys": input_keys(workflow),
+        "inputKeys": input_keys(workflow, editor_info),
     }
 
 
@@ -194,30 +138,39 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return args
 
 
+def describe_error(err: Exception) -> str:
+    if isinstance(err, (scenario_sdk.AuthenticationError, scenario_sdk.PermissionDeniedError)):
+        return (
+            f"Scenario API refused the credentials (HTTP {err.status_code}):"
+            " check SCENARIO_SDK_API_KEY / SCENARIO_SDK_API_SECRET"
+        )
+    if isinstance(err, scenario_sdk.APIStatusError):
+        return f"Scenario API request failed with HTTP {err.status_code}"
+    return f"Scenario API request failed: {err}"
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    key = os.environ.get("SCENARIO_API_KEY", "").strip()
-    secret = os.environ.get("SCENARIO_API_SECRET", "").strip()
+    key = os.environ.get("SCENARIO_SDK_API_KEY", "").strip()
+    secret = os.environ.get("SCENARIO_SDK_API_SECRET", "").strip()
     if not key or not secret:
         print(
-            "SCENARIO_API_KEY and SCENARIO_API_SECRET must be set: the workflows"
-            " endpoint requires HTTP Basic auth with your Scenario API key and secret.",
+            "SCENARIO_SDK_API_KEY and SCENARIO_SDK_API_SECRET must be set: the"
+            " official scenario-sdk reads your Scenario API key and secret from"
+            " these environment variables.",
             file=sys.stderr,
         )
         return 1
 
-    auth_header = build_auth_header(key, secret)
+    client = Scenario()
     wanted = set(args.tag) if args.tag else set(DEFAULT_TAGS)
     kept = 0
     try:
-        for workflow in iter_public_workflows(auth_header, args.max_pages):
+        for workflow in iter_public_workflows(client, args.max_pages):
             # Tag filtering happens client side: the documented tags query
             # parameter does not state how multiple tags combine, and this
             # needs any-of semantics.
-            if not set(workflow.get("tagSet") or []) & wanted:
-                continue
-            if not workflow.get("id"):
-                print("skipping a tagged workflow with no id", file=sys.stderr)
+            if not set(workflow.tag_set or []) & wanted:
                 continue
             trimmed = trim_workflow(workflow)
             if trimmed is None:
@@ -225,12 +178,12 @@ def main(argv: list[str] | None = None) -> int:
                 # reference: full is ignored there), so the full record is
                 # the only place to read it from.
                 try:
-                    trimmed = trim_workflow(fetch_workflow(auth_header, workflow["id"]))
-                except RuntimeError as err:
-                    print(f"skipping {workflow['id']}: {err}", file=sys.stderr)
+                    trimmed = trim_workflow(client.workflows.retrieve(workflow.id).workflow)
+                except scenario_sdk.APIStatusError as err:
+                    print(f"skipping {workflow.id}: {describe_error(err)}", file=sys.stderr)
                     continue
             if trimmed is None:
-                print(f"skipping {workflow['id']}: tagged but has no editor graph", file=sys.stderr)
+                print(f"skipping {workflow.id}: tagged but has no editor graph", file=sys.stderr)
                 continue
             path = write_example(args.output_dir, trimmed)
             kept += 1
@@ -239,8 +192,8 @@ def main(argv: list[str] | None = None) -> int:
                 f" ({len(trimmed['nodes'])} nodes, {len(trimmed['edges'])} edges,"
                 f" {len(trimmed['inputKeys'])} inputs) -> {path}"
             )
-    except RuntimeError as err:
-        print(str(err), file=sys.stderr)
+    except scenario_sdk.ScenarioError as err:
+        print(describe_error(err), file=sys.stderr)
         return 1
 
     if kept == 0:

--- a/skills/scenario-workflows/SKILL.md
+++ b/skills/scenario-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-workflows
-description: "Use when a task involves a Scenario workflow through MCP, including anything the user calls a Scenario app, a saved pipeline, or a multi-step generation graph. Triggers include listing or running workflows, building the inputs object for workflow_run, pricing a run with a dry run, publishing a draft so it becomes runnable, approving or rejecting a paused approval node, copying a workflow, or a workflows_list reply that flooded the context. Keywords: workflow, app, pipeline, approval gate."
+description: "Use when a task involves running a Scenario workflow through MCP, including anything the user calls a Scenario app, a saved pipeline, or a multi-step generation graph. Triggers include listing workflows, building the inputs object for workflow_run, pricing a run with a dry run, approving or rejecting the approval node a run is stuck on, or a workflows_list reply that flooded the context. Creating or editing graphs is scenario-workflow-authoring. Keywords: workflow, app, pipeline, approval gate."
 license: MIT
 ---
 
@@ -8,9 +8,9 @@ license: MIT
 
 ## Overview
 
-A Scenario workflow is a saved node graph chaining several models into one call; users say "app" and mean one whose status is `ready`. `workflow_run` runs it and returns a job tracked like any other generation.
+A Scenario workflow is a saved node graph chaining several models into one call; users say "app" and mean one whose status is `ready`. `workflow_run` returns a job tracked like any other generation.
 
-Only `workflows_list`, `workflow_get` and `workflow_run` are listed by default; create, update, publish, copy, approve, reject and delete run through `scenario_tools_search` plus the executor matching their lane. Connection and the core loop: see the `scenario` skill.
+Only `workflows_list`, `workflow_get` and `workflow_run` are listed by default; approve and reject run through `scenario_tools_search` plus their executor lane. Connection and the core loop: the `scenario` skill. Creating, editing and publishing graphs: the `scenario-workflow-authoring` skill.
 
 ## Quick reference
 
@@ -22,36 +22,35 @@ Only `workflows_list`, `workflow_get` and `workflow_run` are listed by default; 
 | 4. Run                | `workflow_run` with `inputs`       | Returns a job                  |
 | 5. Wait               | `jobs_wait`                        | Re-call with `pending_job_ids` |
 
-Ids are prefixed `wflow_`, not `workflow_` as the tool-doc examples show, so copy them from `workflows_list`. `search` with `target="workflows"` returned 403 at authoring time.
+Ids are prefixed `wflow_`, not `workflow_` as tool-doc examples show; copy them from `workflows_list`. `search` with `target="workflows"` returned 403 at authoring time.
 
 ## Cap every list call
 
-Each record carries the compiled `flow` and the whole `editorInfo` node graph with no compact flag, and live records ran 5,500 to 22,000 characters each. Cap `limit` at 3 or fewer, read only `id`, `name`, `hasFlow` and `inputs`, and page with `page_token` set to the previous reply's `nextPaginationToken`.
+Each record carries the compiled `flow` and the whole `editorInfo` node graph with no compact flag; live records ran 5,500 to 22,000 characters. Cap `limit` at 3 or fewer, read only `id`, `name`, `hasFlow` and `inputs`, and page with `page_token` set to the previous reply's `nextPaginationToken`.
 
-Only `draft` and `ready` filter server-side; other statuses filter each page client-side (the reply flags `_workflowListStatusFilter`), so an empty page beside a `nextPaginationToken` means keep paging.
+Only `draft` and `ready` filter server-side; other statuses filter each page client-side (flagged `_workflowListStatusFilter`); there an empty page beside a `nextPaginationToken` means keep paging.
 
 ## The input contract
 
-`workflow_run`'s `inputs` object is keyed by `inputs[].name`, taken verbatim from the record. Names are authored per workflow, some semantic (`characterDescription`), some positional (`text2`), and positional names are neither contiguous nor ordered: one live workflow exposes only `text2` and `text3`.
+`workflow_run`'s `inputs` object is keyed by `inputs[].name`, taken verbatim from the record. Each name is the id of the node behind it, so names can be positional (`text2`, `text3`), neither contiguous nor ordered.
 
-- `label` and `description` carry the human intent, not the key. A field labelled "Source Image" is still keyed `image1`.
+- `label` and `description` carry the human intent, not the key.
 - Never harvest keys from `editorInfo.nodes[].data.name`; node names go stale.
-- `required` is an object. Test `required.always === true`, because a truthiness check reads `{"always": false}` as required too.
-- `workflow_get` wraps the definition in `workflow` as `inputs_definition` and `editor_info`; `workflows_list` wraps it in `workflows` as `inputs` and `editorInfo`.
+- `required` is an object: test `required.always === true`, a truthiness check reads `{"always": false}` as required too.
+- Inputs are typed: `string`, `file`, `file_array`, `string_array`, more. `file` takes an asset id (upload first). Match the type: the API drops scalar-for-array mismatches silently and still charges; `workflow_run` wraps simple scalars into arrays, but only simple ones.
+- `workflow_get` wraps `inputs_definition`/`editor_info` in `workflow`; `workflows_list` wraps `inputs`/`editorInfo` in `workflows`.
 
 ## Worked example: run a saved app
 
 1. `workflows_list` with `status="ready"`, `limit=3`, plus `team_id` and `project_id`. Read `id`, `name` and `inputs` off each record; ignore `flow` and `editorInfo`.
-2. An `inputs[]` entry `{"name": "text1", "label": "Text 1", "required": {"always": false}}` runs with `{"text1": "..."}`.
-3. `workflow_run` with `workflow_id`, `dry_run=true`, and the full `inputs` object. The reply is `creativeUnitsCost`, `creativeUnitsDiscount` and an empty `job`; quote the cost first. It also runs the real validator, doubling as a pre-flight check.
+2. An `inputs[]` entry `{"name": "text1", "required": {"always": false}}` runs with `{"text1": "..."}`.
+3. `workflow_run` with `workflow_id`, `dry_run=true`, and the full `inputs` object. The reply is `creativeUnitsCost`, `creativeUnitsDiscount` and an empty `job`; quote the cost first. It also runs the real validator.
 4. Repeat without `dry_run`, then `jobs_wait` on the returned job, re-calling with `pending_job_ids` while it runs.
-5. `asset_display` each output asset, one call per id.
+5. `asset_display` each output asset, one per id.
 
 ## Common mistakes
 
 - Guessing input keys from labels or the node graph instead of reading `inputs[]`.
-- Treating `required` as a boolean, so every input reads as mandatory.
-- Skipping the dry run because `ready` looks like proof: two of three ready workflows failed its validation with correctly named inputs. Report that error rather than blaming the payload.
-- Running a draft: it carries `flow: []` and `hasFlow: false` while `inputs` looks complete. `workflow_create` and `workflow_update` only persist a draft; `workflow_publish` compiles it.
-- Calling `workflow_approve` or `workflow_reject` with fewer than all three of `workflow_id`, `workflow_job_id` and `node_id`: the gate is per node, and a run parked on one never finishes on its own.
-- Sending `workflow_id` to `workflow_copy`: its parameter is `source_workflow_id`.
+- Skipping the dry run: two of three ready workflows failed its validation with correctly named inputs; report that error, not the payload.
+- Running a draft: `flow: []` and `hasFlow: false` while `inputs` looks complete. Publishing: see `scenario-workflow-authoring`.
+- Calling `workflow_approve` or `workflow_reject` without all three of `workflow_id`, `workflow_job_id` and `node_id`: the gate is per node; a parked run never finishes on its own. Find the run with `jobs_list`, read it with `job_get` `verbose=true` (compact replies omit `metadata`): `metadata.flow` lists per-node statuses, the pending approval node's id is `node_id`, the job's id is `workflow_job_id`, its `workflowId` the `workflow_id`. Reject cancels the run.

--- a/skills/scenario-workflows/SKILL.md
+++ b/skills/scenario-workflows/SKILL.md
@@ -22,7 +22,7 @@ Only `workflows_list`, `workflow_get` and `workflow_run` are listed by default; 
 | 4. Run                | `workflow_run` with `inputs`       | Returns a job                  |
 | 5. Wait               | `jobs_wait`                        | Re-call with `pending_job_ids` |
 
-Ids are prefixed `wflow_`, not `workflow_` as tool-doc examples show; copy them from `workflows_list`. `search` with `target="workflows"` returned 403 at authoring time.
+Ids are prefixed `wflow_`, not `workflow_` as tool-doc examples show; copy them from `workflows_list`. `search` with `target="workflows"` returned 403 at authoring time, with or without `public=true`.
 
 ## Cap every list call
 

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -8,15 +8,15 @@ license: MIT
 
 ## Overview
 
-Scenario (scenario.com) generates AI images, video, 3D, and audio across 500+ models plus custom model training; its MCP server exposes the full pipeline. The Quick reference below is the core loop.
+Scenario (scenario.com) generates AI images, video, 3D, and audio across 500+ models plus custom model training; its MCP server exposes the full pipeline; the Quick reference below is the core loop.
 
 ## Setup
 
-Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Prefer OAuth: no credentials pass through the conversation. Client config snippets and API-key setup for headless use: [references/setup.md](references/setup.md). Never ask an agent to collect, encode, or echo a key or secret.
+Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Prefer OAuth: no credentials pass through the conversation. Client config and API-key setup for headless use: [references/setup.md](references/setup.md). Never ask an agent to collect, encode, or echo a key or secret.
 
-The default toolset is the core loop below; `?toolsets=full` exposes everything, and `scenario_tools_search` plus the `scenario_tool_execute_read` / `write` / `delete` executors reach any tool.
+The default toolset is the core loop below; `?toolsets=full` exposes everything. Any other tool: `scenario_tools_search` with the verb as `query` returns its schema and lane; the matching `scenario_tool_execute_read` / `write` / `delete` runs it with `{name, parameters}` (`team_id` and `project_id` go inside `parameters`).
 
-On OAuth connections most tools take `team_id` and `project_id`; a Forbidden error usually means missing or wrong scope. Read-only tools fill them in when exactly one team and project remain possible; tools that change data never do: the refusal names the one candidate to confirm or lists the choices (`teams_list` and `projects_list` also enumerate them). Ask the user rather than picking for them.
+On OAuth connections every data-changing tool (and most others) takes `team_id` and `project_id`; a Forbidden error usually means missing or wrong scope. Read-only tools fill them in when exactly one candidate remains; writes never do: the refusal names the candidate or lists the choices (`teams_list` / `projects_list` enumerate them). Ask the user rather than picking for them.
 
 ## Quick reference
 
@@ -37,8 +37,8 @@ Generating a stylized game prop image:
 
 1. `search` with `target="models"`, `query="flux"`, `public=true`, or `recommend` with the user's own words as `prompt`. Re-discover ids each time: availability differs per team.
 2. `model_schema_get` on the pick: exact field names, types, required flags, defaults. Names differ per model, file fields take asset ids even when named `...Url`, and `cost_impact: true` flags what moves the price.
-3. If the schema carries `runs_as` (`"lora"` or `"composition"`), never send that model's own id to `model_run`. The schema's `run_with.required_arguments` holds the real call: `model_id` there is the base model, and its `parameters` (the `loras` or `modelId` wiring) merge into inputs from the same schema, so one `model_schema_get` is enough. Sending `required_arguments` alone discards your prompt.
-4. Optional: `prompt_spark` rewrites a thin prompt into an on-model one; pass the discovered id (for a LoRA, the LoRA's own id, not the base) and your draft as `prompt`. Skip it when the prompt is already deliberate.
+3. If the schema carries `runs_as` (`"lora"` or `"composition"`), never send that model's own id to `model_run`. The schema's `run_with.required_arguments` holds the real call: `model_id` there is the base model, and its `parameters` (the `loras` or `modelId` wiring) merge into inputs from the same schema; one `model_schema_get` is enough. Sending `required_arguments` alone discards your prompt.
+4. Optional: `prompt_spark` rewrites a thin prompt into an on-model one; pass the discovered id (for a LoRA, its own id, not the base) and your draft as `prompt`. Skip when the prompt is deliberate.
 5. `model_run` with `model_id` and schema-conformant `parameters`. Returns asset_ids, or `status="in_progress"` with a `job_id`.
 6. `jobs_wait` with `job_ids=[...]` (up to 32). A timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`.
 7. `asset_display` shows the asset inline. `asset_download` returns a file URL; `format` converts image outputs (`png` default, `webp`, `jpg`), omit it for video, 3D, or audio. Save with `curl -L`, it may redirect.
@@ -48,5 +48,5 @@ Local inputs go up with `upload_asset`: multipart preferred (pass `file_size`, P
 ## Common mistakes
 
 - A bare value where the schema says `array: true`: pass the array anyway; a scalar can be silently dropped, ignoring your reference image or LoRA.
-- Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins. On `proceed`, prefer `specialty.model_id` when present (it sits outside `ranked`), else the top `ranked` entry. Never run a `requires_plan_upgrade` entry; show it with its upgrade option.
-- Debugging blind: run the `diagnose` MCP prompt (or `diagnostics_run`) for a report with trace ids, and `usage` for credit questions.
+- Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins. On `proceed`, prefer `specialty.model_id` when present, else the top `ranked` entry. Never run a `requires_plan_upgrade` entry; show it with its upgrade option.
+- Debugging blind: the `diagnose` MCP prompt (or `diagnostics_run`) returns a report with trace ids; `usage` answers credit questions.

--- a/tests/scenario-workflow-authoring/requirements.txt
+++ b/tests/scenario-workflow-authoring/requirements.txt
@@ -1,0 +1,1 @@
+scenario-sdk

--- a/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
+++ b/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
@@ -9,9 +9,9 @@ import os
 import sys
 import tempfile
 import unittest
+import unittest.mock as mock
 import urllib.parse
 from pathlib import Path
-from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "scenario-workflow-authoring" / "scripts"
 if str(SCRIPTS) not in sys.path:
@@ -36,12 +36,20 @@ class FakeResponse:
         return False
 
 
-def serve_pages(pages: list[dict], requests: list) -> mock.Mock:
-    """urlopen stand-in that records each request and replays canned pages."""
+def serve_pages(pages: list[dict], requests: list, details: dict | None = None) -> mock.Mock:
+    """urlopen stand-in: replays canned list pages, routes /workflows/{id} to details."""
+    detail_payloads = details or {}
 
     def _open(request, timeout=None):
         requests.append(request)
-        return FakeResponse(pages[min(len(requests), len(pages)) - 1])
+        path = urllib.parse.urlparse(request.full_url).path
+        if not path.endswith("/workflows"):
+            wid = urllib.parse.unquote(path.rsplit("/", 1)[-1])
+            return FakeResponse(detail_payloads[wid])
+        served = sum(
+            1 for r in requests if urllib.parse.urlparse(r.full_url).path.endswith("/workflows")
+        )
+        return FakeResponse(pages[min(served, len(pages)) - 1])
 
     return mock.Mock(side_effect=_open)
 
@@ -64,11 +72,11 @@ def graph_workflow(wid: str, tags: list[str] | None, **overrides) -> dict:
     return workflow
 
 
-def run_main(pages: list[dict], argv: list[str], env: dict | None = ENV):
+def run_main(pages: list[dict], argv: list[str], env: dict | None = ENV, details: dict | None = None):
     requests: list = []
     out, err = io.StringIO(), io.StringIO()
     environ = dict(env) if env else {}
-    with mock.patch("urllib.request.urlopen", serve_pages(pages, requests)) as opener:
+    with mock.patch("urllib.request.urlopen", serve_pages(pages, requests, details)) as opener:
         with mock.patch.dict(os.environ, environ, clear=True):
             with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
                 code = fwe.main(argv)
@@ -153,15 +161,47 @@ class TagFilterTestCase(unittest.TestCase):
         self.assertEqual(written, ["b"])
 
     def test_tagged_workflow_without_editor_graph_is_skipped(self) -> None:
-        code, written, _, err = self.run_filter(
-            [
-                graph_workflow("a", ["featured"], editorInfo={"nodes": [], "edges": []}),
-                graph_workflow("b", ["featured"], editorInfo=None),
-            ]
-        )
+        with tempfile.TemporaryDirectory() as tmp:
+            code, requests, _, err, _ = run_main(
+                [
+                    {
+                        "workflows": [
+                            graph_workflow("a", ["featured"], editorInfo={"nodes": [], "edges": []}),
+                            graph_workflow("b", ["featured"], editorInfo=None),
+                        ]
+                    }
+                ],
+                ["--output-dir", tmp],
+                details={
+                    "a": {"workflow": {"id": "a", "name": "Workflow a"}},
+                    "b": {"workflow": {"id": "b", "name": "Workflow b"}},
+                },
+            )
+            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
         self.assertEqual(code, 0)
         self.assertEqual(written, [])
         self.assertIn("no editor graph", err)
+        # The full record was consulted before each skip.
+        detail_paths = [
+            urllib.parse.urlparse(r.full_url).path
+            for r in requests
+            if not urllib.parse.urlparse(r.full_url).path.endswith("/workflows")
+        ]
+        self.assertEqual(detail_paths, ["/v1/workflows/a", "/v1/workflows/b"])
+
+    def test_listing_without_graph_falls_back_to_the_full_record(self) -> None:
+        listed = graph_workflow("a", ["featured"])
+        del listed["editorInfo"]
+        detail = {"workflow": graph_workflow("a", ["featured"])}
+        with tempfile.TemporaryDirectory() as tmp:
+            code, requests, out, _, _ = run_main(
+                [{"workflows": [listed]}], ["--output-dir", tmp], details={"a": detail}
+            )
+            payload = json.loads((Path(tmp) / "a.json").read_text())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["nodes"], [{"id": "n1", "type": "model", "data": {"modelId": "m"}}])
+        self.assertIn("Wrote 1", out)
+        self.assertEqual(len(requests), 2)
 
     def test_zero_matches_still_exits_zero_with_a_notice(self) -> None:
         code, written, out, _ = self.run_filter([graph_workflow("c", ["upscale"])])
@@ -258,6 +298,25 @@ class TrimTestCase(unittest.TestCase):
         )
         self.assertEqual(fwe.input_keys({"inputKeys": ["k1", "k2"]}), ["k1", "k2"])
         self.assertEqual(fwe.input_keys({}), [])
+
+    def test_editor_info_input_keys_win_over_fallbacks(self) -> None:
+        # Live records keep the ordered pin list at editorInfo.inputKeys.
+        workflow = {
+            "editorInfo": {"inputKeys": ["text1", "image5"]},
+            "inputKeys": ["stale"],
+            "inputs": {"other": {}},
+        }
+        self.assertEqual(fwe.input_keys(workflow), ["text1", "image5"])
+        # An empty editorInfo list still defers to the fallbacks.
+        self.assertEqual(
+            fwe.input_keys({"editorInfo": {"inputKeys": []}, "inputs": {"a": {}}}), ["a"]
+        )
+
+    def test_for_each_end_keeps_its_parent_node_id(self) -> None:
+        node = fwe.trim_node(
+            {"id": "fe1_end", "type": "forEachEnd", "data": {"parentNodeId": "fe1"}}
+        )
+        self.assertEqual(node, {"id": "fe1_end", "type": "forEachEnd", "data": {"parentNodeId": "fe1"}})
 
     def test_workflow_without_nodes_is_not_an_example(self) -> None:
         self.assertIsNone(fwe.trim_workflow({"id": "w", "editorInfo": {"edges": []}}))

--- a/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
+++ b/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
@@ -1,0 +1,285 @@
+"""fetch_workflow_examples: auth, pagination, tag filtering, trimming. No network."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import urllib.parse
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "scenario-workflow-authoring" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import fetch_workflow_examples as fwe
+
+ENV = {"SCENARIO_API_KEY": "key", "SCENARIO_API_SECRET": "secret"}
+
+
+class FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+def serve_pages(pages: list[dict], requests: list) -> mock.Mock:
+    """urlopen stand-in that records each request and replays canned pages."""
+
+    def _open(request, timeout=None):
+        requests.append(request)
+        return FakeResponse(pages[min(len(requests), len(pages)) - 1])
+
+    return mock.Mock(side_effect=_open)
+
+
+def graph_workflow(wid: str, tags: list[str] | None, **overrides) -> dict:
+    workflow = {
+        "id": wid,
+        "name": f"Workflow {wid}",
+        "description": "desc",
+        "tagSet": tags,
+        "inputs": {"prompt": {"type": "text"}},
+        "editorInfo": {
+            "nodes": [{"id": "n1", "type": "model", "data": {"modelId": "m"}}],
+            "edges": [],
+        },
+    }
+    if tags is None:
+        del workflow["tagSet"]
+    workflow.update(overrides)
+    return workflow
+
+
+def run_main(pages: list[dict], argv: list[str], env: dict | None = ENV):
+    requests: list = []
+    out, err = io.StringIO(), io.StringIO()
+    environ = dict(env) if env else {}
+    with mock.patch("urllib.request.urlopen", serve_pages(pages, requests)) as opener:
+        with mock.patch.dict(os.environ, environ, clear=True):
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                code = fwe.main(argv)
+    return code, requests, out.getvalue(), err.getvalue(), opener
+
+
+def query_of(request) -> dict:
+    return urllib.parse.parse_qs(urllib.parse.urlparse(request.full_url).query)
+
+
+class AuthTestCase(unittest.TestCase):
+    def test_header_is_basic_base64_of_key_colon_secret(self) -> None:
+        # base64("key:secret") == "a2V5OnNlY3JldA=="
+        self.assertEqual(fwe.build_auth_header("key", "secret"), "Basic a2V5OnNlY3JldA==")
+
+    def test_requests_carry_the_auth_header(self) -> None:
+        _, requests, _, _, _ = run_main([{"workflows": []}], [])
+        self.assertEqual(requests[0].get_header("Authorization"), "Basic a2V5OnNlY3JldA==")
+
+    def test_missing_env_vars_fail_before_any_request(self) -> None:
+        code, requests, _, err, opener = run_main([{"workflows": []}], [], env=None)
+        self.assertEqual(code, 1)
+        self.assertIn("SCENARIO_API_KEY", err)
+        self.assertIn("SCENARIO_API_SECRET", err)
+        self.assertEqual(requests, [])
+        opener.assert_not_called()
+
+
+class PaginationTestCase(unittest.TestCase):
+    def test_first_request_asks_for_public_workflows(self) -> None:
+        _, requests, _, _, _ = run_main([{"workflows": []}], [])
+        query = query_of(requests[0])
+        self.assertEqual(query["privacy"], ["public"])
+        self.assertEqual(query["pageSize"], [str(fwe.PAGE_SIZE)])
+        self.assertNotIn("paginationToken", query)
+
+    def test_follows_next_pagination_token_until_exhausted(self) -> None:
+        pages = [
+            {"workflows": [], "nextPaginationToken": "tok-1"},
+            {"workflows": [], "nextPaginationToken": "tok-2"},
+            {"workflows": []},
+        ]
+        code, requests, _, _, _ = run_main(pages, [])
+        self.assertEqual(code, 0)
+        self.assertEqual(len(requests), 3)
+        self.assertEqual(query_of(requests[1])["paginationToken"], ["tok-1"])
+        self.assertEqual(query_of(requests[2])["paginationToken"], ["tok-2"])
+
+    def test_max_pages_caps_the_walk(self) -> None:
+        endless = [{"workflows": [], "nextPaginationToken": "again"}] * 10
+        _, requests, _, _, _ = run_main(endless, ["--max-pages", "2"])
+        self.assertEqual(len(requests), 2)
+
+
+class TagFilterTestCase(unittest.TestCase):
+    def run_filter(self, workflows: list[dict], argv: list[str] | None = None):
+        with tempfile.TemporaryDirectory() as tmp:
+            code, _, out, err, _ = run_main(
+                [{"workflows": workflows}], ["--output-dir", tmp, *(argv or [])]
+            )
+            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
+        return code, written, out, err
+
+    def test_keeps_featured_and_sc_featured_only(self) -> None:
+        code, written, _, _ = self.run_filter(
+            [
+                graph_workflow("a", ["featured"]),
+                graph_workflow("b", ["sc:featured", "tool"]),
+                graph_workflow("c", ["upscale"]),
+                graph_workflow("d", None),
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(written, ["a", "b"])
+
+    def test_tag_flag_overrides_the_default_set(self) -> None:
+        code, written, _, _ = self.run_filter(
+            [graph_workflow("a", ["featured"]), graph_workflow("b", ["mine"])],
+            ["--tag", "mine"],
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(written, ["b"])
+
+    def test_tagged_workflow_without_editor_graph_is_skipped(self) -> None:
+        code, written, _, err = self.run_filter(
+            [
+                graph_workflow("a", ["featured"], editorInfo={"nodes": [], "edges": []}),
+                graph_workflow("b", ["featured"], editorInfo=None),
+            ]
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(written, [])
+        self.assertIn("no editor graph", err)
+
+    def test_zero_matches_still_exits_zero_with_a_notice(self) -> None:
+        code, written, out, _ = self.run_filter([graph_workflow("c", ["upscale"])])
+        self.assertEqual(code, 0)
+        self.assertEqual(written, [])
+        self.assertIn("No public workflows", out)
+        self.assertIn("Wrote 0", out)
+
+
+class TrimTestCase(unittest.TestCase):
+    def test_node_data_keeps_the_allowlist_and_drops_content(self) -> None:
+        workflow = graph_workflow(
+            "w",
+            ["featured"],
+            editorInfo={
+                "nodes": [
+                    {
+                        "id": "n1",
+                        "type": "model",
+                        "position": {"x": 1, "y": 2},
+                        "width": 300,
+                        "height": 200,
+                        "data": {
+                            "type": "image-generation",
+                            "modelId": "model-123",
+                            "title": "Generate",
+                            "isInput": True,
+                            "isOutput": False,
+                            "prompt": "a castle at dawn",
+                            "assetId": "asset-999",
+                            "imageUrl": "https://example.com/x.png",
+                        },
+                    },
+                    {"id": "n2", "type": "output", "data": {"assetId": "asset-1"}},
+                ],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "type": "smooth",
+                        "source": "n1",
+                        "sourceHandle": "image",
+                        "target": "n2",
+                        "targetHandle": "input",
+                        "data": {"color": "red"},
+                    }
+                ],
+            },
+        )
+        trimmed = fwe.trim_workflow(workflow)
+        self.assertEqual(
+            trimmed["nodes"][0],
+            {
+                "id": "n1",
+                "type": "model",
+                "data": {
+                    "type": "image-generation",
+                    "modelId": "model-123",
+                    "title": "Generate",
+                    "isInput": True,
+                    "isOutput": False,
+                },
+            },
+        )
+        self.assertNotIn("position", trimmed["nodes"][0])
+        # A node whose data is all content ends up with no data key at all.
+        self.assertEqual(trimmed["nodes"][1], {"id": "n2", "type": "output"})
+        self.assertEqual(
+            trimmed["edges"],
+            [{"source": "n1", "sourceHandle": "image", "target": "n2", "targetHandle": "input"}],
+        )
+
+    def test_false_is_kept_but_none_is_dropped(self) -> None:
+        node = fwe.trim_node({"id": "n", "type": "t", "data": {"isOutput": False, "modelId": None}})
+        self.assertEqual(node["data"], {"isOutput": False})
+
+    def test_output_file_has_only_the_contract_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            code, _, _, _, _ = run_main(
+                [{"workflows": [graph_workflow("w1", ["featured"])]}], ["--output-dir", tmp]
+            )
+            self.assertEqual(code, 0)
+            payload = json.loads((Path(tmp) / "w1.json").read_text())
+        self.assertEqual(
+            set(payload), {"id", "name", "description", "nodes", "edges", "inputKeys"}
+        )
+        self.assertEqual(payload["id"], "w1")
+        self.assertEqual(payload["inputKeys"], ["prompt"])
+
+    def test_input_keys_from_dict_list_and_absent_inputs(self) -> None:
+        self.assertEqual(fwe.input_keys({"inputs": {"a": {}, "b": {}}}), ["a", "b"])
+        self.assertEqual(
+            fwe.input_keys({"inputs": [{"key": "x"}, {"name": "y"}, "z", {"other": 1}]}),
+            ["x", "y", "z"],
+        )
+        self.assertEqual(fwe.input_keys({"inputKeys": ["k1", "k2"]}), ["k1", "k2"])
+        self.assertEqual(fwe.input_keys({}), [])
+
+    def test_workflow_without_nodes_is_not_an_example(self) -> None:
+        self.assertIsNone(fwe.trim_workflow({"id": "w", "editorInfo": {"edges": []}}))
+        self.assertIsNone(fwe.trim_workflow({"id": "w"}))
+
+
+class HttpErrorTestCase(unittest.TestCase):
+    def test_http_401_becomes_a_readable_credentials_error(self) -> None:
+        import urllib.error
+
+        def _raise(request, timeout=None):
+            raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", None, None)
+
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch("urllib.request.urlopen", side_effect=_raise):
+            with mock.patch.dict(os.environ, ENV, clear=True):
+                with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                    code = fwe.main([])
+        self.assertEqual(code, 1)
+        self.assertIn("HTTP 401", err.getvalue())
+        self.assertIn("SCENARIO_API_KEY", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
+++ b/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
@@ -289,6 +289,27 @@ class FullRecordTestCase(unittest.TestCase):
         self.assertIn("HTTP 404", err)
         self.assertIn("Wrote 1", out)
 
+    def test_connection_error_on_retrieve_also_skips_not_aborts(self) -> None:
+        # APIConnectionError is not an APIStatusError: a transient network
+        # blip on one retrieve must not abort the whole export.
+        request = httpx.Request("GET", "https://api.cloud.scenario.com/v1/workflows/a")
+        api = FakeWorkflowsAPI(
+            chain_pages(
+                [listed_workflow("a", ["featured"]), listed_workflow("b", ["featured"])]
+            ),
+            details={
+                "a": scenario_sdk.APIConnectionError(request=request),
+                "b": full_workflow("b", editor_info=GRAPH),
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            code, out, err, _ = run_main(api, ["--output-dir", tmp])
+            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
+        self.assertEqual(code, 0)
+        self.assertEqual(written, ["b"])
+        self.assertIn("skipping a", err)
+        self.assertIn("Wrote 1", out)
+
 
 class TrimTestCase(unittest.TestCase):
     def test_node_data_keeps_the_allowlist_and_drops_content(self) -> None:

--- a/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
+++ b/tests/scenario-workflow-authoring/test_fetch_workflow_examples.py
@@ -1,4 +1,9 @@
-"""fetch_workflow_examples: auth, pagination, tag filtering, trimming. No network."""
+"""fetch_workflow_examples: auth, pagination, tag filtering, trimming. No network.
+
+The suite depends on the official scenario-sdk (see requirements.txt): the
+script's fixtures are real SDK response models, and the client is faked at
+the workflows-API seam so no HTTP ever happens.
+"""
 
 from __future__ import annotations
 
@@ -10,8 +15,12 @@ import sys
 import tempfile
 import unittest
 import unittest.mock as mock
-import urllib.parse
 from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import scenario_sdk
+from scenario_sdk.types.workflow_list_response import WorkflowListResponse
 
 SCRIPTS = Path(__file__).resolve().parents[2] / "skills" / "scenario-workflow-authoring" / "scripts"
 if str(SCRIPTS) not in sys.path:
@@ -19,204 +28,273 @@ if str(SCRIPTS) not in sys.path:
 
 import fetch_workflow_examples as fwe
 
-ENV = {"SCENARIO_API_KEY": "key", "SCENARIO_API_SECRET": "secret"}
+ENV = {"SCENARIO_SDK_API_KEY": "key", "SCENARIO_SDK_API_SECRET": "secret"}
+
+GRAPH = {"nodes": [{"id": "n1", "type": "model", "data": {"modelId": "m"}}], "edges": []}
 
 
-class FakeResponse:
-    def __init__(self, payload: dict) -> None:
-        self._body = json.dumps(payload).encode("utf-8")
+def listed_workflow(wid: str, tags: list[str] | None, **overrides) -> WorkflowListResponse:
+    """A validated list-response item, built from the wire shape the API returns.
 
-    def read(self) -> bytes:
-        return self._body
-
-    def __enter__(self) -> "FakeResponse":
-        return self
-
-    def __exit__(self, *exc: object) -> bool:
-        return False
-
-
-def serve_pages(pages: list[dict], requests: list, details: dict | None = None) -> mock.Mock:
-    """urlopen stand-in: replays canned list pages, routes /workflows/{id} to details."""
-    detail_payloads = details or {}
-
-    def _open(request, timeout=None):
-        requests.append(request)
-        path = urllib.parse.urlparse(request.full_url).path
-        if not path.endswith("/workflows"):
-            wid = urllib.parse.unquote(path.rsplit("/", 1)[-1])
-            return FakeResponse(detail_payloads[wid])
-        served = sum(
-            1 for r in requests if urllib.parse.urlparse(r.full_url).path.endswith("/workflows")
-        )
-        return FakeResponse(pages[min(served, len(pages)) - 1])
-
-    return mock.Mock(side_effect=_open)
-
-
-def graph_workflow(wid: str, tags: list[str] | None, **overrides) -> dict:
-    workflow = {
+    Public listings carry no editor graph; pass editorInfo=... to model the
+    private-listing shape.
+    """
+    payload = {
         "id": wid,
-        "name": f"Workflow {wid}",
+        "authorId": "author",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
         "description": "desc",
-        "tagSet": tags,
-        "inputs": {"prompt": {"type": "text"}},
-        "editorInfo": {
-            "nodes": [{"id": "n1", "type": "model", "data": {"modelId": "m"}}],
-            "edges": [],
-        },
+        "hasFlow": True,
+        "inputs": [],
+        "name": f"Workflow {wid}",
+        "ownerId": "owner",
+        "privacy": "public",
+        "shortDescription": "short",
+        "status": "ready",
+        "tagSet": tags or [],
     }
-    if tags is None:
-        del workflow["tagSet"]
-    workflow.update(overrides)
-    return workflow
+    payload.update(overrides)
+    return WorkflowListResponse.model_validate(payload)
 
 
-def run_main(pages: list[dict], argv: list[str], env: dict | None = ENV, details: dict | None = None):
-    requests: list = []
+def full_workflow(wid: str, *, editor_info, inputs=(), name: str | None = None) -> SimpleNamespace:
+    """A retrieve-record stand-in exposing the SDK model's attribute names."""
+    return SimpleNamespace(
+        id=wid,
+        name=name or f"Workflow {wid}",
+        description="desc",
+        tag_set=[],
+        editor_info=editor_info,
+        inputs=list(inputs),
+    )
+
+
+class FakePage:
+    def __init__(self, workflows: list, next_page: "FakePage | None" = None) -> None:
+        self.workflows = workflows
+        self._next = next_page
+
+    def has_next_page(self) -> bool:
+        return self._next is not None
+
+    def get_next_page(self) -> "FakePage":
+        return self._next
+
+
+def chain_pages(*workflow_lists: list) -> FakePage:
+    page = None
+    for workflows in reversed(workflow_lists):
+        page = FakePage(list(workflows), next_page=page)
+    return page
+
+
+class FakeWorkflowsAPI:
+    """Stands in for client.workflows: canned pages, per-id details, recorded calls."""
+
+    def __init__(self, first_page: FakePage, details: dict | None = None, list_error: Exception | None = None) -> None:
+        self.first_page = first_page
+        self.details = details or {}
+        self.list_error = list_error
+        self.list_calls: list[dict] = []
+        self.retrieve_calls: list[str] = []
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        if self.list_error is not None:
+            raise self.list_error
+        return self.first_page
+
+    def retrieve(self, workflow_id: str, **kwargs):
+        self.retrieve_calls.append(workflow_id)
+        result = self.details[workflow_id]
+        if isinstance(result, Exception):
+            raise result
+        return SimpleNamespace(workflow=result)
+
+
+def run_main(api: FakeWorkflowsAPI, argv: list[str], env: dict | None = ENV):
     out, err = io.StringIO(), io.StringIO()
-    environ = dict(env) if env else {}
-    with mock.patch("urllib.request.urlopen", serve_pages(pages, requests, details)) as opener:
-        with mock.patch.dict(os.environ, environ, clear=True):
+    client = SimpleNamespace(workflows=api)
+    with mock.patch.object(fwe, "Scenario", mock.Mock(return_value=client)) as client_cls:
+        with mock.patch.dict(os.environ, dict(env) if env else {}, clear=True):
             with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
                 code = fwe.main(argv)
-    return code, requests, out.getvalue(), err.getvalue(), opener
+    return code, out.getvalue(), err.getvalue(), client_cls
 
 
-def query_of(request) -> dict:
-    return urllib.parse.parse_qs(urllib.parse.urlparse(request.full_url).query)
+def status_error(cls, code: int) -> scenario_sdk.APIStatusError:
+    request = httpx.Request("GET", "https://api.cloud.scenario.com/v1/workflows")
+    return cls("boom", response=httpx.Response(code, request=request), body=None)
 
 
 class AuthTestCase(unittest.TestCase):
-    def test_header_is_basic_base64_of_key_colon_secret(self) -> None:
-        # base64("key:secret") == "a2V5OnNlY3JldA=="
-        self.assertEqual(fwe.build_auth_header("key", "secret"), "Basic a2V5OnNlY3JldA==")
-
-    def test_requests_carry_the_auth_header(self) -> None:
-        _, requests, _, _, _ = run_main([{"workflows": []}], [])
-        self.assertEqual(requests[0].get_header("Authorization"), "Basic a2V5OnNlY3JldA==")
-
-    def test_missing_env_vars_fail_before_any_request(self) -> None:
-        code, requests, _, err, opener = run_main([{"workflows": []}], [], env=None)
+    def test_missing_env_vars_fail_before_any_client(self) -> None:
+        api = FakeWorkflowsAPI(chain_pages([]))
+        code, _, err, client_cls = run_main(api, [], env=None)
         self.assertEqual(code, 1)
-        self.assertIn("SCENARIO_API_KEY", err)
-        self.assertIn("SCENARIO_API_SECRET", err)
-        self.assertEqual(requests, [])
-        opener.assert_not_called()
+        self.assertIn("SCENARIO_SDK_API_KEY", err)
+        self.assertIn("SCENARIO_SDK_API_SECRET", err)
+        client_cls.assert_not_called()
+        self.assertEqual(api.list_calls, [])
+
+    def test_authentication_error_is_readable(self) -> None:
+        api = FakeWorkflowsAPI(
+            chain_pages([]), list_error=status_error(scenario_sdk.AuthenticationError, 401)
+        )
+        code, _, err, _ = run_main(api, [])
+        self.assertEqual(code, 1)
+        self.assertIn("HTTP 401", err)
+        self.assertIn("SCENARIO_SDK_API_KEY", err)
 
 
 class PaginationTestCase(unittest.TestCase):
-    def test_first_request_asks_for_public_workflows(self) -> None:
-        _, requests, _, _, _ = run_main([{"workflows": []}], [])
-        query = query_of(requests[0])
-        self.assertEqual(query["privacy"], ["public"])
-        self.assertEqual(query["pageSize"], [str(fwe.PAGE_SIZE)])
-        self.assertNotIn("paginationToken", query)
-
-    def test_follows_next_pagination_token_until_exhausted(self) -> None:
-        pages = [
-            {"workflows": [], "nextPaginationToken": "tok-1"},
-            {"workflows": [], "nextPaginationToken": "tok-2"},
-            {"workflows": []},
-        ]
-        code, requests, _, _, _ = run_main(pages, [])
+    def test_first_list_call_asks_for_public_workflows(self) -> None:
+        api = FakeWorkflowsAPI(chain_pages([]))
+        code, _, _, _ = run_main(api, [])
         self.assertEqual(code, 0)
-        self.assertEqual(len(requests), 3)
-        self.assertEqual(query_of(requests[1])["paginationToken"], ["tok-1"])
-        self.assertEqual(query_of(requests[2])["paginationToken"], ["tok-2"])
+        self.assertEqual(api.list_calls, [{"privacy": "public", "page_size": fwe.PAGE_SIZE}])
+
+    def test_walks_every_page(self) -> None:
+        details = {w: full_workflow(w, editor_info=GRAPH) for w in ("a", "b", "c")}
+        api = FakeWorkflowsAPI(
+            chain_pages(
+                [listed_workflow("a", ["featured"])],
+                [listed_workflow("b", ["featured"])],
+                [listed_workflow("c", ["featured"])],
+            ),
+            details=details,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            code, _, _, _ = run_main(api, ["--output-dir", tmp])
+            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
+        self.assertEqual(code, 0)
+        self.assertEqual(written, ["a", "b", "c"])
 
     def test_max_pages_caps_the_walk(self) -> None:
-        endless = [{"workflows": [], "nextPaginationToken": "again"}] * 10
-        _, requests, _, _, _ = run_main(endless, ["--max-pages", "2"])
-        self.assertEqual(len(requests), 2)
-
-
-class TagFilterTestCase(unittest.TestCase):
-    def run_filter(self, workflows: list[dict], argv: list[str] | None = None):
-        with tempfile.TemporaryDirectory() as tmp:
-            code, _, out, err, _ = run_main(
-                [{"workflows": workflows}], ["--output-dir", tmp, *(argv or [])]
-            )
-            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
-        return code, written, out, err
-
-    def test_keeps_featured_and_sc_featured_only(self) -> None:
-        code, written, _, _ = self.run_filter(
-            [
-                graph_workflow("a", ["featured"]),
-                graph_workflow("b", ["sc:featured", "tool"]),
-                graph_workflow("c", ["upscale"]),
-                graph_workflow("d", None),
-            ]
+        details = {w: full_workflow(w, editor_info=GRAPH) for w in ("a", "b", "c")}
+        api = FakeWorkflowsAPI(
+            chain_pages(
+                [listed_workflow("a", ["featured"])],
+                [listed_workflow("b", ["featured"])],
+                [listed_workflow("c", ["featured"])],
+            ),
+            details=details,
         )
+        with tempfile.TemporaryDirectory() as tmp:
+            code, _, _, _ = run_main(api, ["--output-dir", tmp, "--max-pages", "2"])
+            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
         self.assertEqual(code, 0)
         self.assertEqual(written, ["a", "b"])
 
+
+class TagFilterTestCase(unittest.TestCase):
+    def run_filter(self, workflows: list, argv: list[str] | None = None, details: dict | None = None):
+        api = FakeWorkflowsAPI(chain_pages(workflows), details=details or {})
+        with tempfile.TemporaryDirectory() as tmp:
+            code, out, err, _ = run_main(api, ["--output-dir", tmp, *(argv or [])])
+            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
+        return code, written, out, err, api
+
+    def test_keeps_featured_and_sc_featured_only(self) -> None:
+        details = {w: full_workflow(w, editor_info=GRAPH) for w in ("a", "b")}
+        code, written, _, _, api = self.run_filter(
+            [
+                listed_workflow("a", ["featured"]),
+                listed_workflow("b", ["sc:featured", "tool"]),
+                listed_workflow("c", ["upscale"]),
+                listed_workflow("d", None),
+            ],
+            details=details,
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(written, ["a", "b"])
+        self.assertEqual(api.retrieve_calls, ["a", "b"])
+
     def test_tag_flag_overrides_the_default_set(self) -> None:
-        code, written, _, _ = self.run_filter(
-            [graph_workflow("a", ["featured"]), graph_workflow("b", ["mine"])],
+        details = {"b": full_workflow("b", editor_info=GRAPH)}
+        code, written, _, _, _ = self.run_filter(
+            [listed_workflow("a", ["featured"]), listed_workflow("b", ["mine"])],
             ["--tag", "mine"],
+            details=details,
         )
         self.assertEqual(code, 0)
         self.assertEqual(written, ["b"])
 
     def test_tagged_workflow_without_editor_graph_is_skipped(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            code, requests, _, err, _ = run_main(
-                [
-                    {
-                        "workflows": [
-                            graph_workflow("a", ["featured"], editorInfo={"nodes": [], "edges": []}),
-                            graph_workflow("b", ["featured"], editorInfo=None),
-                        ]
-                    }
-                ],
-                ["--output-dir", tmp],
-                details={
-                    "a": {"workflow": {"id": "a", "name": "Workflow a"}},
-                    "b": {"workflow": {"id": "b", "name": "Workflow b"}},
-                },
-            )
-            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
+        code, written, _, err, api = self.run_filter(
+            [
+                listed_workflow("a", ["featured"]),
+                listed_workflow("b", ["featured"]),
+            ],
+            details={
+                "a": full_workflow("a", editor_info={"nodes": [], "edges": []}),
+                "b": full_workflow("b", editor_info=None),
+            },
+        )
         self.assertEqual(code, 0)
         self.assertEqual(written, [])
         self.assertIn("no editor graph", err)
         # The full record was consulted before each skip.
-        detail_paths = [
-            urllib.parse.urlparse(r.full_url).path
-            for r in requests
-            if not urllib.parse.urlparse(r.full_url).path.endswith("/workflows")
-        ]
-        self.assertEqual(detail_paths, ["/v1/workflows/a", "/v1/workflows/b"])
-
-    def test_listing_without_graph_falls_back_to_the_full_record(self) -> None:
-        listed = graph_workflow("a", ["featured"])
-        del listed["editorInfo"]
-        detail = {"workflow": graph_workflow("a", ["featured"])}
-        with tempfile.TemporaryDirectory() as tmp:
-            code, requests, out, _, _ = run_main(
-                [{"workflows": [listed]}], ["--output-dir", tmp], details={"a": detail}
-            )
-            payload = json.loads((Path(tmp) / "a.json").read_text())
-        self.assertEqual(code, 0)
-        self.assertEqual(payload["nodes"], [{"id": "n1", "type": "model", "data": {"modelId": "m"}}])
-        self.assertIn("Wrote 1", out)
-        self.assertEqual(len(requests), 2)
+        self.assertEqual(api.retrieve_calls, ["a", "b"])
 
     def test_zero_matches_still_exits_zero_with_a_notice(self) -> None:
-        code, written, out, _ = self.run_filter([graph_workflow("c", ["upscale"])])
+        code, written, out, _, _ = self.run_filter([listed_workflow("c", ["upscale"])])
         self.assertEqual(code, 0)
         self.assertEqual(written, [])
         self.assertIn("No public workflows", out)
         self.assertIn("Wrote 0", out)
 
 
+class FullRecordTestCase(unittest.TestCase):
+    def test_public_listing_hits_fetch_the_full_record(self) -> None:
+        api = FakeWorkflowsAPI(
+            chain_pages([listed_workflow("a", ["featured"])]),
+            details={"a": full_workflow("a", editor_info=GRAPH)},
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            code, out, _, _ = run_main(api, ["--output-dir", tmp])
+            payload = json.loads((Path(tmp) / "a.json").read_text())
+        self.assertEqual(code, 0)
+        self.assertEqual(api.retrieve_calls, ["a"])
+        self.assertEqual(payload["nodes"], [{"id": "n1", "type": "model", "data": {"modelId": "m"}}])
+        self.assertIn("Wrote 1", out)
+
+    def test_listing_that_already_carries_the_graph_skips_retrieve(self) -> None:
+        api = FakeWorkflowsAPI(
+            chain_pages([listed_workflow("a", ["featured"], editorInfo=GRAPH)])
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            code, _, _, _ = run_main(api, ["--output-dir", tmp])
+            payload = json.loads((Path(tmp) / "a.json").read_text())
+        self.assertEqual(code, 0)
+        self.assertEqual(api.retrieve_calls, [])
+        self.assertEqual(payload["nodes"], [{"id": "n1", "type": "model", "data": {"modelId": "m"}}])
+
+    def test_failed_retrieve_skips_that_workflow_and_continues(self) -> None:
+        api = FakeWorkflowsAPI(
+            chain_pages(
+                [listed_workflow("a", ["featured"]), listed_workflow("b", ["featured"])]
+            ),
+            details={
+                "a": status_error(scenario_sdk.NotFoundError, 404),
+                "b": full_workflow("b", editor_info=GRAPH),
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            code, out, err, _ = run_main(api, ["--output-dir", tmp])
+            written = sorted(p.stem for p in Path(tmp).glob("*.json"))
+        self.assertEqual(code, 0)
+        self.assertEqual(written, ["b"])
+        self.assertIn("HTTP 404", err)
+        self.assertIn("Wrote 1", out)
+
+
 class TrimTestCase(unittest.TestCase):
     def test_node_data_keeps_the_allowlist_and_drops_content(self) -> None:
-        workflow = graph_workflow(
+        workflow = full_workflow(
             "w",
-            ["featured"],
-            editorInfo={
+            editor_info={
                 "nodes": [
                     {
                         "id": "n1",
@@ -277,11 +355,24 @@ class TrimTestCase(unittest.TestCase):
         node = fwe.trim_node({"id": "n", "type": "t", "data": {"isOutput": False, "modelId": None}})
         self.assertEqual(node["data"], {"isOutput": False})
 
+    def test_for_each_end_keeps_its_parent_node_id(self) -> None:
+        node = fwe.trim_node(
+            {"id": "fe1_end", "type": "forEachEnd", "data": {"parentNodeId": "fe1"}}
+        )
+        self.assertEqual(node, {"id": "fe1_end", "type": "forEachEnd", "data": {"parentNodeId": "fe1"}})
+
     def test_output_file_has_only_the_contract_keys(self) -> None:
+        api = FakeWorkflowsAPI(
+            chain_pages([listed_workflow("w1", ["featured"])]),
+            details={
+                "w1": full_workflow(
+                    "w1",
+                    editor_info=dict(GRAPH, inputKeys=["prompt"]),
+                )
+            },
+        )
         with tempfile.TemporaryDirectory() as tmp:
-            code, _, _, _, _ = run_main(
-                [{"workflows": [graph_workflow("w1", ["featured"])]}], ["--output-dir", tmp]
-            )
+            code, _, _, _ = run_main(api, ["--output-dir", tmp])
             self.assertEqual(code, 0)
             payload = json.loads((Path(tmp) / "w1.json").read_text())
         self.assertEqual(
@@ -290,54 +381,20 @@ class TrimTestCase(unittest.TestCase):
         self.assertEqual(payload["id"], "w1")
         self.assertEqual(payload["inputKeys"], ["prompt"])
 
-    def test_input_keys_from_dict_list_and_absent_inputs(self) -> None:
-        self.assertEqual(fwe.input_keys({"inputs": {"a": {}, "b": {}}}), ["a", "b"])
-        self.assertEqual(
-            fwe.input_keys({"inputs": [{"key": "x"}, {"name": "y"}, "z", {"other": 1}]}),
-            ["x", "y", "z"],
+    def test_editor_info_input_keys_win_over_typed_inputs(self) -> None:
+        workflow = full_workflow(
+            "w",
+            editor_info={"inputKeys": ["text1", "image5"]},
+            inputs=[SimpleNamespace(name="other")],
         )
-        self.assertEqual(fwe.input_keys({"inputKeys": ["k1", "k2"]}), ["k1", "k2"])
-        self.assertEqual(fwe.input_keys({}), [])
-
-    def test_editor_info_input_keys_win_over_fallbacks(self) -> None:
-        # Live records keep the ordered pin list at editorInfo.inputKeys.
-        workflow = {
-            "editorInfo": {"inputKeys": ["text1", "image5"]},
-            "inputKeys": ["stale"],
-            "inputs": {"other": {}},
-        }
-        self.assertEqual(fwe.input_keys(workflow), ["text1", "image5"])
-        # An empty editorInfo list still defers to the fallbacks.
-        self.assertEqual(
-            fwe.input_keys({"editorInfo": {"inputKeys": []}, "inputs": {"a": {}}}), ["a"]
-        )
-
-    def test_for_each_end_keeps_its_parent_node_id(self) -> None:
-        node = fwe.trim_node(
-            {"id": "fe1_end", "type": "forEachEnd", "data": {"parentNodeId": "fe1"}}
-        )
-        self.assertEqual(node, {"id": "fe1_end", "type": "forEachEnd", "data": {"parentNodeId": "fe1"}})
+        self.assertEqual(fwe.input_keys(workflow, workflow.editor_info), ["text1", "image5"])
+        # An empty editorInfo list still defers to the typed inputs.
+        empty = full_workflow("w", editor_info={"inputKeys": []}, inputs=[SimpleNamespace(name="a")])
+        self.assertEqual(fwe.input_keys(empty, empty.editor_info), ["a"])
 
     def test_workflow_without_nodes_is_not_an_example(self) -> None:
-        self.assertIsNone(fwe.trim_workflow({"id": "w", "editorInfo": {"edges": []}}))
-        self.assertIsNone(fwe.trim_workflow({"id": "w"}))
-
-
-class HttpErrorTestCase(unittest.TestCase):
-    def test_http_401_becomes_a_readable_credentials_error(self) -> None:
-        import urllib.error
-
-        def _raise(request, timeout=None):
-            raise urllib.error.HTTPError(request.full_url, 401, "Unauthorized", None, None)
-
-        out, err = io.StringIO(), io.StringIO()
-        with mock.patch("urllib.request.urlopen", side_effect=_raise):
-            with mock.patch.dict(os.environ, ENV, clear=True):
-                with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
-                    code = fwe.main([])
-        self.assertEqual(code, 1)
-        self.assertIn("HTTP 401", err.getvalue())
-        self.assertIn("SCENARIO_API_KEY", err.getvalue())
+        self.assertIsNone(fwe.trim_workflow(full_workflow("w", editor_info={"edges": []})))
+        self.assertIsNone(fwe.trim_workflow(full_workflow("w", editor_info=None)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `skills/scenario-workflow-authoring/`: the create → publish lifecycle (author `editor_info` + `inputs_definition`, never hand-write `flow`), template cloning via `workflow_get`, non-atomic-create recovery, and a worked text-to-image example. MCP and AI applications can now both run saved workflows (`scenario-workflows`) and build or edit them. The node-choice doctrine is single-sourced in the reference.
- `references/editor-info.md` holds the authoring grammar: the persisted node-type vocabulary (UI palette names are invalid), the inverted edge direction (`source` is the downstream consumer), per-node `data` contracts, pins and `inputKeys`, CEL rules, ifElse/forEach/approval, import/export mapping, and a live-validated minimal payload.
- Examples seed from the connected session itself, verified live: `workflow_get` returns the full graph of any workflow whose id you have, public ones included, with no credentials beyond the session. Both workflow skills record that `search`'s `workflows` target returned 403 at authoring time (with or without `public=true`), so ids come from the user, an app URL, or `workflows_list`.
- `scripts/fetch_workflow_examples.py` is the maintainer bulk exporter, built on the official scenario-sdk (PEP 723 header, `uv run` works out of the box). Public listings never return the editor graph (the API reference: `full` is ignored there), so each tagged hit's graph comes from a per-id retrieve, and any API error on one retrieve skips that workflow instead of aborting the export. 19 unittest tests fake the client at the workflows-API seam; `requirements.txt` declares the CI dependency.
- `scenario-workflows`: inputs are typed and scalar-for-array mismatches drop silently while still charging; a stalled approval gate is found with `jobs_list` + `job_get` `verbose=true` via `metadata.flow`; copy/rename/publish niches moved to the authoring skill; the two skills cross-reference each other.
- `scenario`: documents the catalog executor call shape (`scenario_tools_search` with the verb as `query`, then `scenario_tool_execute_*` with `{name, parameters}`, ids inside `parameters`).

## Review rounds

- Both review bots caught that public listings never return the editor graph (confirmed against the API reference via the official scenario-sdk docstrings, and re-verified live): each tagged hit's graph now comes from a per-id retrieve.
- A second round re-anchored seeding on `workflow_get` after the `search` workflows-target 403 reproduced across two sessions (already tracked upstream), widened the retrieve error handling to any API error, and single-sourced the node doctrine; all threads answered and resolved.
- Also from review: `editorInfo.inputKeys` is read first (confirmed live), `parentNodeId` survives trimming so loop examples stay usable, the reference's `form` example is a scalar setting rather than a wired prompt, and the tests use a single `unittest.mock` import style.
- Python bytecode caches are ignored repo-wide so a local test run can never stage one.

## Validation

- [x] `pnpm validate` passes: house style, prettier, supporting files, groupings, README table, cspell, and `skills-ref` spec validation across all 15 skills
- [x] `pnpm test`: 19 unittest tests, all green locally and in CI (CI installs `scenario-sdk` from the suite's `requirements.txt`)
- [x] Live round-trip against the MCP server (create → publish → dry-run price → run → inspect → delete) plus the application-test protocol per AGENTS.md
- [x] Rebased onto `main`; CI green on the current head
- [x] All review comments fixed and answered in thread

## Stats

- 11 files changed: one new skill with a reference and a script, updates to `scenario-workflows` and `scenario`, a 19-test suite, and registrations (README, `skills.sh.json`, `project-words.txt`, `.gitignore`)

---
_Generated by [Claude Code](https://claude.ai/code)_