### PR TITLE
feat(scenario-image): add the image generation and editing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | Skill                                                                          | Use it for                                                                                                         |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
 | [scenario](skills/scenario/SKILL.md)                                           | Connecting to the Scenario MCP and the core generation loop: discover, schema, run, wait, display, download        |
+| [scenario-image](skills/scenario-image/SKILL.md)                               | Text-to-image and image editing: model choice, sizing fields, prompt limits, reference images, masked inpainting   |
 | [scenario-game-assets](skills/scenario-game-assets/SKILL.md)                   | Sprites, icons, props, tilesets, pixel art, concept art, transparent backgrounds, style-consistent batches         |
 | [scenario-textures](skills/scenario-textures/SKILL.md)                         | Seamless and tileable textures, PBR materials, tiling-safe upscaling, engine-ready sizing                          |
 | [scenario-skyboxes](skills/scenario-skyboxes/SKILL.md)                         | 360 equirectangular panoramas and skyboxes, seam-safe upscaling, engine export                                     |

--- a/project-words.txt
+++ b/project-words.txt
@@ -2,6 +2,8 @@ captioner
 equirectangular
 ffprobe
 inpaint
+inpainting
+outpainting
 kling
 krea
 loras

--- a/project-words.txt
+++ b/project-words.txt
@@ -3,7 +3,6 @@ equirectangular
 ffprobe
 inpaint
 inpainting
-outpainting
 kling
 krea
 loras
@@ -14,6 +13,7 @@ muxed
 muxes
 mvdan
 numpy
+outpainting
 remesh
 remeshing
 retexture

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -8,6 +8,11 @@
       "skills": ["scenario"]
     },
     {
+      "title": "Images",
+      "description": "Generate and edit images: model choice, sizing, references, masked edits.",
+      "skills": ["scenario-image"]
+    },
+    {
       "title": "Game art and environments",
       "description": "Sprites, icons, tilesets, textures, skyboxes, and 3D assets ready for game engines.",
       "skills": [

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -28,17 +28,17 @@ All three are per-model, so take them from the schema rather than from a previou
 
 - **Size.** Sizing has no common shape: numeric `width` and `height` with `min`, `max`, and a `step` to land on; an enum (`aspectRatio`, a `resolution` in megapixels or K tiers, a `size` mixing tiers with pixel pairs); or an aspect ratio alone, which puts an exact pixel target out of reach entirely. Pixels sent to an enum field, or an off-step value, are rejected. When the schema cannot express the size asked for, report what it can reach rather than rounding silently.
 - **Prompt length.** The prompt field's `max_length` ranges from roughly 2000 characters to 32000. A prompt that fits one model is a 400 on the next.
-- **References.** Name (`referenceImages`, `image`), cap, and cardinality all come from the schema, and the name settles none of them: a field called `referenceImages` is a single scalar file on some models. Pass an array only where the schema says `array: true`, and there pass one even for a lone asset, since a bare string is dropped silently and the run then succeeds while ignoring the reference. State each reference's role in the prompt.
+- **References.** Name (`referenceImages`, `image`), cap, and cardinality all come from the schema, and the name settles none of them: a field called `referenceImages` is a single scalar file on some models. Pass an array only where the schema says `array: true`, and there pass one even for a lone asset, since a bare string is dropped silently and the run then succeeds while ignoring the reference. With several references, say in the prompt which is which.
 
 A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields variations, not a set. Anything with a per-item difference needs one `model_run` per item.
 
 ## Worked example: replacing a label on a product shot
 
 1. `recommend` with `capability="img2img"` and the user's own words as `prompt`. On `next_step.type="ask_user"`, present the options instead of picking; skip any `requires_plan_upgrade` entry.
-2. `upload_asset` the product photo, which returns an `asset_id`.
+2. `upload_asset` the product photo, then `upload_asset_complete`, which returns the `asset_id`. Only the inline path under ~100KB skips the second call.
 3. `model_schema_get` on the pick: the reference field's name and cap, which sizing family it uses, the prompt `max_length`, and whether a `mask` field exists.
-4. For a masked edit, build the mask from the source image, then read the `mask` field's own description: it usually demands the source's format and dimensions plus an alpha channel, so export with alpha preserved.
-5. `model_run` with `parameters={"prompt": "...", "referenceImages": ["asset_abc"]}` plus the mask and sizing fields the schema named. Use `dry_run=true` first when cost matters.
+4. For a masked edit, read the `mask` field's own description before building anything. Masks are not interchangeable: one model wants an alpha channel at the source's exact dimensions, another wants a black and white image it resizes itself, and which pixels get painted differs too.
+5. `model_run` with the schema's own field names: the prompt, the reference (wrapped in an array only where the schema says `array: true`), plus the mask and sizing fields it named. Use `dry_run=true` first when cost matters.
 6. `jobs_wait`, then `asset_display` to review and `asset_download` to save.
 
 ## Common mistakes

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Images are Scenario's largest catalog, split across `txt2img` (generate from a prompt) and `img2img` (edit, restyle, inpaint, upscale). The loop is the one the `scenario` skill teaches. What breaks image runs is the per-model contract: sizing fields, prompt limits, and reference caps differ between two models that do the same job, so read `model_schema_get` every time. Holding one look across a set: see `scenario-consistency`. Sprites, icons, and tilesets: see `scenario-game-assets`.
+Scenario runs hundreds of image models, split across `txt2img` (generate from a prompt) and `img2img` (edit, restyle, inpaint, upscale). The loop is the one the `scenario` skill teaches. What breaks image runs is the per-model contract: sizing fields, prompt limits, and reference caps differ between two models that do the same job, so read `model_schema_get` every time. Holding one look across a set: see `scenario-consistency`. Sprites, icons, and tilesets: see `scenario-game-assets`.
 
 ## Quick reference
 
@@ -28,7 +28,7 @@ All three are per-model, so take them from the schema rather than from a previou
 
 - **Size.** Models use one of two families: either an enum `aspectRatio` (`1:1`, `16:9`, `9:16`, often `match_input_image`) paired with a `resolution` in megapixels, or numeric `width` and `height` in pixels carrying `min`, `max`, and a `step` the value must land on. Pixels sent to an enum field, or an off-step size, are rejected.
 - **Prompt length.** The prompt field's `max_length` ranges from roughly 2000 characters to 32000. A prompt that fits one model is a 400 on the next.
-- **References.** `referenceImages` is array-typed with a per-model cap (commonly 8 to 10). Pass an array even for one asset: a bare string is dropped silently, so the run succeeds while ignoring the reference. State each reference's role in the prompt.
+- **References.** `referenceImages` is array-typed, and its cap is the schema's `max_length` on that field, which varies widely. Pass an array even for one asset: a bare string is dropped silently, so the run succeeds while ignoring the reference. State each reference's role in the prompt.
 
 `numOutputs` repeats one prompt, so it yields variations, not a set. Anything with a per-item difference needs one `model_run` per item.
 

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -26,18 +26,18 @@ Inpainting and outpainting are `img2img`, not capabilities of their own.
 
 All three are per-model, so take them from the schema rather than from a previous run:
 
-- **Size.** Models use one of two families: either an enum `aspectRatio` (`1:1`, `16:9`, `9:16`, often `match_input_image`) paired with a `resolution` in megapixels, or numeric `width` and `height` in pixels carrying `min`, `max`, and a `step` the value must land on. Pixels sent to an enum field, or an off-step size, are rejected.
+- **Size.** Sizing has no common shape: numeric `width` and `height` with `min`, `max`, and a `step` to land on, or an enum, either `aspectRatio` plus a megapixel `resolution` or a single `size` mixing tiers and pixel pairs (`2K`, `4096*2304`). Pixels sent to an enum field, or an off-step value, are rejected. When no enum value reaches the target, report the achievable size rather than rounding silently.
 - **Prompt length.** The prompt field's `max_length` ranges from roughly 2000 characters to 32000. A prompt that fits one model is a 400 on the next.
-- **References.** `referenceImages` is array-typed, and its cap is the schema's `max_length` on that field, which varies widely. Pass an array even for one asset: a bare string is dropped silently, so the run succeeds while ignoring the reference. State each reference's role in the prompt.
+- **References.** The reference field is array-typed, and both its name (`referenceImages`, `images`) and its cap come from the schema. Pass an array even for one asset: a bare string is dropped silently, so the run succeeds while ignoring the reference. State each reference's role in the prompt.
 
-`numOutputs` repeats one prompt, so it yields variations, not a set. Anything with a per-item difference needs one `model_run` per item.
+A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields variations, not a set. Anything with a per-item difference needs one `model_run` per item.
 
 ## Worked example: replacing a label on a product shot
 
 1. `recommend` with `capability="img2img"` and the user's own words as `prompt`. On `next_step.type="ask_user"`, present the options instead of picking; skip any `requires_plan_upgrade` entry.
 2. `upload_asset` the product photo, which returns an `asset_id`.
 3. `model_schema_get` on the pick: the reference field's name and cap, which sizing family it uses, the prompt `max_length`, and whether a `mask` field exists.
-4. For a masked edit, build the mask from the source image. It must match the source's format and dimensions and carry an alpha channel, so export with alpha preserved.
+4. For a masked edit, build the mask from the source image, then read the `mask` field's own description: it usually demands the source's format and dimensions plus an alpha channel, so export with alpha preserved.
 5. `model_run` with `parameters={"prompt": "...", "referenceImages": ["asset_abc"]}` plus the mask and sizing fields the schema named. Use `dry_run=true` first when cost matters.
 6. `jobs_wait`, then `asset_display` to review and `asset_download` to save.
 
@@ -47,4 +47,4 @@ All three are per-model, so take them from the schema rather than from a previou
 - Reusing one model's parameter block on another: `aspectRatio` and `width`/`height` rarely coexist, and unknown fields are rejected.
 - Retrying a 403 `ModelAccessRestrictedError`: it names `modelId` and `requiredPlan`, so surface the upgrade or pick another model.
 - Prompting "transparent background": diffusion outputs are opaque. Use a `background` field when the schema has one, otherwise run a background-removal model afterwards.
-- Sizing a mask for convenience: a mask differing from the source in format or dimensions fails the run.
+- Sizing a mask for convenience: models taking a mask generally require the source's exact format and dimensions.

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -26,9 +26,9 @@ Inpainting and outpainting are `img2img`, not capabilities of their own.
 
 All three are per-model, so take them from the schema rather than from a previous run:
 
-- **Size.** Sizing has no common shape: numeric `width` and `height` with `min`, `max`, and a `step` to land on, or an enum, either `aspectRatio` plus a megapixel `resolution` or a single `size` mixing tiers and pixel pairs (`2K`, `4096*2304`). Pixels sent to an enum field, or an off-step value, are rejected. When no enum value reaches the target, report the achievable size rather than rounding silently.
+- **Size.** Sizing has no common shape: numeric `width` and `height` with `min`, `max`, and a `step` to land on; an enum (`aspectRatio`, a `resolution` in megapixels or K tiers, a `size` mixing tiers with pixel pairs); or an aspect ratio alone, which puts an exact pixel target out of reach entirely. Pixels sent to an enum field, or an off-step value, are rejected. When the schema cannot express the size asked for, report what it can reach rather than rounding silently.
 - **Prompt length.** The prompt field's `max_length` ranges from roughly 2000 characters to 32000. A prompt that fits one model is a 400 on the next.
-- **References.** The reference field is array-typed, and both its name (`referenceImages`, `images`) and its cap come from the schema. Pass an array even for one asset: a bare string is dropped silently, so the run succeeds while ignoring the reference. State each reference's role in the prompt.
+- **References.** Name (`referenceImages`, `image`), cap, and cardinality all come from the schema, and the name settles none of them: a field called `referenceImages` is a single scalar file on some models. Pass an array only where the schema says `array: true`, and there pass one even for a lone asset, since a bare string is dropped silently and the run then succeeds while ignoring the reference. State each reference's role in the prompt.
 
 A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields variations, not a set. Anything with a per-item difference needs one `model_run` per item.
 
@@ -43,8 +43,8 @@ A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields
 
 ## Common mistakes
 
-- Passing a single reference as a bare string: it is dropped without an error, and the output quietly ignores it.
+- Passing a bare string where the schema marks the reference field `array: true`: it is dropped without an error, and the output quietly ignores it.
 - Reusing one model's parameter block on another: `aspectRatio` and `width`/`height` rarely coexist, and unknown fields are rejected.
 - Retrying a 403 `ModelAccessRestrictedError`: it names `modelId` and `requiredPlan`, so surface the upgrade or pick another model.
 - Prompting "transparent background": diffusion outputs are opaque. Use a `background` field when the schema has one, otherwise run a background-removal model afterwards.
-- Sizing a mask for convenience: models taking a mask generally require the source's exact format and dimensions.
+- Assuming a model can hit a requested pixel size: some expose an aspect ratio and nothing else.

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: scenario-image
+description: "Use when generating or editing images with Scenario through MCP: text-to-image, image-to-image, instruction editing, inpainting or outpainting with a mask, background control, aspect ratio or resolution sizing, several outputs per run, or choosing between Scenario image models. Also when a run fails on prompt length, a plan-restricted model, or a reference image that was silently ignored. Keywords: txt2img, img2img, image edit, inpaint, mask, reference image, aspect ratio."
+license: MIT
+---
+
+# Scenario Image Generation and Editing
+
+## Overview
+
+Images are Scenario's largest catalog, split across `txt2img` (generate from a prompt) and `img2img` (edit, restyle, inpaint, upscale). The loop is the one the `scenario` skill teaches. What breaks image runs is the per-model contract: sizing fields, prompt limits, and reference caps differ between two models that do the same job, so read `model_schema_get` every time. Holding one look across a set: see `scenario-consistency`. Sprites, icons, and tilesets: see `scenario-game-assets`.
+
+## Quick reference
+
+| Need              | Call                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| Pick a model      | `recommend` with `capability="txt2img"` or `"img2img"`, or `search` (`target="models"`, `public=true`) |
+| Read the contract | `model_schema_get`, before every `model_run`                                                           |
+| Estimate cost     | `model_run` with `dry_run=true`; `cost_impact: true` marks the fields that move price                  |
+| Generate or edit  | `model_run`, then `jobs_wait`                                                                          |
+| Review and save   | `asset_display`, then `asset_download` (`png` default, `webp`, `jpg`)                                  |
+
+Inpainting and outpainting are `img2img`, not capabilities of their own.
+
+## The three fields that fail runs
+
+All three are per-model, so take them from the schema rather than from a previous run:
+
+- **Size.** Models use one of two families: either an enum `aspectRatio` (`1:1`, `16:9`, `9:16`, often `match_input_image`) paired with a `resolution` in megapixels, or numeric `width` and `height` in pixels carrying `min`, `max`, and a `step` the value must land on. Pixels sent to an enum field, or an off-step size, are rejected.
+- **Prompt length.** The prompt field's `max_length` ranges from roughly 2000 characters to 32000. A prompt that fits one model is a 400 on the next.
+- **References.** `referenceImages` is array-typed with a per-model cap (commonly 8 to 10). Pass an array even for one asset: a bare string is dropped silently, so the run succeeds while ignoring the reference. State each reference's role in the prompt.
+
+`numOutputs` repeats one prompt, so it yields variations, not a set. Anything with a per-item difference needs one `model_run` per item.
+
+## Worked example: replacing a label on a product shot
+
+1. `recommend` with `capability="img2img"` and the user's own words as `prompt`. On `next_step.type="ask_user"`, present the options instead of picking; skip any `requires_plan_upgrade` entry.
+2. `upload_asset` the product photo, which returns an `asset_id`.
+3. `model_schema_get` on the pick: the reference field's name and cap, which sizing family it uses, the prompt `max_length`, and whether a `mask` field exists.
+4. For a masked edit, build the mask from the source image. It must match the source's format and dimensions and carry an alpha channel, so export with alpha preserved.
+5. `model_run` with `parameters={"prompt": "...", "referenceImages": ["asset_abc"]}` plus the mask and sizing fields the schema named. Use `dry_run=true` first when cost matters.
+6. `jobs_wait`, then `asset_display` to review and `asset_download` to save.
+
+## Common mistakes
+
+- Passing a single reference as a bare string: it is dropped without an error, and the output quietly ignores it.
+- Reusing one model's parameter block on another: `aspectRatio` and `width`/`height` rarely coexist, and unknown fields are rejected.
+- Retrying a 403 `ModelAccessRestrictedError`: it names `modelId` and `requiredPlan`, so surface the upgrade or pick another model.
+- Prompting "transparent background": diffusion outputs are opaque. Use a `background` field when the schema has one, otherwise run a background-removal model afterwards.
+- Sizing a mask for convenience: a mask differing from the source in format or dimensions fails the run.


### PR DESCRIPTION
## Summary

- Adds `scenario-image`, the general image generation and editing skill: the one content type with no skill of its own. `scenario-game-assets`, `scenario-consistency`, and `scenario-textures` each cover a slice of image work; nothing taught the general lane. On skills.sh, `ai-image-generation` is the single most-installed skill in the space (~345k installs), and Scenario had nothing there.
- Teaches the per-model contract behind the failures agents actually hit: prompt `max_length` ranges from roughly 2000 to 32000 characters between models, and "Input prompt must be at most 2048 characters long" is a recurring `model_run` 400; a plan-gated 403 names the model and the plan it needs, and retrying never clears it.
- Makes references fully schema-driven: name, cap, and cardinality all come from `model_schema_get`, and the name settles none of them. A field called `referenceImages` is a single scalar file on some models; where the schema says `array: true`, a bare string is dropped silently and the run succeeds while ignoring the reference.
- Teaches that sizing has no common shape (numeric `width`/`height` with a `step`; enum `aspectRatio`, `resolution`, or `size` tiers; or an aspect ratio alone, which puts an exact pixel target out of reach), and that the mask contract is the `mask` field's own description, not a family rule.
- Registers the skill in a new "Images" grouping in `skills.sh.json` and adds its README row.

## Validation

- [x] Application-tested per AGENTS.md against the live tool surface, three rounds with a fresh planning agent each. Round 1 failed (the Size bullet regressed below the no-skill baseline by teaching a confident two-family dichotomy); round 2 failed (the fix deferred the field name to the schema but still asserted array typing, contradicted live by a scalar `referenceImages` on `model_qwen-image-edit`); the final run passes with notes (see the validation comment on this PR).
- [x] Baseline probe confirms the skill earns its context cost: unaided, the agent invented `search { type: "model" }` (live requires `target="models"`), nested the payload under `inputs` rather than `parameters`, and planned a local `cwebp` re-encode instead of `asset_download` with `format`.
- [x] `pnpm validate` passes: house style, prettier, supporting files, groupings, README, cspell, and skills-ref spec validation.
- [x] Description 477 characters, body 676 words, no em dashes. Every tool and parameter claim verified live via `model_schema_get`, not recalled.

## Review follow-ups

- Bugbot's sort-order finding is fixed in 18d8988: `project-words.txt` is back in `LC_ALL=C` order.
- Review surfaced a pre-existing `referenceImages` cardinality overclaim in `scenario-consistency` that this PR's cross-reference exposes; fixed separately in #33 so this PR stays scoped to the new skill.

## Stats

- 4 files changed, 58 insertions: `skills/scenario-image/SKILL.md` (new), `README.md`, `skills.sh.json`, `project-words.txt`.
- 6 commits, squash-merge title: `feat(scenario-image): add the image generation and editing skill`.

## Merge notes

- Rebased onto `main` after #32 landed; all checks green.
- A local merge simulation confirms this and #28 merge cleanly together and with #30 and #31 in any order, with `pnpm validate` passing on the combined tree. Independent of #29 and #33.
- This branch ships the current `main` version of the core `scenario` skill, whose upload sentence names only `file_size`. #29 fixes that; until it lands, an agent on this branch may invent upload parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDWmf2g2C52mFj4R3ozSEu
