### PR TITLE
ci: rename the validate workflow to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: validate
+name: CI
 
 on:
   push:


### PR DESCRIPTION
## Summary

Renames the main checks workflow from `validate` to the classical **CI** name: `.github/workflows/validate.yml` becomes `.github/workflows/ci.yml` and its display name becomes `CI`. Jobs, steps, and triggers are unchanged.

PR title linting already exists in this repo as the `pr-name-linter` workflow (`.github/workflows/pr-name.yml`), which lints the title with the repo's own commitlint config, so no new lint step is added.

No branch ruleset references the old workflow or job names, so the rename is safe for required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 86503f64344027232ffb35d9070a49977b32fbd0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->