### PR TITLE
fix(scenario-video): teach dubbing, lipsync, and the duration limits

### DIFF
--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-video
-description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (still animation, first/last frame anchors), motion prompting, lipsync and talking avatars, dubbing or translating a clip, video upscale to 4K, prompt-based editing, trim, split, concat, extend, reframe, background removal, frame or audio extraction, or a clip rejected for exceeding a duration limit. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, localization."
+description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (still animation, first/last frame anchors), motion prompting, lipsync and talking avatars, dubbing or translating a clip, video upscale to 4K, prompt-based editing, trim, split, concat, extend, reframe, resize, background removal, frame or audio extraction, waiting on long video jobs, or a clip rejected for exceeding a duration limit. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, localization."
 license: MIT
 ---
 

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-video
-description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (animating a still, first/last frame anchors), motion prompt iteration, lipsync and talking avatars, video upscale to 4K, prompt-based video editing, trim, split, concat, reframe, resize, extend, frame extraction, background removal, or waiting on long video jobs. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, ads, film previz, game cinematics, social clips."
+description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (animating a still, first/last frame anchors), motion prompt iteration, lipsync and talking avatars, dubbing or translating a clip into another language, video upscale to 4K, prompt-based video editing, trim, split, concat, reframe, resize, extend, frame extraction, or a clip rejected for exceeding a duration limit. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, localization, game cinematics."
 license: MIT
 ---
 
@@ -40,10 +40,23 @@ Iterating on motion: the source image already fixes the look, so prompt only mot
 All editing is `model_run` on a video-input model; discover each with `search`:
 
 - Prompt-driven edits (restyle, swap objects, characters, or backgrounds): query `"video edit"` (Grok Edit Video, Wan 2.7 Video Edit, Lucy Edit, Luma Modify Video).
-- Lipsync and dubbing: query `"lipsync"` for video-to-video sync (Sync Lipsync, Kling Lipsync, Veed) and talking-portrait image-to-video avatars.
+- Lipsync and dubbing: query `"lipsync"` or `"dubbing"`; see the next section, the two are not the same step.
 - Upscaling up to 4K: query `"video upscale"` (Topaz, SeedVR2, Magnific, Flash VSR).
 - Deterministic utilities: query `"tool"` or `"video"` for trim (Video Cut), split, concat with transitions, resize, reverse, reframe to new aspect ratios, background removal, and frame extraction (Video to Image Sequence).
 - Extending a clip with new footage from its last frame: query `"extend video"`.
+
+## Dubbing is not lipsync
+
+Dubbing translates the speech and keeps each speaker's own voice, tone, and timing. It does not move the mouth, so a dubbed talking head still has lips forming the original language. Two separate steps, in this order:
+
+1. **Dub.** Takes the clip as `file`, a required `targetLang` (an ISO 639-1 or BCP-47 code from the schema's allowed values), and `sourceLang`, which defaults to `auto`. `keyterms` is array-typed and carries names, brands, and jargon across untranslated; a bare string is ignored, so pass `["Scenario"]` even for one term.
+2. **Lipsync.** Takes `video` and `audio` separately, plus `syncMode` for when the two durations disagree: `cut_off` (the default), `loop`, `bounce`, `silence`, or `remap`. Leaving the default is what truncates a dub that ran longer than its source.
+
+Building a localized talking head from nothing runs audio, then video, then dub, then lipsync. Judge it on a stylized character before promising it on a photoreal one.
+
+## Duration limits
+
+Input clips have hard ceilings, and models reject rather than trim: a 30.08 second reference against a 30.0 second limit fails the whole run. The error states both numbers. Trim first with the deterministic cut or split tools (`search` `query="video cut"`), landing under the limit rather than exactly on it.
 
 ## Common mistakes
 

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-video
-description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (animating a still, first/last frame anchors), motion prompting, lipsync and talking avatars, dubbing or translating a clip into another language, video upscale to 4K, prompt-based video editing, trim, split, reframe, background removal, waiting on long video jobs, or a clip rejected for exceeding a duration limit. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, localization, game cinematics."
+description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (still animation, first/last frame anchors), motion prompting, lipsync and talking avatars, dubbing or translating a clip, video upscale to 4K, prompt-based editing, trim, split, concat, extend, reframe, background removal, frame or audio extraction, or a clip rejected for exceeding a duration limit. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, localization."
 license: MIT
 ---
 
@@ -49,8 +49,8 @@ All editing is `model_run` on a video-input model; discover each with `search`:
 
 Dubbing translates the speech and keeps each speaker's own voice, tone, and timing. It does not move the mouth, so a dubbed talking head still has lips forming the original language. Three steps, in this order:
 
-1. **Dub.** Takes the clip as `file` and a required `targetLang` from the schema's allowed values. `sourceLang` auto-detects, though the value meaning auto differs per model. When a brand or name must survive translation, pick a hit whose schema carries `keyterms`, since not all do; it is array-typed, so pass `["Scenario"]` even for one term.
-2. **Extract.** Dubbing a video returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the new speech out with an audio extraction tool.
+1. **Dub.** Takes the clip as `file` and a required `targetLang` from the schema's allowed values. Omit `sourceLang` to auto-detect, since the value that means auto differs between models. When a brand or name must survive translation, pick a hit whose schema carries `keyterms`, as not all do; where it is `array: true`, pass `["Scenario"]` even for one term.
+2. **Extract.** Dubbing a video returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the new speech out with `search` `query="audio extract"`, which surfaces the tool; a generic `query="tool"` buries it.
 3. **Lipsync.** Takes `video` and `audio` separately, plus `syncMode` where the schema exposes it (`cut_off`, `loop`, `bounce`, `silence`, `remap`). Defaults differ, so set it explicitly: a dub longer than its source is truncated under `cut_off` and repeated under `loop`.
 
 Building a localized talking head from nothing runs audio, video, dub, extract, lipsync. Judge it on a stylized character before promising it on a photoreal one.

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-video
-description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (animating a still, first/last frame anchors), motion prompt iteration, lipsync and talking avatars, dubbing or translating a clip into another language, video upscale to 4K, prompt-based video editing, trim, split, concat, reframe, resize, extend, frame extraction, or a clip rejected for exceeding a duration limit. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, localization, game cinematics."
+description: "Use when generating or editing video on Scenario via MCP: text-to-video, image-to-video (animating a still, first/last frame anchors), motion prompting, lipsync and talking avatars, dubbing or translating a clip into another language, video upscale to 4K, prompt-based video editing, trim, split, reframe, background removal, waiting on long video jobs, or a clip rejected for exceeding a duration limit. Keywords: txt2video, img2video, video2video, I2V, T2V, V2V, localization, game cinematics."
 license: MIT
 ---
 
@@ -42,17 +42,18 @@ All editing is `model_run` on a video-input model; discover each with `search`:
 - Prompt-driven edits (restyle, swap objects, characters, or backgrounds): query `"video edit"` (Grok Edit Video, Wan 2.7 Video Edit, Lucy Edit, Luma Modify Video).
 - Lipsync and dubbing: query `"lipsync"` or `"dubbing"`; see the next section, the two are not the same step.
 - Upscaling up to 4K: query `"video upscale"` (Topaz, SeedVR2, Magnific, Flash VSR).
-- Deterministic utilities: query `"tool"` or `"video"` for trim (Video Cut), split, concat with transitions, resize, reverse, reframe to new aspect ratios, background removal, and frame extraction (Video to Image Sequence).
+- Deterministic utilities: query `"tool"` for trim, split, concat with transitions, resize, reverse, reframe, background removal, and audio or frame extraction. Assembling clips into a finished cut: see `scenario-video-assembly`.
 - Extending a clip with new footage from its last frame: query `"extend video"`.
 
 ## Dubbing is not lipsync
 
-Dubbing translates the speech and keeps each speaker's own voice, tone, and timing. It does not move the mouth, so a dubbed talking head still has lips forming the original language. Two separate steps, in this order:
+Dubbing translates the speech and keeps each speaker's own voice, tone, and timing. It does not move the mouth, so a dubbed talking head still has lips forming the original language. Three steps, in this order:
 
-1. **Dub.** Takes the clip as `file`, a required `targetLang` (an ISO 639-1 or BCP-47 code from the schema's allowed values), and `sourceLang`, which defaults to `auto`. `keyterms` is array-typed and carries names, brands, and jargon across untranslated; a bare string is ignored, so pass `["Scenario"]` even for one term.
-2. **Lipsync.** Takes `video` and `audio` separately, plus `syncMode` for when the two durations disagree: `cut_off` (the default), `loop`, `bounce`, `silence`, or `remap`. Leaving the default is what truncates a dub that ran longer than its source.
+1. **Dub.** Takes the clip as `file` and a required `targetLang` from the schema's allowed values. `sourceLang` auto-detects, though the value meaning auto differs per model. When a brand or name must survive translation, pick a hit whose schema carries `keyterms`, since not all do; it is array-typed, so pass `["Scenario"]` even for one term.
+2. **Extract.** Dubbing a video returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the new speech out with an audio extraction tool.
+3. **Lipsync.** Takes `video` and `audio` separately, plus `syncMode` where the schema exposes it (`cut_off`, `loop`, `bounce`, `silence`, `remap`). Defaults differ, so set it explicitly: a dub longer than its source is truncated under `cut_off` and repeated under `loop`.
 
-Building a localized talking head from nothing runs audio, then video, then dub, then lipsync. Judge it on a stylized character before promising it on a photoreal one.
+Building a localized talking head from nothing runs audio, video, dub, extract, lipsync. Judge it on a stylized character before promising it on a photoreal one.
 
 ## Duration limits
 

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -33,7 +33,7 @@ Connection and the core generation loop: see the `scenario` skill in this repo.
 5. `jobs_wait` with `job_ids=["job_xyz"]`. On `status="in_progress"`, call again, passing the returned `pending_job_ids` as `job_ids`.
 6. `asset_display` the output video; `asset_download` (no `format`) returns the file URL, save it with `curl -L`.
 
-Iterating on motion: the source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several image-to-video models also accept first and last frame anchors or keyframe sequences (Kling, Veo 3.1, Seedance, Luma Ray 3.2); take exact parameter names from `model_schema_get`, never from memory.
+Iterating on motion: the source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several also accept first and last frame anchors or keyframe sequences; take exact parameter names from `model_schema_get`, never from memory.
 
 ## Editing existing footage
 
@@ -42,7 +42,7 @@ All editing is `model_run` on a video-input model; discover each with `search`:
 - Prompt-driven edits (restyle, swap objects, characters, or backgrounds): query `"video edit"` (Grok Edit Video, Wan 2.7 Video Edit, Lucy Edit, Luma Modify Video).
 - Lipsync and dubbing: query `"lipsync"` or `"dubbing"`; see the next section, the two are not the same step.
 - Upscaling up to 4K: query `"video upscale"` (Topaz, SeedVR2, Magnific, Flash VSR).
-- Deterministic utilities: query `"tool"` for trim, split, concat with transitions, resize, reverse, reframe, background removal, and audio or frame extraction. Assembling clips into a finished cut: see `scenario-video-assembly`.
+- Deterministic utilities: query `"tool"` for trim, split, concat with transitions, resize, reverse, reframe, and background removal. Extraction tools sit outside that page, so query them by name (`"audio extract"`, `"image sequence"`). Assembling clips into a finished cut: see `scenario-video-assembly`.
 - Extending a clip with new footage from its last frame: query `"extend video"`.
 
 ## Dubbing is not lipsync
@@ -51,19 +51,19 @@ Dubbing translates the speech and keeps each speaker's own voice, tone, and timi
 
 1. **Dub.** Takes the clip as `file` and a required `targetLang` from the schema's allowed values. Omit `sourceLang` to auto-detect, since the value that means auto differs between models. When a brand or name must survive translation, pick a hit whose schema carries `keyterms`, as not all do; where it is `array: true`, pass `["Scenario"]` even for one term.
 2. **Extract.** Dubbing a video returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the new speech out with `search` `query="audio extract"`, which surfaces the tool; a generic `query="tool"` buries it.
-3. **Lipsync.** Takes `video` and `audio` separately, plus `syncMode` where the schema exposes it (`cut_off`, `loop`, `bounce`, `silence`, `remap`). Defaults differ, so set it explicitly: a dub longer than its source is truncated under `cut_off` and repeated under `loop`.
+3. **Lipsync.** Takes `video` and `audio` separately, plus `syncMode` where the schema exposes it (`cut_off`, `loop`, `bounce`, `silence`, `remap`), which decides what happens when the two durations disagree. The names do not say which one loses, so read the field description and set it rather than inheriting a default.
 
 Building a localized talking head from nothing runs audio, video, dub, extract, lipsync. Judge it on a stylized character before promising it on a photoreal one.
 
 ## Duration limits
 
-Input clips have hard ceilings, and models reject rather than trim: a 30.08 second reference against a 30.0 second limit fails the whole run. The error states both numbers. Trim first with the deterministic cut or split tools (`search` `query="video cut"`), landing under the limit rather than exactly on it.
+Where a model bounds input length it rejects rather than trims, and by a hair: a 30.08 second reference against a 30.0 second limit fails the whole run, with the error naming both numbers. A ceiling is not a standard field, so look for it in the file field's own description, and expect plenty of models to state none. When one applies, trim first with the deterministic cut or split tools (`search` `query="video cut"`), landing under the limit rather than exactly on it.
 
 ## Common mistakes
 
 - Passing a local file path as `image` or `video`: models take `asset_id`s; `upload_asset` first.
 - Calling `model_run` without `model_schema_get`: field names and duration limits differ per model; a payload that worked on Kling will not fit Veo.
 - Polling `job_get` in a loop: use `jobs_wait`; its ~180s timeout is not an error; re-call with `pending_job_ids`.
-- Treating search hits as stable: catalogs evolve, so re-run `search` and prefer non-deprecated hits (many deprecated models carry a `deprecated:<replacement_id>` tag pointing at the successor; some only a bare tag).
+- Treating search hits as stable: catalogs evolve, so re-run `search` and prefer non-deprecated hits (a `deprecated:<replacement_id>` tag names the successor).
 - Pasting raw CDN URLs into chat: use `asset_display` for inline preview.
 - Passing `format` to `asset_download` for a video: it converts image formats only, so omit it.


### PR DESCRIPTION
Two gaps that both produced real, recent support traffic: dubbing conflated with lipsync, and duration limits that reject rather than trim.

## Summary

- **New "Dubbing is not lipsync" section.** Dubbing translates the speech and keeps each speaker's own voice, but does not move the mouth. The working chain is three steps: dub, **extract**, lipsync, because dubbing a video returns a dubbed video while a lipsync model's `audio` field takes an audio asset. The extract step ships the search query that actually surfaces the tool (`query="audio extract"`); a generic `query="tool"` buries it.
- **Schema-conditional parameter contracts**, because the live models disagree: `targetLang` is required, `sourceLang` is omitted for auto-detect (the value meaning auto differs between models), `keyterms` exists on some dubbing models only (an array even for a single term), and `syncMode` (`cut_off`, `loop`, `bounce`, `silence`, `remap`) is set explicitly from its field description rather than inherited.
- **New "Duration limits" section.** Bounded video models reject rather than trim, by a hair: a 30.08 s reference against a 30.0 s limit fails the whole run, with the error naming both numbers. The ceiling, when one exists, lives in the file field's own description. Trim first with the cut or split tools, landing under the limit rather than exactly on it.
- **Editing bullets reworked**: lipsync and dubbing now point at the new section, extraction tools are queried by name, and assembling clips cross-references `scenario-video-assembly` instead of re-teaching concat.
- **Description refreshed** with dubbing, translation, audio-extraction, duration-limit, and localization triggers; the `resize` and `waiting on long video jobs` keywords the rewrite had dropped were restored after review (the body still teaches both).

## Validation

- [x] **Application-tested per AGENTS.md**, three rounds with fresh planning agents graded against the live tool surface. Round 1 found a blocker (the dub-to-lipsync chain did not connect without an extract step). Round 2 failed on three defects the round-1 edit introduced. Round 3 (two independent planners, so divergence counts as ambiguity) surfaced an extract contradiction and two ambiguities. Each round's findings are fixed in follow-up commits on this branch.
- [x] Parameter contracts read off the **live model schemas** via `model_schema_get`, not recalled: the full `syncMode` enum, `keyterms` presence and its array shape, and the per-model `sourceLang` auto values. No model IDs hardcoded; every entry point is a `search`.
- [x] Review feedback addressed: the one inline nit (description dropped `resize` and job-wait trigger keywords) is fixed and answered in-thread.
- [x] `pnpm validate` passes: house style, prettier, supporting files, groupings, README table, cspell, and `skills-ref` spec validation.
- [x] Budgets: description 499/500 chars, body 894 words (hard cap 900), no em dashes, US spellings.

## Stats

- 1 file changed: `skills/scenario-video/SKILL.md` (+19/−5)
- 1 skill touched: `scenario-video`
- Rebased onto current `main`, which now includes #28, #29, #30, and #33. The earlier note about the core `scenario` skill's upload sentence no longer applies: #29 has landed and this branch carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDWmf2g2C52mFj4R3ozSEu
