### PR TITLE
fix(scenario-game-assets): teach reference prep for variation batches

### DIFF
--- a/skills/scenario-game-assets/SKILL.md
+++ b/skills/scenario-game-assets/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Scenario's public catalog carries purpose-trained models for game asset types (sprites, icons, props, tilesets, isometric scenes, pixel art, concept art) plus utility models for background removal, upscaling, and pixel cleanup. The workflow is always: discover a model by asset type, inspect its schema, generate, post-process, export. Connection and the core generation loop: see the `scenario` skill in this repo.
+Scenario's public catalog carries purpose-trained models per asset type (sprites, icons, props, tilesets, isometric scenes, pixel art, concept art) plus utilities for background removal, upscaling, and pixel cleanup. Discover by asset type, inspect the schema, generate, post-process, export. Connection and core loop: see the `scenario` skill.
 
 ## Quick reference
 
@@ -22,34 +22,34 @@ Scenario's public catalog carries purpose-trained models for game asset types (s
 | Pixel-art cleanup          | `search` query="pixel" (grid snapping, palette reduction)                                                   |
 | Export for an engine       | `asset_download` with format="png"                                                                          |
 
-## Worked example: an icon set with transparent backgrounds
+## Worked example: a transparent potion icon set
 
 Request: "four style-matched potion icons for an RPG inventory."
 
-1. `search` target="models", query="game icon", public=true. Typical hits: cartoon icon LoRAs such as "Stylized Game Icons & Props". Confirm the pick with the user; catalogs differ per team, so re-discover instead of hardcoding model IDs.
+1. `search` target="models", query="game icon", public=true. Typical hits: cartoon icon LoRAs ("Stylized Game Icons & Props"). Confirm the pick with the user: catalogs differ per team; re-discover, never hardcode model IDs.
 2. `model_schema_get` model_id="<picked id>". Note the prompt field, size fields, and any sample-count parameter.
-3. `model_run` parameters={"prompt": "health potion, corked glass bottle, glowing red liquid, bold outline, centered, plain background"}. For the batch, use the schema's sample-count parameter when present, or rerun varying only the item ("mana potion", "stamina potion"). Keep the wording template fixed so the set stays coherent.
-4. `jobs_wait` with job_ids=["<returned job_id>"] (it accepts up to 32 ids, so one call covers the whole batch), then `asset_display` to review.
-5. `search` query="background removal" (Photoroom, Pixelcut, and 851 Labs variants exist), `model_schema_get` the picked tool, then `model_run` with the schema's image field set to the generated asset id. Some models generate native alpha directly; search "transparent".
-6. Optional: run an upscaler on keepers (search "upscale", then `model_schema_get` as always; Scenario's Flux upscalers go 2x to 8x and beyond).
-7. `asset_download` asset_id, format="png" (PNG keeps the alpha channel). Follow redirects when saving: `curl -L -o potion.png "<url>"`.
+3. `model_run` parameters={"prompt": "health potion, corked glass bottle, glowing red liquid, bold outline, centered, plain background"}. Batch via the schema's sample-count parameter when present, or rerun varying only the item ("mana potion", "stamina potion") with the wording template fixed for a coherent set.
+4. `jobs_wait` job_ids=["<returned job_id>"] (up to 32 ids, one call covers the batch), then `asset_display` to review.
+5. `search` query="background removal" (Photoroom, Pixelcut, 851 Labs), `model_schema_get` the pick, then `model_run` with its image field set to the generated asset id. Some models generate native alpha; search "transparent".
+6. Optional: upscale keepers (search "upscale", `model_schema_get` as always; Scenario's Flux upscalers go 2x to 8x and beyond).
+7. `asset_download` asset_id, format="png" (PNG keeps alpha). Follow redirects: `curl -L -o potion.png "<url>"`.
 
 ## Style consistency
 
-- Reference images: `upload_asset` the art direction images, then pass their asset ids to the model's image or reference parameters (asset ids, never local paths).
-- `asset_describe` turns one on-style asset into a promptable style synthesis to reuse across prompts (full-toolset tool: if it is not listed, reconnect with `?toolsets=full` or run it via `scenario_tools_search` + `scenario_tool_execute_read`; see the `scenario` skill).
-- `search` target="assets" with images={like: ["asset_..."]} finds existing assets that already match the target look.
-- For a locked-in project style, train a custom LoRA on the project's own art: see the `scenario-model-training` skill in this repo. Trained models run through the same generation loop.
+- Reference images: `upload_asset` the art direction images, then pass the asset ids (never local paths) to the model's image or reference parameters.
+- `asset_describe` turns one on-style asset into a promptable style synthesis reusable across prompts (full-toolset tool: if unlisted, reconnect with `?toolsets=full` or run via `scenario_tools_search` + `scenario_tool_execute_read`; see the `scenario` skill).
+- `search` target="assets" images={like: ["asset_..."]} finds assets already matching the target look.
+- For a locked-in project style, train a custom LoRA on the project's own art (the `scenario-model-training` skill); trained models use the same generation loop.
 
-## Preparing a reference for a variation batch
+## Preparing a variation-batch reference
 
-Restyling one approved component into a set (a button, a panel, a popup well, an icon family) fails on the reference more often than on the prompt. The model has no way to separate the object from what was composited onto it, so everything in the reference is treated as the thing being copied.
+Restyling one approved component into a set (button, panel, popup well, icon family) fails on the reference more often than the prompt: the model treats everything composited onto the object as the object.
 
-- **Crop to the object's own bounds.** Transparent padding reads as composition, so the output lands at a different scale and offset every run. Downstream code that measures the sprite then gets a different box each time. Trim the alpha, generate, and re-pad to a fixed canvas afterwards.
-- **Strip baked effects before generating.** A drop shadow, outer glow, or bevel in the reference is read as part of the silhouette and comes back thickened, doubled, or fused to the object. Feed the flat art and re-apply the effect in engine, where it stays adjustable.
-- **Say which parts are functional.** A nine-slice panel needs stretchable middles and fixed corners, and diffusion has no concept of either. Name the constraint in the prompt, then check the output rather than assuming it held.
+- **Crop to the object's own bounds.** Transparent padding reads as composition: scale and offset drift every run, so sprite-measuring code gets a different box. Trim the alpha, generate, re-pad to a fixed canvas. When the model's supported aspect ratios exclude the source's, aspect also drifts per run; reconcile UI components with a nine-slice-aware rescale (stretch middle bands, keep corners and lettering undistorted) before re-padding.
+- **Strip baked effects before generating.** A drop shadow, outer glow, or bevel in the reference reads as silhouette and comes back thickened, doubled, or fused to the object. Feed flat art and re-apply the effect in engine, where it stays adjustable. For a final PNG matching a shadowed source, lift the source's effect layer by alpha (on a transparent source, shadow pixels are semi-transparent, the object fully opaque) and composite it under each output.
+- **Say which parts are functional.** A nine-slice panel needs stretchable middles and fixed corners; diffusion has no concept of either. Name the constraint in the prompt, then check that it held.
 - **One object, plain field, no scene.** Several objects in one reference get recombined into a hybrid.
-- **Check the alpha edge after background removal.** A removed shadow leaves a semi-transparent fringe that reads as a halo once the asset sits on a colored UI background.
+- **Check the alpha edge on any transparent output.** Removed shadows leave a semi-transparent fringe; native-alpha models can ship a large semi-transparent glow around the object. Both read as a halo on a colored UI background.
 
 Verify the set by measurement, not by eye: compare each output's alpha bounding box against the source before accepting the batch.
 
@@ -57,6 +57,7 @@ Verify the set by measurement, not by eye: compare each output's alpha bounding 
 
 - Prompting "transparent background" at a diffusion model: outputs are opaque. Cut the background afterward with a removal tool, or pick a native-alpha model.
 - Exporting JPG sprites: JPG has no alpha channel; keep format="png".
-- Shipping AI pixel art with off-grid pixels or noisy palettes: post-process with a pixel cleanup tool (search "pixel") that snaps pixels to a grid and enforces a strict palette.
-- Skipping `model_schema_get`: specialty models (the pixel-art family, for example) are txt2img-only with their own fields, and generic parameters get rejected.
-- Hand-stitching tilesets: dedicated seamless tileset generators exist (search "pixel art" surfaces them), and texture-specific upscalers preserve tiling.
+- Shipping AI pixel art with off-grid pixels or noisy palettes: post-process with a pixel cleanup tool (search "pixel") for grid snapping and a strict palette.
+- Skipping `model_schema_get`: specialty models (the pixel-art family) are txt2img-only with their own fields; generic parameters get rejected.
+- Hand-stitching tilesets: dedicated seamless tileset generators exist (search "pixel art"); texture-specific upscalers preserve tiling.
+- Single-sampling lettered assets: the same recipe can render one word and fail another (dark embossed text, not the reference typography). Generate several samples per run (schema's sample-count parameter) and pin exact hex colors in the prompt when the palette drifts.

--- a/skills/scenario-game-assets/SKILL.md
+++ b/skills/scenario-game-assets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-game-assets
-description: Use when creating game art through the Scenario MCP, including sprites, sprite sheets, game icons, props, loot, tilesets, seamless tiles, isometric buildings, top-down maps, pixel art, UI components such as buttons and panels, and character or concept art, or when game assets need transparent backgrounds, background removal, restyling one approved component into a variation set, upscaling, pixel-grid cleanup, or engine-ready PNG export for Unity, Godot, or Unreal.
+description: Use when creating game art through the Scenario MCP, including sprites, sprite sheets, game icons, props, loot, tilesets, seamless tiles, isometric buildings, top-down maps, pixel art, UI components such as buttons and panels, and character or concept art, or when game assets need transparent backgrounds, background removal, style-consistent variation batches (restyling an approved component into a set), upscaling, pixel-grid cleanup, or engine-ready PNG export for Unity, Godot, or Unreal.
 license: MIT
 ---
 

--- a/skills/scenario-game-assets/SKILL.md
+++ b/skills/scenario-game-assets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-game-assets
-description: Use when creating game art through the Scenario MCP, including sprites, sprite sheets, game icons, props, loot, tilesets, seamless tiles, isometric buildings, top-down maps, pixel art, and character or concept art, or when game assets need transparent backgrounds, background removal, style-consistent variation batches, upscaling, pixel-grid cleanup, or engine-ready PNG export for Unity, Godot, or Unreal.
+description: Use when creating game art through the Scenario MCP, including sprites, sprite sheets, game icons, props, loot, tilesets, seamless tiles, isometric buildings, top-down maps, pixel art, UI components such as buttons and panels, and character or concept art, or when game assets need transparent backgrounds, background removal, restyling one approved component into a variation set, upscaling, pixel-grid cleanup, or engine-ready PNG export for Unity, Godot, or Unreal.
 license: MIT
 ---
 
@@ -40,6 +40,18 @@ Request: "four style-matched potion icons for an RPG inventory."
 - `asset_describe` turns one on-style asset into a promptable style synthesis to reuse across prompts (full-toolset tool: if it is not listed, reconnect with `?toolsets=full` or run it via `scenario_tools_search` + `scenario_tool_execute_read`; see the `scenario` skill).
 - `search` target="assets" with images={like: ["asset_..."]} finds existing assets that already match the target look.
 - For a locked-in project style, train a custom LoRA on the project's own art: see the `scenario-model-training` skill in this repo. Trained models run through the same generation loop.
+
+## Preparing a reference for a variation batch
+
+Restyling one approved component into a set (a button, a panel, a popup well, an icon family) fails on the reference more often than on the prompt. The model has no way to separate the object from what was composited onto it, so everything in the reference is treated as the thing being copied.
+
+- **Crop to the object's own bounds.** Transparent padding reads as composition, so the output lands at a different scale and offset every run. Downstream code that measures the sprite then gets a different box each time. Trim the alpha, generate, and re-pad to a fixed canvas afterwards.
+- **Strip baked effects before generating.** A drop shadow, outer glow, or bevel in the reference is read as part of the silhouette and comes back thickened, doubled, or fused to the object. Feed the flat art and re-apply the effect in engine, where it stays adjustable.
+- **Say which parts are functional.** A nine-slice panel needs stretchable middles and fixed corners, and diffusion has no concept of either. Name the constraint in the prompt, then check the output rather than assuming it held.
+- **One object, plain field, no scene.** Several objects in one reference get recombined into a hybrid.
+- **Check the alpha edge after background removal.** A removed shadow leaves a semi-transparent fringe that reads as a halo once the asset sits on a colored UI background.
+
+Verify the set by measurement, not by eye: compare each output's alpha bounding box against the source before accepting the batch.
 
 ## Common mistakes
 


### PR DESCRIPTION
## Why

Restyling one approved component into a set (a button, a panel, a popup well, an icon family) is a recurring ask, and it fails on the **reference**, not on the prompt. The skill covered how to pass a reference and never covered how to prepare one, so an agent does everything right and still gets an unusable batch.

Two symptoms come up repeatedly:

- A drop shadow present in the source gets read as part of the silhouette and comes back thickened, doubled, or fused into the object.
- Transparent padding drifts between source and output, so the sprite lands at a different scale and offset on every run. Anything downstream that measures the asset then gets a different box each time.

Both trace to one fact the skill never stated: the model cannot separate the object from what was composited onto it, so **everything** in the reference is treated as the thing being copied. Once that is on the page the individual rules follow from it rather than reading as a list of tips.

## What changed

`skills/scenario-game-assets/SKILL.md` only. New "Preparing a reference for a variation batch" section:

- Crop to the object's own bounds, then re-pad to a fixed canvas after generating.
- Strip baked effects (shadow, glow, bevel) from the reference and re-apply them in engine, where they stay adjustable.
- Name functional constraints explicitly: a nine-slice panel needs stretchable middles and fixed corners, and diffusion has no concept of either, so the output has to be checked rather than assumed.
- One object on a plain field; multi-object references get recombined into a hybrid.
- Check the alpha edge after background removal, since a removed shadow leaves a semi-transparent fringe that reads as a halo over a colored UI background.
- Verify the set by measurement (alpha bounding box against the source), not by eye.

Also widened the description to trigger on UI components and on "restyling one approved component into a variation set", which is closer to how the request actually arrives than "style-consistent variation batches".

This is craft guidance rather than API surface, so it makes no tool or parameter claims beyond what the skill already had.

## Validation

`pnpm validate` passes. Body is 854 words, inside the 900 cap; description is 468 characters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7cvQTekunobA5N41gJeP3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f25c8af05c3847cbde7347e39db8f2558c909ae3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->