### PR TITLE
fix(scenario): teach the scope, concurrency, and plan-limit contract

### DIFF
--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -48,14 +48,12 @@ Local inputs go up with `upload_asset`: multipart preferred (pass `file_size`, P
 
 ## Limits that stop a batch
 
-- **Concurrency.** A team may only have so many custom jobs running at once. Past that, `model_run` returns 429 `PlanLimitReachedError` with `details.actionName: "parallel-custom-jobs"` and the ceiling in `details.actionLimit`. Launch with `wait=false`, keep that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
-- **Model access.** 403 `ModelAccessRestrictedError` names `modelId` and `requiredPlan`: surface the upgrade or pick another model, since retrying never clears it.
-- **Field caps.** Prompt `max_length` varies widely between models, and `model_schema_get` is the only place it is stated.
+- **Concurrency.** A team may only have so many custom jobs running at once. Past that, `model_run` returns a 429 whose `details` name the limit (`actionName: "parallel-custom-jobs"`) and the ceiling (`actionLimit`). Launch with `wait=false`, keep that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
+- **Model access.** A 403 on `model_run` names the model and the plan it needs: surface the upgrade or pick another model, since retrying never clears it. `recommend` flags the same models in advance with `requires_plan_upgrade` and `required_plan`.
 
 ## Common mistakes
 
 - A bare value where the schema says `array: true`: pass the array anyway; a scalar can be silently dropped, ignoring your reference image or LoRA.
 - Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins. On `proceed`, prefer `specialty.model_id` when present, else the top `ranked` entry. Never run a `requires_plan_upgrade` entry; show it with its upgrade option.
 - Calling a tool with scope left out because an earlier call worked without it: the fill-in only applies while one candidate remains, so the same omission fails once a second team or project is in play.
-- Reaching for `job_cancel` on a stuck generation: it covers other job types and refuses these. Let `jobs_wait` finish, or stop re-calling it.
 - Debugging blind: the `diagnose` MCP prompt (or `diagnostics_run`) returns a report with trace ids; `usage` answers credit questions.

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -44,11 +44,11 @@ Generating a stylized game prop image:
 6. `jobs_wait` with `job_ids=[...]` (up to 32). A timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`.
 7. `asset_display` shows the asset inline. `asset_download` returns a file URL; `format` converts image outputs (`png` default, `webp`, `jpg`), omit it for video, 3D, or audio. Save with `curl -L`, it may redirect.
 
-Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Multipart is preferred: add `file_size`, follow the returned `instructions` to PUT every part URL, then call `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both calls as it does everywhere else, and neither accepts a field it does not name.
+Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Multipart is preferred: add `file_size`, follow the returned `instructions` to PUT every part URL, then call `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both calls as it does everywhere else; beyond the fields named here they take nothing, no parts list and no etags.
 
 ## Limits that stop a batch
 
-- **Concurrency.** A team may only have so many jobs running at once. Past that, `model_run` returns a 429 whose `details` name the limit (`actionName`) and the ceiling (`actionLimit`). Launch with `wait=false`, keep that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
+- **Concurrency.** A team may only have so many jobs running at once. Past that, `model_run` returns a 429 whose `details` name the limit (`actionName`) and the ceiling (`actionLimit`). Launch with `wait=false` until a 429 names the ceiling, hold that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
 - **Model access.** A 403 on `model_run` names the model and the plan it needs: surface the upgrade or pick another model, since retrying never clears it. `recommend` flags the same models in advance with `requires_plan_upgrade` and `required_plan`.
 
 ## Common mistakes

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -44,11 +44,11 @@ Generating a stylized game prop image:
 6. `jobs_wait` with `job_ids=[...]` (up to 32). A timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`.
 7. `asset_display` shows the asset inline. `asset_download` returns a file URL; `format` converts image outputs (`png` default, `webp`, `jpg`), omit it for video, 3D, or audio. Save with `curl -L`, it may redirect.
 
-Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Multipart is preferred: add `file_size`, PUT each presigned URL, then call `upload_asset_complete` with the returned `upload_id` and nothing else. Inline `data` only under ~100KB. Both tools reject any field they do not name, so invent none.
+Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Multipart is preferred: add `file_size`, follow the returned `instructions` to PUT every part URL, then call `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both calls as it does everywhere else, and neither accepts a field it does not name.
 
 ## Limits that stop a batch
 
-- **Concurrency.** A team may only have so many custom jobs running at once. Past that, `model_run` returns a 429 whose `details` name the limit (`actionName: "parallel-custom-jobs"`) and the ceiling (`actionLimit`). Launch with `wait=false`, keep that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
+- **Concurrency.** A team may only have so many jobs running at once. Past that, `model_run` returns a 429 whose `details` name the limit (`actionName`) and the ceiling (`actionLimit`). Launch with `wait=false`, keep that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
 - **Model access.** A 403 on `model_run` names the model and the plan it needs: surface the upgrade or pick another model, since retrying never clears it. `recommend` flags the same models in advance with `requires_plan_upgrade` and `required_plan`.
 
 ## Common mistakes

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -44,7 +44,7 @@ Generating a stylized game prop image:
 6. `jobs_wait` with `job_ids=[...]` (up to 32). A timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`.
 7. `asset_display` shows the asset inline. `asset_download` returns a file URL; `format` converts image outputs (`png` default, `webp`, `jpg`), omit it for video, 3D, or audio. Save with `curl -L`, it may redirect.
 
-Local inputs go up with `upload_asset`: multipart preferred (pass `file_size`, PUT the presigned URLs, then `upload_asset_complete`); inline base64 only under ~100KB.
+Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Multipart is preferred: add `file_size`, PUT each presigned URL, then call `upload_asset_complete` with the returned `upload_id` and nothing else. Inline `data` only under ~100KB. Both tools reject any field they do not name, so invent none.
 
 ## Limits that stop a batch
 

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -16,12 +16,13 @@ Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Prefer OAuth: no cre
 
 The default toolset is the core loop below; `?toolsets=full` exposes everything. Any other tool: `scenario_tools_search` with the verb as `query` returns its schema and lane; the matching `scenario_tool_execute_read` / `write` / `delete` runs it with `{name, parameters}` (`team_id` and `project_id` go inside `parameters`).
 
-On OAuth connections every data-changing tool (and most others) takes `team_id` and `project_id`; a Forbidden error usually means missing or wrong scope. Read-only tools fill them in when exactly one candidate remains; writes never do: the refusal names the candidate or lists the choices (`teams_list` / `projects_list` enumerate them). Ask the user rather than picking for them. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices instead of picking.
+Resolve scope first, then pass `team_id` and `project_id` on every later call. `teams_list` returns the teams with their projects; `projects_list` requires a `team_id`, so it cannot come first. Confirm the pair with the user rather than picking. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices instead of picking. The server fills scope in only for read-only tools, and only while one candidate remains, so an unresolved scope fails the call instead of guessing. A Forbidden error usually means missing or wrong scope.
 
 ## Quick reference
 
 | Step              | Tool                                     | Notes                                              |
 | ----------------- | ---------------------------------------- | -------------------------------------------------- |
+| Resolve scope     | `teams_list`, then `projects_list`       | Once per session; pass the ids on every call       |
 | Find a model      | `search` or `recommend`                  | Free; never hardcode model ids                     |
 | Get the schema    | `model_schema_get`                       | Always before `model_run`; check `runs_as`         |
 | Generate          | `model_run`                              | Schema-conformant `parameters`; `dry_run` for cost |
@@ -45,8 +46,16 @@ Generating a stylized game prop image:
 
 Local inputs go up with `upload_asset`: multipart preferred (pass `file_size`, PUT the presigned URLs, then `upload_asset_complete`); inline base64 only under ~100KB.
 
+## Limits that stop a batch
+
+- **Concurrency.** A team may only have so many custom jobs running at once. Past that, `model_run` returns 429 `PlanLimitReachedError` with `details.actionName: "parallel-custom-jobs"` and the ceiling in `details.actionLimit`. Launch with `wait=false`, keep that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
+- **Model access.** 403 `ModelAccessRestrictedError` names `modelId` and `requiredPlan`: surface the upgrade or pick another model, since retrying never clears it.
+- **Field caps.** Prompt `max_length` varies widely between models, and `model_schema_get` is the only place it is stated.
+
 ## Common mistakes
 
 - A bare value where the schema says `array: true`: pass the array anyway; a scalar can be silently dropped, ignoring your reference image or LoRA.
 - Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins. On `proceed`, prefer `specialty.model_id` when present, else the top `ranked` entry. Never run a `requires_plan_upgrade` entry; show it with its upgrade option.
+- Calling a tool with scope left out because an earlier call worked without it: the fill-in only applies while one candidate remains, so the same omission fails once a second team or project is in play.
+- Reaching for `job_cancel` on a stuck generation: it covers other job types and refuses these. Let `jobs_wait` finish, or stop re-calling it.
 - Debugging blind: the `diagnose` MCP prompt (or `diagnostics_run`) returns a report with trace ids; `usage` answers credit questions.


### PR DESCRIPTION
Hardens the core `scenario` skill on the three contracts agents most often get wrong: scope resolution, batch-stopping limits, and the upload flow. Application-tested per AGENTS.md with fresh planning agents graded against the live tool reference, then rebased onto `main` after #23 with both PRs' edits preserved.

## Summary

- Scope resolution promoted to a first-class step: resolve `team_id` / `project_id` first and pass them on every later call. `teams_list` comes before `projects_list` (which requires a `team_id`), a new Quick reference row makes the rule visible at a glance, and non-interactive runs take the pair from their task instructions or stop and list the choices.
- New "Limits that stop a batch" section covers the two ceilings that never clear on retry: the per-team concurrency cap (a 429 whose `details` name the limit and the ceiling, with the `wait=false` plus `jobs_wait` throughput recipe) and plan-restricted models (a 403 naming the model and the plan it needs; `recommend` flags the same models in advance with `requires_plan_upgrade`).
- Upload contract fully specified: `upload_asset` always needs `file_name`, `content_type`, and `kind`; multipart adds `file_size`, follows the returned `instructions` to PUT every part URL, then `upload_asset_complete` with the `upload_id`. Scope rides on both calls, and beyond the named fields the tools take nothing (no parts list, no etags).
- New Common mistakes bullet for the subtle scope failure: the server fill-in only works while exactly one candidate remains, so an omission that worked earlier starts failing once a second team or project is in play.
- Removed a `job_cancel` bullet that contradicted the tool's own description, caught during application testing rather than shipped as a guess.

## Validation

- [x] Application-tested per AGENTS.md: multiple rounds of fresh planning agents graded against the tool reference at mcp.scenario.com/docs/tools, with each failure fixed in the skill text and re-run (the `job_cancel` removal and an `upload_asset_complete` scope regression both came out of these rounds)
- [x] `pnpm validate` passes: house style, prettier, supporting-file checks, groupings, README table, cspell, and skills-ref spec validation
- [x] Body is 860 words, under the 900 hard cap; no em dashes
- [x] Rebased onto `main` after #23 merged, resolving the overlap as proposed: this PR's scope paragraph (including the non-interactive-run sentence that landed on `main`), #23's tightened steps 3 and 4, and both sets of Common mistakes bullets

## Stats

- 1 file changed: `skills/scenario/SKILL.md` (+9 / -2 lines)
- 1 skill touched: `scenario`
- 5 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDWmf2g2C52mFj4R3ozSEu
