### PR TITLE
feat(scenario-moderation): add the blocked-generation recovery skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | [scenario-model-training](skills/scenario-model-training/SKILL.md)             | Training custom models for style, character, or product consistency, and generating with them                      |
 | [scenario-workflows](skills/scenario-workflows/SKILL.md)                       | Running saved workflows (apps): building the run inputs, dry-run pricing, unsticking approval gates                |
 | [scenario-workflow-authoring](skills/scenario-workflow-authoring/SKILL.md)     | Creating and editing workflow graphs: the editor_info grammar, node wiring, publishing drafts into runnable apps   |
+| [scenario-moderation](skills/scenario-moderation/SKILL.md)                     | Recovering a blocked generation: provider-side filters, model switching, proportional wording, look-alike errors   |
 | [scenario-report](skills/scenario-report/SKILL.md)                             | Reporting a bug or change request as a reproducible, redacted issue on this repository's public tracker            |
 
 ## Example prompts

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -44,9 +44,9 @@
       "skills": ["scenario-workflows", "scenario-workflow-authoring"]
     },
     {
-      "title": "Feedback",
-      "description": "Turn a blocked session into a reproducible public issue, redacted and approved before it is posted.",
-      "skills": ["scenario-report"]
+      "title": "Troubleshooting",
+      "description": "Get past a blocked generation, and turn a stuck session into a reproducible public issue.",
+      "skills": ["scenario-moderation", "scenario-report"]
     }
   ]
 }

--- a/skills/scenario-moderation/SKILL.md
+++ b/skills/scenario-moderation/SKILL.md
@@ -19,7 +19,7 @@ Content filters run on the model provider's side, not on Scenario. A block is th
 | Price an alternative    | `model_run` with `dry_run=true`                                                        |
 | Re-test the same intent | One `model_run` per candidate, prompt unchanged, so the model stays the only variable  |
 
-Three failures look alike and only the first is about wording: a provider moderation block, a 403 `ModelAccessRestrictedError` (the plan does not include that model), and a model a team has put on its own blocklist. Read the error before rewriting anything.
+Three failures look alike and only the first is about wording: a provider moderation block, a 403 Forbidden error (the plan does not include that model), and a model a team has put on its own blocklist. Read the error before rewriting anything.
 
 ## Why legitimate prompts get blocked
 
@@ -38,6 +38,15 @@ With both present the prompt sits near the threshold, which is why the same inte
 4. **Constrain any upstream rewriter.** When an LLM node writes the final prompt, put steps 2 and 3 in its instructions, or the block returns on the next run.
 
 Then stop. If every model refuses and one honest rewrite has not cleared it, the filter is reading something real: say so and hand it back to the user. Grinding out variants until one slips through is evasion, not art direction.
+
+## Worked example: a flagged weapon prop
+
+The studio's own character is named Onyx, and "Onyx's oversized war hammer, huge spiked head" comes back flagged.
+
+1. Read the error: `job_get` with `verbose=true`, or the `error` and `hint` fields on the `jobs_wait` row. It names moderation, so this is a filter, not a plan restriction or a team blocklist.
+2. `search` (`target="models"`, `public=true`) for two alternatives with the same capability, price each with `model_run` and `dry_run=true`, then run the unchanged prompt on each. One passes: done, the filter belonged to the first provider.
+3. Suppose all of them refuse. Rewrite once, by proportion and without the name: "a war hammer as tall as its wielder's shoulder, spiked head two hand-spans across", and carry Onyx's look with a reference image (see `scenario-consistency`).
+4. Still refused everywhere: stop and tell the user what the filter appears to be reacting to.
 
 ## Common mistakes
 

--- a/skills/scenario-moderation/SKILL.md
+++ b/skills/scenario-moderation/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: scenario-moderation
+description: "Use when a Scenario generation is blocked, refused, or comes back with a moderation or sensitive-content error, when the same prompt succeeds on one model and fails on another, when prompts describing a team's own characters, weapons, or props get flagged, or when a run passes one time and fails the next with no real change. Keywords: blocked prompt, content moderation, sensitive content, flagged, refused generation, provider filter, false positive."
+license: MIT
+---
+
+# Scenario Blocked Generations
+
+## Overview
+
+Content filters run on the model provider's side, not on Scenario. A block is therefore a property of the model that was picked, not of the account or of the prompt in the abstract, and the same prompt usually passes on other models in the catalog. Treat a block as a routing problem first and a wording problem second. This skill is about false positives on content a team is entitled to make; it is not a way to produce content a provider prohibits. Core loop: see the `scenario` skill.
+
+## Quick reference
+
+| Step                    | Call                                                                                   |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| Read the actual error   | `job_get` with `verbose=true`, or the `error` and `hint` fields on the `jobs_wait` row |
+| Find alternative models | `search` (`target="models"`, `public=true`), or `recommend` with the same `capability` |
+| Price an alternative    | `model_run` with `dry_run=true`                                                        |
+| Re-test the same intent | One `model_run` per candidate, prompt unchanged, so the model stays the only variable  |
+
+Three failures look alike and only the first is about wording: a provider moderation block, a 403 `ModelAccessRestrictedError` (the plan does not include that model), and a model a team has put on its own blocklist. Read the error before rewriting anything.
+
+## Why legitimate prompts get blocked
+
+Two triggers stack, and either alone often sits under the threshold:
+
+- **Recognizable characters.** Automated filters react to character names and signature traits they recognize. They cannot know who owns the IP, so a team's own characters are flagged like anyone else's.
+- **Intensity-coded language.** Words chosen to convey scale or drama ("oversized", "huge", "massive") read as violence in aggregate, even when the subject is a prop.
+
+With both present the prompt sits near the threshold, which is why the same intent passes one run and fails the next: a small rewording tips it over. An upstream LLM step that rewrites prompts is a frequent cause, because it leans harder on intensifiers to solve an unrelated problem and re-introduces the block on every run.
+
+## Recovery, cheapest first
+
+1. **Switch model.** Usually needs no prompt edit at all. Run the unchanged prompt against two or three alternatives at comparable cost; if they pass, the filter was that provider's, not the content's.
+2. **Describe scale by proportion, not intensity.** "The staff reaches shoulder height" or "the blade is about as long as the forearm" carries the same art direction as "oversized" without the violence coding.
+3. **Soften recognizable names in the direct model input.** Describe the design in the prompt and carry identity with a reference image instead, which holds the look better anyway (see `scenario-consistency`).
+4. **Constrain any upstream rewriter.** When an LLM node writes the final prompt, put steps 2 and 3 in its instructions, or the block returns on the next run.
+
+## Common mistakes
+
+- Retrying the identical prompt: near-threshold prompts pass intermittently, so a retry that happens to work has fixed nothing.
+- Rewriting wording before trying another model: wording changes are slow and lose art direction, switching models is one call.
+- Assuming IP ownership exempts a prompt: the filter is automated and sees only the text and images sent to it.
+- Reporting a block as a Scenario fault: confirm other models refuse it too, then file it with `scenario-report`.
+- Escalating to a pricier model expecting a laxer filter: cost and moderation strictness are unrelated.
+- Reading an empty model list as moderation: a team blocklist or a plan restriction removes models before any prompt is judged.

--- a/skills/scenario-moderation/SKILL.md
+++ b/skills/scenario-moderation/SKILL.md
@@ -37,6 +37,8 @@ With both present the prompt sits near the threshold, which is why the same inte
 3. **Soften recognizable names in the direct model input.** Describe the design in the prompt and carry identity with a reference image instead, which holds the look better anyway (see `scenario-consistency`).
 4. **Constrain any upstream rewriter.** When an LLM node writes the final prompt, put steps 2 and 3 in its instructions, or the block returns on the next run.
 
+Then stop. If every model refuses and one honest rewrite has not cleared it, the filter is reading something real: say so and hand it back to the user. Grinding out variants until one slips through is evasion, not art direction.
+
 ## Common mistakes
 
 - Retrying the identical prompt: near-threshold prompts pass intermittently, so a retry that happens to work has fixed nothing.


### PR DESCRIPTION
Adds a skill for the one failure where an agent's instinct is actively counterproductive: a generation comes back blocked, the agent rewrites the prompt, loses the art direction, and it still fails, because the filter belongs to the model provider rather than to Scenario or to the account.

## Why this one

Blocked generations are a recurring enterprise support theme, from studios generating their **own** characters, and the diagnosis pattern support arrives at is consistent and teachable:

- Moderation runs provider-side. The same prompt usually passes on other models in the catalog.
- Two triggers stack: recognizable characters (filters react to names and signature traits, and cannot know who owns the IP) and intensity-coded language ("oversized", "huge") that reads as violence in aggregate even when the subject is a prop.
- With both present the prompt sits on the threshold, which is why identical intent passes one run and fails the next.
- An upstream LLM prompt-rewriting step is a common culprit: it leans harder on intensifiers to fix an unrelated problem and re-introduces the block on every run.

## What it teaches

A recovery ladder, cheapest first: switch model (one call, no prompt edit), then describe scale by proportion rather than intensity, then carry identity with a reference image instead of recognizable names, then constrain the upstream rewriter. It then **stops**: when every model refuses and one honest rewrite has not cleared it, the filter is reading something real, so say so and hand it back rather than iterating.

It also separates the three failures that look identical in a transcript and get conflated: a provider moderation block, a plan restriction, and a model on a team's own blocklist. Only the first is about wording.

## Scope

Explicitly scoped, in the Overview, to false positives on content a team is entitled to make. It is not framed as, and does not function as, a way to produce content a provider prohibits: the techniques are proportional description and reference images, both standard art direction, and the ladder now terminates rather than running open-ended.

## Validation

**Application-tested per AGENTS.md.** A fresh planning agent, given only this skill plus the core `scenario` skill and a realistic blocked-generation task, was graded against the live tool surface:

- **Round 1: PASS.** All 7 traps handled. Six defects were raised by the grader and all were refuted under adversarial verification.
- **Baseline probe** (no skill installed) showed the skill earns its context cost, but also that the baseline invented a stop condition the skill lacked and named it as what separates a revision from evasion. That gap is now closed, and **round 2 re-confirmed PASS** with the stop condition landing.

`pnpm validate` passes. Description 453 chars, body 636 words, no em dashes. Diagnostic claims verified against the live tool surface (`job_get`'s `verbose` flag, the `error` / `hint` fields on `jobs_wait` rows).

## Merge notes

Touches `README.md` and `skills.sh.json` (renames the "Feedback" grouping to "Troubleshooting"). A local merge simulation confirms **this and #27 merge cleanly together and with #30 and #31** in any order; an earlier note in this description claiming they would conflict was wrong. Independent of #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDWmf2g2C52mFj4R3ozSEu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8ddb67dc864f1bacecea51475706025e09d65be3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->