### PR TITLE
fix(scenario): keep credential handling out of the setup reference

### DIFF
--- a/skills/scenario/references/setup.md
+++ b/skills/scenario/references/setup.md
@@ -20,4 +20,6 @@ Cursor / VSCode (`mcp.json`):
 
 ## API keys (headless or CI)
 
-The same endpoint accepts `Authorization: Basic base64(key:secret)`; create keys at app.scenario.com/settings/api. Build the header per the [connection guide](https://mcp.scenario.com/docs) and keep it out of the conversation: reference an environment variable in the client config (`--header "Authorization: Basic $SCENARIO_MCP_AUTH"`) or edit the config file directly. Never ask an agent to collect, encode, or echo a key or secret.
+Where nobody is present to complete the OAuth prompt, the same endpoint also authenticates with a Scenario API key, created at app.scenario.com/settings/api. Wiring one into a client is an operator task done by hand: the [connection guide](https://mcp.scenario.com/docs#using-an-api-key) carries the current steps for each client.
+
+Credentials stay out of the conversation. An agent asked to set this up points to the guide and stops there. It does not ask for a key or secret, does not place one in a command, a config file, or a message, and does not repeat one that appears in its context.


### PR DESCRIPTION
The public Snyk audit of the `scenario` skill fails at HIGH on W007, insecure credential handling. The trigger is `references/setup.md`, not `SKILL.md`: the audit reads supporting files and links straight to it.

- Drop the credential recipe from the API-key section: it spelled out the Basic auth header construction (key and secret joined, base64 encoded) and showed a CLI flag carrying that header, which reads as an instruction for an agent to assemble and emit a secret
- Point at the connection guide's API-key section instead, so the per-client steps stay on the page that maintains them, and keep app.scenario.com/settings/api as where a key is created
- State the rule positively: setting up a key is an operator task done by hand, and the agent neither asks for a credential nor places one in a command, a config file, or a message
- Leave `SKILL.md` untouched, both to avoid conflicting with #35, which rewrites that file, and because the finding cites only the concrete commands and header examples, all of which live in the reference

The audit's other two findings are structural rather than defects, so they are unchanged: W011 (free text reaching `search` and `prompt_spark`) and W012 (a runtime MCP endpoint) describe what an MCP generation skill is. `scenario-workflow-authoring` audits MEDIUM with only W011, so its env-var usage line does not trip W007, and no other skill carries credential-handling text.

`pnpm validate` passes.

---------

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnxsRhyRiWdZXiEfZXrzuA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2ae88cc71c5b26219807333aa0785b85e78514d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->