### PR TITLE
fix(scenario-audio): teach the song lane its own contract

### DIFF
--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -43,7 +43,7 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 Prompting tips:
 
 - SFX: name the source, material, action, and acoustic space, and say what to exclude ("no music", "no reverb"). One event per clip; generate variations as separate runs.
-- Music: give genre, mood, tempo, and instrumentation in the style field, and set the instrumental flag rather than saying it in words.
+- Music: give genre, mood, tempo, and instrumentation. Short beds usually take a single prompt, with duration or looping in the schema; songs with vocals split the request across fields, below.
 - Speech: keep the text field to the words to speak. Voice choice, language, emotion, and pacing live in separate schema fields or inline tags depending on the model; check the schema instead of packing direction into the text.
 
 ## Songs with vocals

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-audio
-description: Use when generating or handling audio on Scenario via MCP. Triggers include music tracks, background scores, soundtracks, game sound effects, SFX, foley, ambience, looping audio, voiceover, narration, speech, TTS, text-to-speech, voice cloning, re-voicing a recording, scoring or adding sound to a video, transcription, or requests to create, wait on, play, or download audio files (MP3, WAV) with Scenario tools.
+description: Use when generating or handling audio on Scenario via MCP. Triggers include music tracks, full-length songs with vocals written from lyrics, background scores, soundtracks, game sound effects, SFX, foley, ambience, looping audio, voiceover, narration, speech, TTS, text-to-speech, voice cloning, re-voicing a recording, scoring or adding sound to a video, transcription, or requests to create, wait on, play, or download audio files (MP3, WAV) with Scenario tools.
 license: MIT
 ---
 
@@ -25,7 +25,7 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 
 ## What the audio surface covers
 
-- Music: text-to-music models produce instrumental tracks or full songs; several accept lyrics with section tags and duration controls.
+- Music: text-to-music models produce short beds or full-length songs with vocals; the song lane has its own contract, below.
 - Sound effects: text-to-SFX models generate short clips from a description; some support seamless looping.
 - Voice and speech: text-to-speech models with preset voices, multilingual output, and emotion or pacing controls; some clone a voice from a short reference clip; speech-to-speech re-voices an existing recording.
 - Video to audio: models that score a silent video or add synchronized sound effects, taking a video asset as input.
@@ -43,8 +43,21 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 Prompting tips:
 
 - SFX: name the source, material, action, and acoustic space, and say what to exclude ("no music", "no reverb"). One event per clip; generate variations as separate runs.
-- Music: give genre, mood, tempo, and instrumentation, and say instrumental or vocal. Lyrics-capable models expect structured sections; check the schema.
+- Music: give genre, mood, tempo, and instrumentation in the style field, and set the instrumental flag rather than saying it in words.
 - Speech: keep the text field to the words to speak. Voice choice, language, emotion, and pacing live in separate schema fields or inline tags depending on the model; check the schema instead of packing direction into the text.
+
+## Songs with vocals
+
+A full-length song is not a longer music bed. Song models split the request across two fields instead of one, and the schema names differ per model, so confirm each with `model_schema_get`:
+
+- **The style field** (usually `prompt`) carries genre, mood, tempo in BPM, key, vocal style, and instrumentation. It never carries the words.
+- **The lyric field** carries the words, shaped by section tags such as `[Intro]`, `[Verse]`, `[Chorus]`, and `[Bridge]`, which is how the arrangement gets its structure.
+- **Instrumental is a flag, not a phrase.** Current models expose a boolean (`isInstrumental` on one family); asking for "no vocals" in the style prompt does not reliably suppress them.
+- **Auto-lyrics is also a flag.** With the lyric field empty, an optimizer flag (`lyricsOptimizer` on one family) writes lyrics from the style brief. Empty lyrics with no flag is not the same request.
+
+Both fields are length-capped, separately and in the thousands of characters, and going over is a 400 rather than a truncation.
+
+Run length is the thing to plan around. Song models generally expose no duration parameter: the output follows the lyric sheet, up to several minutes on current models, and cost tracks that duration. The lyric sheet is therefore the cost lever, so price a full-length song with `dry_run: true` before committing, and launch it with `wait=false`.
 
 ## Common mistakes
 
@@ -55,3 +68,5 @@ Prompting tips:
 - Passing `format` to `asset_download` for audio: it converts image formats only, so omit it.
 - Putting voice direction inside TTS text ("say this angrily"): direction can end up spoken. Use the schema's emotion or voice fields.
 - Sending image parameters (width, height) to audio models: their schemas do not accept them.
+- Pasting lyrics into the style field: the model then describes a song instead of singing one.
+- Running a full-length song without `dry_run`: there is no duration field to cap it, so the lyric sheet sets both the length and the bill.

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -43,21 +43,19 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 Prompting tips:
 
 - SFX: name the source, material, action, and acoustic space, and say what to exclude ("no music", "no reverb"). One event per clip; generate variations as separate runs.
-- Music: give genre, mood, tempo, and instrumentation. Short beds usually take a single prompt, with duration or looping in the schema; songs with vocals split the request across fields, below.
+- Music: give genre, mood, tempo, and instrumentation. Short beds usually take a single prompt, with duration or looping in the schema; songs with vocals are their own lane, below.
 - Speech: keep the text field to the words to speak. Voice choice, language, emotion, and pacing live in separate schema fields or inline tags depending on the model; check the schema instead of packing direction into the text.
 
 ## Songs with vocals
 
-A full-length song is not a longer music bed. Song models split the request across two fields instead of one, and the schema names differ per model, so confirm each with `model_schema_get`:
+A full-length song is not a longer music bed, and song schemas vary more than the rest of the audio lane, so `model_schema_get` decides everything here. Current families shape the request three ways: a style prompt plus a separate lyric sheet, a single prose prompt carrying style and structure together, or an ordered section array with per-section lyrics, styles, and durations.
 
-- **The style field** (usually `prompt`) carries genre, mood, tempo in BPM, key, vocal style, and instrumentation. It never carries the words.
-- **The lyric field** carries the words, shaped by section tags such as `[Intro]`, `[Verse]`, `[Chorus]`, and `[Bridge]`, which is how the arrangement gets its structure.
-- **Instrumental is a flag, not a phrase.** Current models expose a boolean (`isInstrumental` on one family); asking for "no vocals" in the style prompt does not reliably suppress them.
-- **Auto-lyrics is also a flag.** With the lyric field empty, an optimizer flag (`lyricsOptimizer` on one family) writes lyrics from the style brief. Empty lyrics with no flag is not the same request.
+- **Words never go in a style field.** On split-field models the style field carries genre, mood, tempo in BPM, key, vocal style, and instrumentation; the lyric field carries the words, shaped by section tags such as `[Verse]` and `[Chorus]`.
+- **Instrumental is a flag where the schema has one.** Asking for "no vocals" in the style text does not reliably suppress them; when no flag exists, the schema's text fields are the only lever.
+- **Auto-lyrics is also a flag** on the family that has one: with the lyric field empty, it writes lyrics from the style brief. Empty lyrics with no flag is not the same request.
+- **Text fields are length-capped**, with caps that differ per model and field, and going over is a 400 rather than a truncation.
 
-Both fields are length-capped, separately and in the thousands of characters, and going over is a 400 rather than a truncation.
-
-Run length is the thing to plan around. Song models generally expose no duration parameter: the output follows the lyric sheet, up to several minutes on current models, and cost tracks that duration. The lyric sheet is therefore the cost lever, so price a full-length song with `dry_run: true` before committing, and launch it with `wait=false`.
+Where the schema exposes a duration field (flagged `cost_impact`), it caps both length and price; where none exists, the lyric sheet or prompt sets both. Either way, price the song with `dry_run: true` before committing, and launch with `wait=false`.
 
 ## Common mistakes
 
@@ -69,4 +67,4 @@ Run length is the thing to plan around. Song models generally expose no duration
 - Putting voice direction inside TTS text ("say this angrily"): direction can end up spoken. Use the schema's emotion or voice fields.
 - Sending image parameters (width, height) to audio models: their schemas do not accept them.
 - Pasting lyrics into the style field: the model then describes a song instead of singing one.
-- Running a full-length song without `dry_run`: there is no duration field to cap it, so the lyric sheet sets both the length and the bill.
+- Running a full-length song without `dry_run`: when the schema has no duration field, the lyric sheet sets both the length and the bill.


### PR DESCRIPTION
## Why

The skill treated a song as a longer music bed: one prompt, plus a note that "several accept lyrics with section tags and duration controls". Song models do not work that way, and the mismatch decides whether the output sings or just describes a song.

The full-length-song lane is also where the music catalog has been moving, so an agent asked for "a track with vocals for the trailer" now lands on a model whose contract the skill does not describe.

## What changed

`skills/scenario-audio/SKILL.md` only. New "Songs with vocals" section:

- **Two fields, not one.** The style field (usually `prompt`) carries genre, mood, BPM, key, vocal style, and instrumentation. The lyric field carries the words, shaped by section tags (`[Intro]`, `[Verse]`, `[Chorus]`, `[Bridge]`), which is what gives the arrangement its structure. Lyrics pasted into the style field get described rather than sung.
- **Instrumental and auto-lyrics are booleans, not phrasings.** Asking for "no vocals" in prose does not reliably suppress them; there is a flag for it. Likewise an empty lyric field with the optimizer flag (lyrics written from the style brief) is a different request from an empty lyric field without it.
- **Both fields are separately length-capped**, in the thousands of characters, and going over is a 400 rather than a truncation.
- **There is no duration parameter.** Output length follows the lyric sheet and cost tracks length, which makes the lyric sheet the cost lever. That is the case for `dry_run` before a full-length run, and for `wait=false`.

Field names are given as examples from one current family with the schema still named as the authority, since names differ per model and the skill already forbids hardcoding.

Also updated the music bullet and prompting tip so they point at the flag rather than at prose, added the two matching Common mistakes, and widened the description to trigger on songs and lyrics.

Contract checked against the public model documentation on docs.scenario.com.

## Validation

`pnpm validate` passes. Body is 870 words, inside the 900 cap; description is 464 characters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7cvQTekunobA5N41gJeP3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4d1d9218013337c68d5b5bbf7b4f446d2c56eb7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->