### PR TITLE
feat(scenario-asset-analysis): add the asset analysis and filing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | [scenario-video-assembly](skills/scenario-video-assembly/SKILL.md)             | Assembling clips into a finished video: timeline composition, concat with transitions, overlays, music, captions   |
 | [scenario-consistency](skills/scenario-consistency/SKILL.md)                   | Holding one character, product, or style across a set: baseline-plus-delta prompts, reference images, control maps |
 | [scenario-model-training](skills/scenario-model-training/SKILL.md)             | Training custom models for style, character, or product consistency, and generating with them                      |
+| [scenario-asset-analysis](skills/scenario-asset-analysis/SKILL.md)             | Reading assets back: captions, style descriptions, batch review against a brief, control maps, collections, tags   |
 | [scenario-workflows](skills/scenario-workflows/SKILL.md)                       | Running saved workflows (apps): building the run inputs, dry-run pricing, unsticking approval gates                |
 | [scenario-workflow-authoring](skills/scenario-workflow-authoring/SKILL.md)     | Creating and editing workflow graphs: the editor_info grammar, node wiring, publishing drafts into runnable apps   |
 | [scenario-moderation](skills/scenario-moderation/SKILL.md)                     | Recovering a blocked generation: provider-side filters, model switching, proportional wording, look-alike errors   |

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -39,6 +39,11 @@
       "skills": ["scenario-consistency", "scenario-model-training"]
     },
     {
+      "title": "Reviewing and organizing output",
+      "description": "Read finished assets back: caption them, extract a style or a control map, check a batch against a brief, and file the keepers.",
+      "skills": ["scenario-asset-analysis"]
+    },
+    {
       "title": "Workflows and apps",
       "description": "Discover, run, build, and publish Scenario workflows, the multi-step pipelines users call apps.",
       "skills": ["scenario-workflows", "scenario-workflow-authoring"]

--- a/skills/scenario-asset-analysis/SKILL.md
+++ b/skills/scenario-asset-analysis/SKILL.md
@@ -35,8 +35,8 @@ All four bill credits and all four take `dry_run: true` for an estimate first. R
 
 1. Collect the asset ids from the run (`jobs_wait` returns them).
 2. `asset_analyze` with `dry_run: true` on the first chunk to price the pass.
-3. `asset_analyze` with `images` set to 10 ids and an `instruction` that states the brief and fixes the output: "For each image in order, reply `<index>: pass|fail, <reason in under 12 words>`. Fail anything not centered, not on a plain field, or carrying text." Repeat per chunk. Answers land as text assets (one, or one per image): `asset_download` them to read the verdicts.
-4. `asset_describe` on the strongest pass. Its promptable synthesis goes straight into the next batch's prompt, which holds the look without a training run (see `scenario-consistency`).
+3. `asset_analyze` with `images` set to 10 ids and an `instruction` that states the brief and fixes the output: "For each image in order, reply `<index>: pass|fail, <reason in under 12 words>`, a reason on every line, passes included. Fail anything not centered, not on a plain field, or carrying text." Repeat per chunk. Answers land as text assets (one, or one per image): `asset_download` them to read the verdicts.
+4. `asset_describe` on the strongest pass. Its promptable synthesis goes straight into the next batch's prompt, which holds the look without a training run (see `scenario-consistency`); when the synthesis is only a short title, prompt with the description instead.
 5. File the result: `collection_create`, then `collection_add_assets` in chunks of at most 49 ids. `asset_add_tags` is additive, so tag the failures rather than rebuilding a tag set.
 
 ## Common mistakes

--- a/skills/scenario-asset-analysis/SKILL.md
+++ b/skills/scenario-asset-analysis/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: scenario-asset-analysis
+description: "Use when Scenario assets need reading rather than generating: captioning images for a dataset or alt text, extracting a reusable style description from an on-model reference, asking what an asset shows, checking a batch against a brief before delivery, or extracting a canny, depth, pose, or segmentation control map. Also when finished assets need filing into collections or tagging. Keywords: caption, describe, analyze, review, QA, control map, ControlNet, segmentation, tag, collection."
+license: MIT
+---
+
+# Scenario Asset Analysis
+
+## Overview
+
+Four tools read assets back instead of making new ones: three fixed-purpose, one open-ended. They answer the questions that come after a batch lands, which is where most of the work actually is: is this on brief, what look is this, what does this show, what can the next model condition on.
+
+None of them are in the default toolset. Get schemas with `scenario_tools_search`, then run each through the executor matching its `permission`: `asset_caption` and `asset_describe` are read-class, `asset_analyze` and `asset_detect` are write-class. Or reconnect with `?toolsets=full`. Connection and scope: see the `scenario` skill in this repo.
+
+## Quick reference
+
+| Need                                 | Tool                    | Shape                                                             |
+| ------------------------------------ | ----------------------- | ----------------------------------------------------------------- |
+| A caption for one image              | `asset_caption` (read)  | `details_level`: `action` or `action+style`                       |
+| A reusable look off one image        | `asset_describe` (read) | Returns a full description plus a promptable synthesis            |
+| Anything else, in your own words     | `asset_analyze` (write) | `instruction` plus up to 10 `images` and 10 `text_inputs`         |
+| A conditioning map for another model | `asset_detect` (write)  | `modality`, one of ten including canny, depth, pose, segmentation |
+
+All four bill credits and all four take `dry_run: true` for an estimate first. Read-class does not mean free.
+
+## The three facts that change the plan
+
+- **`asset_analyze` batches.** One call carries up to 10 images against one `instruction`, so reviewing 200 assets is 20 calls, not 200. `num_outputs` (1 to 5) is unrelated: it returns several distinct answers to the same instruction, not one answer per image. Ask for a fixed per-image output shape in the `instruction` so the answers stay parseable.
+- **`asset_detect` strips the background by default.** `remove_background` defaults to true, so a depth or pose map comes back with the frame's context already gone. Set it false whenever the map has to cover the whole image.
+- **Fixed beats flexible when it fits.** `asset_caption` and `asset_describe` are purpose-built and faster than instructing an LLM to do the same job. Reach for `asset_analyze` for classification, extraction, comparison, translation, or a verdict against a brief.
+
+`asset_analyze` and `asset_detect` wait up to 180s and then hand back a `job_id`; carry on with `jobs_wait` as anywhere else.
+
+## Worked example: reviewing a batch against a brief
+
+1. Collect the asset ids from the run (`jobs_wait` returns them).
+2. `asset_analyze` with `dry_run: true` on the first chunk to price the pass.
+3. `asset_analyze` with `images` set to 10 ids and an `instruction` that states the brief and fixes the output: "For each image in order, reply `<index>: pass|fail, <reason in under 12 words>`. Fail anything not centered, not on a plain field, or carrying text." Repeat per chunk.
+4. `asset_describe` on the strongest pass. Its promptable synthesis goes straight into the next batch's prompt, which holds the look without a training run (see `scenario-consistency`).
+5. File the result: `collection_create`, then `collection_add_assets` in chunks of at most 49 ids. `asset_add_tags` is additive, so tag the failures rather than rebuilding a tag set.
+
+## Common mistakes
+
+- One `asset_analyze` call per asset when 10 fit in a call.
+- Treating `num_outputs` as a batch size over `images`.
+- Leaving `remove_background` at its default on an `asset_detect` map that must match the source frame.
+- Running `asset_analyze` or `asset_detect` through `scenario_tool_execute_read`: both are write-class and the call is rejected by lane, not by argument.
+- Sending more than 49 ids to `collection_add_assets`, or re-adding an asset already in the collection: both are hard errors, not no-ops.
+- Asking `asset_analyze` to produce an image. It returns text; control maps come from `asset_detect` and final renders from `model_run`.

--- a/skills/scenario-asset-analysis/SKILL.md
+++ b/skills/scenario-asset-analysis/SKILL.md
@@ -35,7 +35,7 @@ All four bill credits and all four take `dry_run: true` for an estimate first. R
 
 1. Collect the asset ids from the run (`jobs_wait` returns them).
 2. `asset_analyze` with `dry_run: true` on the first chunk to price the pass.
-3. `asset_analyze` with `images` set to 10 ids and an `instruction` that states the brief and fixes the output: "For each image in order, reply `<index>: pass|fail, <reason in under 12 words>`. Fail anything not centered, not on a plain field, or carrying text." Repeat per chunk.
+3. `asset_analyze` with `images` set to 10 ids and an `instruction` that states the brief and fixes the output: "For each image in order, reply `<index>: pass|fail, <reason in under 12 words>`. Fail anything not centered, not on a plain field, or carrying text." Repeat per chunk. Answers land as text assets (one, or one per image): `asset_download` them to read the verdicts.
 4. `asset_describe` on the strongest pass. Its promptable synthesis goes straight into the next batch's prompt, which holds the look without a training run (see `scenario-consistency`).
 5. File the result: `collection_create`, then `collection_add_assets` in chunks of at most 49 ids. `asset_add_tags` is additive, so tag the failures rather than rebuilding a tag set.
 

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -58,5 +58,5 @@ Local inputs go up with `upload_asset`, which always needs `file_name`, `content
 ## Common mistakes
 
 - A bare value where the schema says `array: true`: a scalar can be silently dropped, ignoring your reference image or LoRA.
-- Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins. On `proceed`, prefer `specialty.model_id` when present, else the top `ranked` entry.
+- Taking `recommend`'s `ranked[0]` blindly: read `next_step.type` first. `ask_user` means present the options; the user's pick wins (non-interactive: task instructions name the pick, else `proceed`). On `proceed`, prefer `specialty.model_id`, else the top `ranked` entry.
 - Debugging blind: the `diagnose` MCP prompt (or `diagnostics_run`) returns trace ids; `usage` answers credit questions.


### PR DESCRIPTION
## Why

Every skill in the repo teaches how to make an asset. None teach how to read one back. `asset_analyze` and `asset_caption` appear in no skill at all; `asset_describe` and `asset_detect` get a passing mention in `scenario-game-assets` and `scenario-consistency` with no contract behind them. So an agent that has just produced 200 icons has nothing to go on for the next question, which is usually "are these on brief" rather than "generate more".

## What the skill teaches

The four tools split into three fixed-purpose (`asset_caption`, `asset_describe`, `asset_detect`) and one open-ended (`asset_analyze`), and the budget goes to the things an agent gets wrong by guessing:

- **`asset_analyze` batches.** One call takes up to 10 images against one instruction, so a review pass over 200 assets is 20 calls rather than 200. `num_outputs` looks like the batch control and is not. Answers land as text assets (one, or one per image) that must be `asset_download`ed.
- **`asset_detect` strips the background by default.** `remove_background` defaults to true, the wrong default whenever the map has to register against the source frame.
- **The four split across executor lanes on `permission`, not on how the verb reads.** `asset_caption` and `asset_describe` are read-class; `asset_analyze` and `asset_detect` are write-class. None are in the default toolset.
- **All four bill, including the read-class pair, and all four take `dry_run`.**

Filing rides along in the worked example: `collection_add_assets` caps at 49 ids per call and rejects re-adds, `asset_add_tags` is additive.

## What changed

- New `skills/scenario-asset-analysis/SKILL.md` (646-word body).
- `skills.sh.json`: new "Reviewing and organizing output" grouping.
- `README.md`: table row.
- `skills/scenario/SKILL.md` (one line): `recommend`'s `ask_user` now has a non-interactive fallback (task instructions name the pick, else treat as `proceed`), a gap the application test surfaced.

## Validation

- [x] `pnpm validate` green: house style, prettier, supporting files, groupings, README, cspell, `skills-ref` spec.
- [x] Two live clean-room application tests per the AGENTS.md protocol, reports in the PR comments: the first surfaced two text defects (fixed), a zero-cost plan-only re-check confirmed the fixes land, and a second live run exercised the remaining traps (read lane, additive tags with real failures, both analyze output shapes) and surfaced two one-clause fixes (applied).
- [x] Batch-filing limits verified against the live API: 50 ids returns 400 "You can not add more than 49 assets at once."; re-adding an existing asset returns 400 "One or more assets are already part of the collection". The pre-rebuild REST reference pages that documented this now 404, so live probes are the public verification path.
- [ ] Baseline probe (same task, no skill installed), the one remaining AGENTS.md step for a new skill.

## Stats

4 files changed (+56, -1): one new skill, one one-line fix to `scenario`, plus the grouping and README rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
