### PR TITLE
fix(scenario-3d): teach the rigging and animation lane

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -16,6 +16,8 @@ numpy
 outpainting
 remesh
 remeshing
+retarget
+retargets
 retexture
 retexturing
 shfmt

--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -45,12 +45,12 @@ Multi-view models accept several images of the same subject from different angle
 
 Rigging is a separate `3d23d` step run on a finished mesh, not a flag on the generator. Find the models with `search` `query="rigging"`.
 
-Body plan picks the model. Humanoid models take just the mesh (plus a front-facing hint on some) and infer a biped skeleton. Non-biped work goes to a model exposing `rigType`, whose values cover `quadruped`, `hexapod`, `octopod`, `avian`, `serpentine`, and `aquatic`. Nothing exposes a custom bone hierarchy or a skin-influence count, so export the rigged file and finish weighting or retargeting in a DCC such as Blender or Maya.
+Body plan picks the model. Humanoid models take the mesh and little else (a front-facing hint, or an approximate height, depending on the model) and infer a biped skeleton. Non-biped work goes to a model exposing `rigType`, whose values cover `quadruped`, `hexapod`, `octopod`, `avian`, `serpentine`, and `aquatic`. Nothing exposes a custom bone hierarchy or a skin-influence count, so export the rigged file and finish weighting or retargeting in a DCC such as Blender or Maya.
 
 Three schema details decide whether the output is usable:
 
 - **Input format.** Rigging models accept GLB, and often OBJ, FBX, or STL. OBJ cannot carry a rig, so the output goes out as GLB or FBX.
-- **Size ceiling.** File inputs carry a `max_size` (one rigging model caps at 30 MB). A mesh over the ceiling has to be decimated first.
+- **Size ceiling.** A `max_size` on the file input is the exception rather than the rule (one humanoid rigging model caps at 30 MB). Check the schema before assuming a large mesh needs decimating.
 - **Animation versus rig.** Setting the optional `animation` field retargets a preset clip, and by default only the retarget file comes back. Set `includeRiggedModel` to keep the plain rigged mesh too.
 
 When only motion is wanted, motion-transfer video models animate a still character image with no skeleton at all: see `scenario-video`.

--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-3d
-description: Use when generating or handling 3D assets through the Scenario MCP server, including text-to-3D or image-to-3D meshes, GLB, FBX, OBJ, or VOX files, PBR-textured or game-ready models, voxel models, multi-view reconstruction, retexture, remesh, UV unwrap, or rigging steps, previewing a mesh in the inline 3D viewer, capturing a viewer screenshot, or downloading a model for import into Unity, Unreal, Godot, or Blender.
+description: Use when generating or handling 3D assets through the Scenario MCP server, including text-to-3D or image-to-3D meshes, GLB, FBX, OBJ, or VOX files, PBR-textured or game-ready models, voxel models, multi-view reconstruction, retexture, remesh, UV unwrap, auto-rigging a biped or quadruped character, skin weights, or retargeting an animation, previewing a mesh in the inline 3D viewer, capturing a viewer screenshot, or downloading a model for import into Unity, Unreal, Godot, or Blender.
 license: MIT
 ---
 
@@ -39,7 +39,21 @@ Multi-view models accept several images of the same subject from different angle
 
 ## Refining meshes
 
-3D-to-3D utilities (`3d23d` capability) cover retexturing, remeshing, UV unwrapping, rigging, animation, and part segmentation. Find them with `search` `target="models"`, `query="mesh"` or `query="retexture"`. Most take an existing 3D `asset_id` as input.
+3D-to-3D utilities (`3d23d` capability) cover retexturing, remeshing, UV unwrapping, and part segmentation. Find them with `search` `target="models"`, `query="mesh"` or `query="retexture"`. Most take an existing 3D `asset_id` as input.
+
+## Rigging and animation
+
+Rigging is a separate `3d23d` step run on a finished mesh, not a flag on the generator. Find the models with `search` `query="rigging"`.
+
+Body plan picks the model. Humanoid models take just the mesh (plus a front-facing hint on some) and infer a biped skeleton. Non-biped work goes to a model exposing `rigType`, whose values cover `quadruped`, `hexapod`, `octopod`, `avian`, `serpentine`, and `aquatic`. Nothing exposes a custom bone hierarchy or a skin-influence count, so export the rigged file and finish weighting or retargeting in a DCC such as Blender or Maya.
+
+Three schema details decide whether the output is usable:
+
+- **Input format.** Rigging models accept GLB, and often OBJ, FBX, or STL. OBJ cannot carry a rig, so the output goes out as GLB or FBX.
+- **Size ceiling.** File inputs carry a `max_size` (one rigging model caps at 30 MB). A mesh over the ceiling has to be decimated first.
+- **Animation versus rig.** Setting the optional `animation` field retargets a preset clip, and by default only the retarget file comes back. Set `includeRiggedModel` to keep the plain rigged mesh too.
+
+When only motion is wanted, motion-transfer video models animate a still character image with no skeleton at all: see `scenario-video`.
 
 ## Common mistakes
 
@@ -48,3 +62,5 @@ Multi-view models accept several images of the same subject from different angle
 - Hardcoding model IDs: catalogs rotate (live search shows Meshy 6 models tagged deprecated in favor of Meshy 7). Re-discover with `search` each session.
 - Pasting raw asset URLs into chat instead of calling `asset_display`.
 - Forgetting `-L` with curl: download URLs may redirect before serving the file.
+- Promising a named skeleton or a specific influence count: pick the body plan and the export format, then finish the rest in a DCC.
+- Sending a biped to a `rigType` model: the enum has no biped value, because humanoids have their own rigging models.


### PR DESCRIPTION
Rigging was a single word in a list under "Refining meshes". That left agents unable to answer the questions studios actually ask once a mesh is finished, which is where several recent enterprise support threads landed: which model fits this body plan, what is configurable, and what is not available at all.

## What it adds

A dedicated "Rigging and animation" section. Rigging is a separate `3d23d` step run on a finished mesh, not a flag on the generator.

- **Body plan picks the model.** Humanoid models take the mesh and little else (a front-facing hint on one, an approximate height on another) and infer a biped skeleton. Non-biped work needs a model exposing `rigType`, whose values cover `quadruped`, `hexapod`, `octopod`, `avian`, `serpentine`, `aquatic`. There is deliberately **no biped value** in that enum, which is its own trap and a Common mistakes bullet.
- **Two schema details decide whether the output is usable**: the accepted input formats, with OBJ unable to carry a rig; and the optional `animation` field, which by default returns **only** the retarget file unless `includeRiggedModel` is set.
- **A file-size ceiling is the exception, not the rule.** One humanoid rigging model caps its input at 30 MB; another exposes no `max_size` at all. The text says to check the schema rather than decimating a mesh that did not need it.
- **States the limit plainly**, because agents otherwise promise it: no current rigging model exposes a custom bone hierarchy or a skin-influence count. Pick the body plan and the export format, then finish weighting or retargeting in a DCC.
- **Points at the alternative**: when motion is wanted but a rig is not, motion-transfer video models animate a still character image with no skeleton at all.

## Validation

**Application-tested per AGENTS.md.** A fresh planning agent, given only this skill plus the core `scenario` skill, was asked to rig a six-legged 45 MB FBX, add a walk cycle, export for Unreal, and apply a specific influence count and bone naming convention:

- **Round 1: all 9 traps handled, but FAIL** on one over-generalization. The size-ceiling bullet said "File inputs carry a `max_size`", which is false: the live schemas disagree with each other, so the text would send an agent to decimate a mesh unnecessarily.
- **Round 2: PASS**, all fixes closed, no new defects and no regressions.

All schema facts were read off the **live model schemas** via `model_schema_get`, not recalled: the `rigType` and `animation` enums, `includeRiggedModel` and its default, the presence and absence of `max_size`, and the differing secondary inputs on humanoid riggers. No model IDs are hardcoded; the section teaches `search` `query="rigging"` as the entry point, per the authoring contract.

`pnpm validate` passes. Description 488 chars, body 847 words (cap 900), no em dashes. `retarget` / `retargets` added to `project-words.txt`.

## Merge notes

Touches only `skills/scenario-3d/SKILL.md` and `project-words.txt`. A local merge simulation confirms it merges cleanly with #27, #28, #29 and #31 in any order, and it does not touch anything #23 touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDWmf2g2C52mFj4R3ozSEu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 220572a7d73d87be8a161ee1cc9f1cc87efc457d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->