### PR TITLE
fix(agents): scope squash-message bodies to the net change against main

### DIFF
--- a/.claude/commands/squash-message.md
+++ b/.claude/commands/squash-message.md
@@ -1,12 +1,12 @@
 Generate a single squash commit message for the current PR.
 
 1. Run `git fetch origin main --quiet && git log --oneline $(git merge-base HEAD origin/main)..HEAD` to see all commits in this branch
-2. Analyze all the changes: what was added, fixed, refactored
+2. Analyze the net diff against main (`git diff $(git merge-base HEAD origin/main)..HEAD`): what the PR adds, fixes, or refactors relative to main. The commit list is context, not content: the message describes the diff, not the journey.
 3. Write ONE conventional commit message that summarizes the entire PR and passes `commitlint.config.js`:
    - Title: max 120 chars, conventional commit format (feat/fix/docs/chore), scope from the skill directory names or the cross-cutting scopes (skills, agents, ci, deps, docs, tooling)
    - Body: bullet points of key changes, grouped by category
    - Footer: Co-Authored-By line
-4. Preserve distinct meaningful changes instead of flattening everything into one vague line; it is fine for the body to list multiple feat and fix items
+4. Preserve distinct meaningful changes instead of flattening everything into one vague line, but only changes that exist in the net diff. A branch commit that fixes or reworks something introduced earlier in the same branch is development churn: fold it into the item it amends, never list it as a fix. Label a body item `feat` or `fix` only when the PR mixes both kinds of net change relative to main; a PR that only adds one thing gets plain bullets describing what landed.
 5. Verify the title passes: `echo "TITLE" | pnpm exec commitlint`
 6. Copy the message to clipboard with `echo "MESSAGE" | pbcopy`
 7. Tell me the message you copied


### PR DESCRIPTION
On #27, `/squash-message` produced a body listing four `fix:` items whose defects were all introduced by the same PR: the branch's own iteration history, not changes to anything on `main`. A squash commit lands as one delta, so its message should describe the diff against `main`; the journey stays discoverable on the PR (description, commit list, review threads).

Two lines change in `.claude/commands/squash-message.md`:

- Step 2 now analyzes the net diff (`git diff $(git merge-base HEAD origin/main)..HEAD`) and states that the commit list is context, not content.
- Step 4's "it is fine for the body to list multiple feat and fix items" now applies only to net changes: a branch commit amending something the same branch introduced folds into the item it amends, and `feat`/`fix` prefixes appear only when the PR genuinely mixes both kinds of net change.

`pnpm validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 914c88b8fa589bfcd5c1c1c4d6c2d689c4967022. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->