### PR TITLE
fix(scenario): name the two scope errors and tighten the download contract

### DIFF
--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -12,11 +12,15 @@ Scenario (scenario.com) generates AI images, video, 3D, and audio across 500+ mo
 
 ## Setup
 
-Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Prefer OAuth: no credentials pass through the conversation. Client config and API-key setup for headless use: [references/setup.md](references/setup.md). Never ask an agent to collect, encode, or echo a key or secret.
+Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Prefer OAuth: no credentials pass through the conversation. Client config and API-key setup for headless use: [references/setup.md](references/setup.md). Never ask an agent to collect, encode, or echo a secret.
 
-The default toolset is the core loop below; `?toolsets=full` exposes everything. Any other tool: `scenario_tools_search` with the verb as `query` returns its schema and lane; the matching `scenario_tool_execute_read` / `write` / `delete` runs it with `{name, parameters}` (`team_id` and `project_id` go inside `parameters`).
+The default toolset is the core loop below; `?toolsets=full` exposes everything. Any other tool: `scenario_tools_search` with the verb as `query` returns its schema and lane; the matching `scenario_tool_execute_read` / `write` / `delete` runs it with `{name, parameters}` (`team_id` and `project_id` go inside `parameters`). The lane is the result's own `permission`, not what the verb sounds like: `asset_download` and `asset_analyze` are both write-class.
 
-Resolve scope first, then pass `team_id` and `project_id` on every later call. `teams_list` returns the teams with their projects; `projects_list` requires a `team_id`, so it cannot come first. Confirm the pair with the user rather than picking. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices instead of picking. The server fills scope in only for read-only tools, and only while one candidate remains, so an unresolved scope fails the call instead of guessing. A Forbidden error usually means missing or wrong scope.
+## Scope, and the two errors that name it
+
+Resolve scope first, then pass `team_id` and `project_id` on every later call. `teams_list` returns the teams with their projects; `projects_list` requires a `team_id`, so it cannot come first. Confirm the pair with the user rather than picking. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices.
+
+The server fills scope in only for read-only tools, and only while one candidate remains, so an unresolved scope fails the call rather than guessing, and the error names which half is wrong. `context_missing` means nothing resolved: run `teams_list`, then `projects_list`. `context_ambiguous` means several fit: present them and let the user choose, because a guess here writes assets into someone else's project. Together these are the most common failure across every tool below, and they surface mid-session on the first call that drops the pair once a second team or project is in play. A Forbidden error usually means wrong scope rather than missing scope.
 
 ## Quick reference
 
@@ -38,22 +42,21 @@ Generating a stylized game prop image:
 
 1. `search` with `target="models"`, `query="flux"`, `public=true`, or `recommend` with the user's own words as `prompt`. Re-discover ids each time: availability differs per team.
 2. `model_schema_get` on the pick: exact field names, types, required flags, defaults. Names differ per model, file fields take asset ids even when named `...Url`, and `cost_impact: true` flags what moves the price.
-3. If the schema carries `runs_as` (`"lora"` or `"composition"`), never send that model's own id to `model_run`. The schema's `run_with.required_arguments` holds the real call: `model_id` there is the base model, and its `parameters` (the `loras` or `modelId` wiring) merge into inputs from the same schema; one `model_schema_get` is enough. Sending `required_arguments` alone discards your prompt.
-4. Optional: `prompt_spark` rewrites a thin prompt into an on-model one; pass the discovered id (for a LoRA, its own id, not the base) and your draft as `prompt`. Skip when the prompt is deliberate.
+3. If the schema carries `runs_as` (`"lora"` or `"composition"`), never send that model's own id to `model_run`. Its `run_with.required_arguments` holds the real call: `model_id` there is the base model, and its `parameters` (the `loras` or `modelId` wiring) merge into inputs from the same schema. Sending `required_arguments` alone discards your prompt.
+4. Optional: `prompt_spark` rewrites a thin prompt into an on-model one; pass the discovered id (for a LoRA, its own, not the base) and your draft as `prompt`. Skip a deliberate prompt.
 5. `model_run` with `model_id` and schema-conformant `parameters`. Returns asset_ids, or `status="in_progress"` with a `job_id`.
 6. `jobs_wait` with `job_ids=[...]` (up to 32). A timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`.
-7. `asset_display` shows the asset inline. `asset_download` returns a file URL; `format` converts image outputs (`png` default, `webp`, `jpg`), omit it for video, 3D, or audio. Save with `curl -L`, it may redirect.
+7. `asset_display` shows the asset inline. `asset_download` returns a file URL. Save it with `curl -L`, it may redirect. `format` is an image conversion (`png`, `webp`, `jpg`) and nothing else: any other value returns 400 `Invalid target format`, so omit `format` entirely for video, 3D, and audio.
 
-Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Multipart is preferred: add `file_size`, follow the returned `instructions` to PUT every part URL, then call `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both calls as it does everywhere else; beyond the fields named here they take nothing, no parts list and no etags.
+Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Prefer multipart: add `file_size`, follow the returned `instructions` to PUT every part URL, then `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both; beyond the fields named here they take nothing: no parts list, no etags.
 
 ## Limits that stop a batch
 
-- **Concurrency.** A team may only have so many jobs running at once. Past that, `model_run` returns a 429 whose `details` name the limit (`actionName`) and the ceiling (`actionLimit`). Launch with `wait=false` until a 429 names the ceiling, hold that many in flight, and let `jobs_wait` retire them before launching more. An immediate retry just repeats the error.
-- **Model access.** A 403 on `model_run` names the model and the plan it needs: surface the upgrade or pick another model, since retrying never clears it. `recommend` flags the same models in advance with `requires_plan_upgrade` and `required_plan`.
+- **Concurrency.** A team may only run so many jobs at once. Past that, `model_run` returns a 429 whose `details` name the limit (`actionName`) and the ceiling (`actionLimit`). Launch with `wait=false` until a 429 names the ceiling, hold that many in flight, and let `jobs_wait` retire them before launching more. Retrying immediately just repeats the error.
+- **Model access.** A 403 on `model_run` names the model and the plan it needs: surface the upgrade or pick another model, retrying never clears it. `recommend` flags these ahead of time as `requires_plan_upgrade`; never run one.
 
 ## Common mistakes
 
-- A bare value where the schema says `array: true`: pass the array anyway; a scalar can be silently dropped, ignoring your reference image or LoRA.
-- Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins. On `proceed`, prefer `specialty.model_id` when present, else the top `ranked` entry. Never run a `requires_plan_upgrade` entry; show it with its upgrade option.
-- Calling a tool with scope left out because an earlier call worked without it: the fill-in only applies while one candidate remains, so the same omission fails once a second team or project is in play.
-- Debugging blind: the `diagnose` MCP prompt (or `diagnostics_run`) returns a report with trace ids; `usage` answers credit questions.
+- A bare value where the schema says `array: true`: a scalar can be silently dropped, ignoring your reference image or LoRA.
+- Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins. On `proceed`, prefer `specialty.model_id` when present, else the top `ranked` entry.
+- Debugging blind: the `diagnose` MCP prompt (or `diagnostics_run`) returns trace ids; `usage` answers credit questions.

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -18,9 +18,9 @@ The default toolset is the core loop below; `?toolsets=full` exposes everything.
 
 ## Scope, and the two errors that name it
 
-Resolve scope first, then pass `team_id` and `project_id` on every later call. `teams_list` returns the teams with their projects; `projects_list` requires a `team_id`, so it cannot come first. Confirm the pair with the user rather than picking. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices.
+Resolve scope first, then pass `team_id` and `project_id` on every later call. `teams_list` returns the teams with their projects; `projects_list` requires a `team_id`, so it cannot come first. Confirm the pair with the user rather than picking.
 
-The server fills scope in only for read-only tools, and only while one candidate remains, so an unresolved scope fails the call rather than guessing, and the error names which half is wrong. `context_missing` means nothing resolved: run `teams_list`, then `projects_list`. `context_ambiguous` means several fit: present them and let the user choose, because a guess here writes assets into someone else's project. Together these are the most common failure across every tool below, and they surface mid-session on the first call that drops the pair once a second team or project is in play. A Forbidden error usually means wrong scope rather than missing scope.
+The server fills scope in only for read-only tools, and only while one candidate remains, so an unresolved scope fails the call rather than guessing, and the error names which half is wrong. `context_missing` means nothing resolved: run `teams_list`, then `projects_list`. `context_ambiguous` means several fit: present them and let the user choose, because a guess here writes assets into someone else's project. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices. Together these are the most common failure across every tool below, and they surface mid-session on the first call that drops the pair once a second team or project is in play. A Forbidden error usually means wrong scope rather than missing scope.
 
 ## Quick reference
 


### PR DESCRIPTION
## Why

Two changes to the core skill, both aimed at the failures agents actually hit on the live MCP surface.

**Scope errors were taught as one condition.** The server returns two distinct codes and they call for opposite responses. `context_missing` means nothing resolved, and the agent can fix it alone by running `teams_list` then `projects_list`. `context_ambiguous` means several candidates fit, and resolving that without the user risks writing assets into the wrong project. The old text described the mechanism ("an unresolved scope fails the call") but never named the codes or split the response, so an agent seeing `context_ambiguous` had no instruction telling it to stop and ask. Scope failures are the largest single class of tool errors on the surface, ahead of every schema and plan-limit error, which is why they now get their own heading instead of a clause in Setup.

**`asset_download`'s `format` read as universal.** The old line called `png` the "default", which invites passing a format on every download. `format` maps to the API's `targetFormat` and only converts between image formats; anything else comes back as `400 Invalid target format`. That rejection is the most frequent individual error on the whole surface, so the skill now states the rejection rather than the default, and says to omit `format` entirely for video, 3D, and audio.

## What changed

`skills/scenario/SKILL.md` only.

- New "Scope, and the two errors that name it" section: the resolution order is unchanged, and `context_missing` / `context_ambiguous` now carry separate instructions, with the ask-the-user rule attached to the ambiguous case.
- Step 7 of the worked example states the `format` rejection.
- Setup notes that the executor lane comes from a tool's own `permission` field, not from what the verb sounds like: `asset_download` and `asset_analyze` both read like reads and are write-class, so they need `scenario_tool_execute_write`.
- Removed the "calling a tool with scope left out" bullet, now covered by the new section, and trimmed prose elsewhere to keep the body inside the 900-word cap (893).

Every claim is checked against the live tool schemas via `scenario_tools_search`.

## Validation

`pnpm validate` passes: house style, prettier, supporting files, groupings, README coverage, cspell, and `skills-ref validate` on all 17 skills.

Touches no file that the other open skill PRs touch, so it merges independently.