### PR TITLE
fix(skills): split Seedance sound from music and correct the family caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Or add `https://mcp.scenario.com/mcp` to any MCP client and sign in with a Scena
 | [scenario-skyboxes](skills/scenario-skyboxes/SKILL.md)                         | 360 equirectangular panoramas and skyboxes, seam-safe upscaling, engine export                                     |
 | [scenario-3d](skills/scenario-3d/SKILL.md)                                     | Text or image to 3D meshes, multi-view reconstruction, retexture and remesh, inline 3D preview, GLB/FBX download   |
 | [scenario-video](skills/scenario-video/SKILL.md)                               | Text-to-video and image-to-video, motion prompting, lipsync, video editing, upscaling, cut/split/concat utilities  |
-| [scenario-seedance](skills/scenario-seedance/SKILL.md)                         | Seedance video: mode selection (first frame, references, edit, extend), conditioning traps, cost gating            |
+| [scenario-seedance](skills/scenario-seedance/SKILL.md)                         | Seedance video: mode selection (first frame, references, edit, extend), conditioning traps, native sound, cost     |
 | [scenario-audio](skills/scenario-audio/SKILL.md)                               | Music, sound effects, voice and speech generation, video scoring, audio utilities                                  |
-| [scenario-seedance-music-video](skills/scenario-seedance-music-video/SKILL.md) | Turning a song into a finished music video: beat-aligned shots, lyric transcription, verified ffmpeg assembly      |
+| [scenario-seedance-music-video](skills/scenario-seedance-music-video/SKILL.md) | Turning a song into a music video: beat-aligned shots, lyric transcription, shot sound under the master, assembly  |
 | [scenario-video-assembly](skills/scenario-video-assembly/SKILL.md)             | Assembling clips into a finished video: timeline composition, concat with transitions, overlays, music, captions   |
 | [scenario-consistency](skills/scenario-consistency/SKILL.md)                   | Holding one character, product, or style across a set: baseline-plus-delta prompts, reference images, control maps |
 | [scenario-model-training](skills/scenario-model-training/SKILL.md)             | Training custom models for style, character, or product consistency, and generating with them                      |

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 captioner
+diegetic
 equirectangular
 ffprobe
 inpaint

--- a/skills/scenario-seedance-music-video/SKILL.md
+++ b/skills/scenario-seedance-music-video/SKILL.md
@@ -17,7 +17,7 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 Music written inside a shot restarts in a new key at every cut, so the score comes from outside the video model: here, the supplied master. What Seedance makes on its own side is the sound bolted to the picture. Both deliveries are valid, and the choice sets `generateAudio` on every shot, so make it before generating:
 
 - Song alone: `generateAudio: false` everywhere. build.py stream-copies the master whenever MP4 allows, so the delivered soundtrack is the supplied file, bit for bit.
-- Song over the shots' own sound: `generateAudio: true` with "diegetic sound only, no music, no score" in every prompt, plus `"sound": 0.2` in the edit file. build.py cuts each clip's audio to its slot, mixes it under the master at that gain, and refuses a mix that would clip rather than reshaping the song to fit. The delivery is then one AAC encode, trading the bit-for-bit guarantee for the sound; the master file itself is still hash-checked.
+- Song over the shots' own sound: `generateAudio: true` with "diegetic sound only, no music, no score" in every prompt, plus `"sound": 0.2` in the edit file. build.py cuts each clip's audio to its slot, mixes it under the master at that gain, and refuses a mix that would clip rather than reshaping the song. The delivery is then one AAC encode, trading the bit-for-bit guarantee for the sound; the master file stays hash-checked.
 
 ## Quick reference
 
@@ -55,7 +55,7 @@ Ask once before starting: team and project, track clearance, aspect ratio and le
 }
 ```
 
-Each shot runs until the next starts and the last to the master's end, so gaps are impossible. `in` is an optional head trim. `sound` is the gain on the clips' own audio, 0.1 to 0.3 under a mastered track; drop the line for the song alone. The build fails loudly when a clip is too short, when the mix would clip, or when the delivered audio is not the master.
+Each shot runs until the next starts and the last to the master's end, so gaps are impossible. `in` is an optional head trim. `sound` is the gain on the clips' own audio, 0.1 to 0.3 under a mastered track; drop the line for the song alone. The build fails loudly on a clip too short, a mix that would clip, or delivered audio that is not the master.
 
 ## Common mistakes
 

--- a/skills/scenario-seedance-music-video/SKILL.md
+++ b/skills/scenario-seedance-music-video/SKILL.md
@@ -14,10 +14,10 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 
 ## The two soundtracks
 
-Music written inside a shot restarts in a new key at every cut, so the score comes from outside the video model: here, the supplied master. What Seedance makes on its own side is the sound bolted to the picture. Both deliveries are valid, and the choice sets `generateAudio` on every shot, so make it before generating:
+Music written inside a shot restarts in a new key at every cut, so the score comes from outside the video model: here, the supplied master. What Seedance makes on its own side is the sound bolted to the picture. The choice sets `generateAudio` on every shot, so make it before generating:
 
 - Song alone: `generateAudio: false` everywhere. build.py stream-copies the master whenever MP4 allows, so the delivered soundtrack is the supplied file, bit for bit.
-- Song over the shots' own sound: `generateAudio: true` with "diegetic sound only, no music, no score" in every prompt, plus `"sound": 0.2` in the edit file. build.py cuts each clip's audio to its slot, mixes it under the master at that gain, and refuses a mix that would clip rather than reshaping the song. The delivery is then one AAC encode, trading the bit-for-bit guarantee for the sound; the master file stays hash-checked.
+- Song over the shots' own sound: `generateAudio: true` with "diegetic sound only, no music, no score" in every prompt, plus `"sound": 0.2` in the edit file. build.py cuts each clip's audio to its slot, mixes it under the master at that gain, and refuses a mix that would clip. The delivery is then one AAC encode, trading the bit-for-bit guarantee for the sound; the master file stays hash-checked.
 
 ## Quick reference
 
@@ -55,13 +55,14 @@ Ask once before starting: team and project, track clearance, aspect ratio and le
 }
 ```
 
-Each shot runs until the next starts and the last to the master's end, so gaps are impossible, and every `at` snaps to the nearest frame. `in` is an optional head trim. `sound` is the gain on the clips' own audio, 0.1 to 0.3 under a mastered track; drop the line for the song alone. The build fails loudly on a clip too short, a mix that would clip, or delivered audio that is not the master.
+Each shot runs until the next starts and the last to the master's end, so gaps are impossible, and every `at` snaps to the nearest frame. `in` is an optional head trim. `sound` is the gain on the clips' own audio, sized to what they carry: 0.1 to 0.3 under a mastered track, up to 1.0 when the clips run quiet (build.py takes 0 to 4); drop the line for the song alone. The build fails loudly on a clip too short, a mix that would clip, or delivered audio that is not the master.
 
 ## Common mistakes
 
-- Letting a shot score itself: two scores then fight, and the shot's own restarts at every cut.
+- Letting a shot score itself: its score restarts at every cut.
 - Turning `sound` on while the prompts still allow music: exclude it in words, since `generateAudio` is one switch over the whole track.
-- Trimming, normalizing, fading, or re-encoding the master yourself: build.py copies it when the delivery allows, carries it at unity when it does not, and hash-checks the file either way.
+- Trimming, normalizing, fading, or re-encoding the master yourself: build.py copies it or carries it at unity, and hash-checks the file either way.
+- Trusting a requested aspect ratio: stills and clips land near it, not on it, and build.py pads the difference; crop to the delivery ratio first.
 - Prompting an opening state in reference mode: it will not appear; pass a first-frame `image`.
 - Judging a clip from a sparse contact sheet: a continuous camera move looks like a hard cut; measure first (see [references/shots.md](references/shots.md)).
 - Trusting the beat grid: sections and cut candidates are suggestions; check them against what you hear.

--- a/skills/scenario-seedance-music-video/SKILL.md
+++ b/skills/scenario-seedance-music-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-seedance-music-video
-description: "Use when turning a song, track, or audio master into a finished music video with Scenario and Seedance: planning shots against beats and sections, transcribing lyrics, generating clips that cut to music, assembling a delivery over the untouched master soundtrack, or verifying the final cut. Keywords: music video, beat sync, shot list, lyric transcription, reference frames, ffmpeg assembly, Seedance."
+description: "Use when turning a song, track, or audio master into a finished music video with Scenario and Seedance: planning shots against beats and sections, transcribing lyrics, generating clips that cut to music, keeping the shots' own sound while the song stays the only score, assembling a delivery over the untouched master soundtrack, or verifying the final cut. Keywords: music video, beat sync, shot list, lyric transcription, reference frames, ffmpeg assembly, Seedance."
 license: MIT
 ---
 
@@ -8,9 +8,16 @@ license: MIT
 
 ## Overview
 
-Five steps: song, lyrics, story, frames, video. The supplied master is the soundtrack and is never re-encoded: every Seedance call sets `generateAudio: false`, and [scripts/build.py](scripts/build.py) muxes the master once, at the end, proving it untouched by hash. [scripts/song.py](scripts/song.py) reads the master so cuts land on its structure. The scripts need ffmpeg and ffprobe on PATH, and numpy for song.py.
+Five steps: song, lyrics, story, frames, video. The supplied master is the only score, and no shot writes its own. [scripts/build.py](scripts/build.py) lays the master over the cut once, at the end, and proves the file untouched by hash. [scripts/song.py](scripts/song.py) reads the master so cuts land on its structure. The scripts need ffmpeg and ffprobe on PATH, and numpy for song.py.
 
 Connection and the core generation loop: see the `scenario` skill in this repo. The Seedance parameter contract and conditioning traps: see the `scenario-seedance` skill in this repo.
+
+## The two soundtracks
+
+Music written inside a shot restarts in a new key at every cut, so the score comes from outside the video model: here, the supplied master. What Seedance makes on its own side is the sound bolted to the picture. Both deliveries are valid, and the choice sets `generateAudio` on every shot, so make it before generating:
+
+- Song alone: `generateAudio: false` everywhere. build.py stream-copies the master whenever MP4 allows, so the delivered soundtrack is the supplied file, bit for bit.
+- Song over the shots' own sound: `generateAudio: true` with "diegetic sound only, no music, no score" in every prompt, plus `"sound": 0.2` in the edit file. build.py cuts each clip's audio to its slot, mixes it under the master at that gain, and refuses a mix that would clip rather than reshaping the song to fit. The delivery is then one AAC encode, trading the bit-for-bit guarantee for the sound; the master file itself is still hash-checked.
 
 ## Quick reference
 
@@ -20,10 +27,10 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 | 2. Lyrics | `search` query `"audio to text"`, `model_run`     | supplied lyrics win; sung-vocal transcription is a draft          |
 | 3. Story  | one page, shown to the user first                 | the cheapest place to be wrong; name what must not drift          |
 | 4. Frames | image model at the delivery aspect ratio          | reference stills, one per look to hold                            |
-| 5. Shots  | Seedance `model_run`, `generateAudio: false`      | `dry_run` first; `wait=false`; `jobs_wait` with `pending_job_ids` |
-| 6. Cut    | `python3 scripts/build.py edit.json out.mp4`      | one ffmpeg pass: conform, concatenate, mux master, verify         |
+| 5. Shots  | Seedance `model_run`, audio per the choice above  | `dry_run` first; `wait=false`; `jobs_wait` with `pending_job_ids` |
+| 6. Cut    | `python3 scripts/build.py edit.json out.mp4`      | one ffmpeg pass: conform, concatenate, lay the master, verify     |
 
-Ask once before starting: team and project, track clearance, aspect ratio and length, what must and must not appear, spend ceiling. Then run without stopping.
+Ask once before starting: team and project, track clearance, aspect ratio and length, sound under the song or not, what must and must not appear, spend ceiling. Then run without stopping.
 
 ## Worked example: one verse, three shots
 
@@ -40,6 +47,7 @@ Ask once before starting: team and project, track clearance, aspect ratio and le
   "fps": 24,
   "width": 1280,
   "height": 720,
+  "sound": 0.2,
   "shots": [
     { "clip": "clips/01.mp4", "at": 0.0 },
     { "clip": "clips/02.mp4", "at": 12.5, "in": 1.0 }
@@ -47,12 +55,13 @@ Ask once before starting: team and project, track clearance, aspect ratio and le
 }
 ```
 
-Each shot runs until the next starts and the last to the master's end, so gaps are impossible. `in` is an optional head trim. The build fails loudly when a clip is too short or the delivered audio is not the master.
+Each shot runs until the next starts and the last to the master's end, so gaps are impossible. `in` is an optional head trim. `sound` is the gain on the clips' own audio, 0.1 to 0.3 under a mastered track; drop the line for the song alone. The build fails loudly when a clip is too short, when the mix would clip, or when the delivered audio is not the master.
 
 ## Common mistakes
 
-- Leaving `generateAudio` at its default (true): the master is the only soundtrack, muxed once by build.py.
-- Trimming, normalizing, fading, or re-encoding the master: build.py stream-copies it whenever MP4 allows and verifies by hash.
+- Letting a shot score itself: two scores then fight, and the shot's own restarts at every cut.
+- Turning `sound` on while the prompts still allow music: exclude it in words, since `generateAudio` is one switch over the whole track.
+- Trimming, normalizing, fading, or re-encoding the master yourself: build.py copies it when the delivery allows, carries it at unity when it does not, and hash-checks the file either way.
 - Prompting an opening state in reference mode: it will not appear; pass a first-frame `image`.
 - Judging a clip from a sparse contact sheet: a continuous camera move looks like a hard cut; measure first (see [references/shots.md](references/shots.md)).
 - Trusting the beat grid: sections and cut candidates are suggestions; check them against what you hear.

--- a/skills/scenario-seedance-music-video/SKILL.md
+++ b/skills/scenario-seedance-music-video/SKILL.md
@@ -30,7 +30,7 @@ Music written inside a shot restarts in a new key at every cut, so the score com
 | 5. Shots  | Seedance `model_run`, audio per the choice above  | `dry_run` first; `wait=false`; `jobs_wait` with `pending_job_ids` |
 | 6. Cut    | `python3 scripts/build.py edit.json out.mp4`      | one ffmpeg pass: conform, concatenate, lay the master, verify     |
 
-Ask once before starting: team and project, track clearance, aspect ratio and length, sound under the song or not, what must and must not appear, spend ceiling. Then run without stopping.
+Ask once before starting: team and project, track clearance, aspect ratio and length, sound under the song or not, what must and must not appear, spend ceiling. With no one to answer, take the song alone, since it is the delivery that keeps the master bit for bit. Then run without stopping.
 
 ## Worked example: one verse, three shots
 

--- a/skills/scenario-seedance-music-video/SKILL.md
+++ b/skills/scenario-seedance-music-video/SKILL.md
@@ -30,14 +30,14 @@ Music written inside a shot restarts in a new key at every cut, so the score com
 | 5. Shots  | Seedance `model_run`, audio per the choice above  | `dry_run` first; `wait=false`; `jobs_wait` with `pending_job_ids` |
 | 6. Cut    | `python3 scripts/build.py edit.json out.mp4`      | one ffmpeg pass: conform, concatenate, lay the master, verify     |
 
-Ask once before starting: team and project, track clearance, aspect ratio and length, sound under the song or not, what must and must not appear, spend ceiling. With no one to answer, take the song alone, since it is the delivery that keeps the master bit for bit. Then run without stopping.
+Ask once before starting: team and project, track clearance, aspect ratio and length, sound under the song or not, what must and must not appear, spend ceiling. With no one to answer, take the song alone, since it keeps the master bit for bit, and write the story down rather than waiting to show it. Then run without stopping.
 
 ## Worked example: one verse, three shots
 
-1. `python3 scripts/song.py master.mp3 -o song.json`. Sections are shot boundaries, cut candidates are cut points; listen before trusting them. The master stays read-only.
+1. `python3 scripts/song.py master.mp3 -o song.json`. Sections are shot boundaries, cut candidates are cut points; listen before trusting them.
 2. Upload the master: multipart `upload_asset`, then `upload_asset_complete` (see the `scenario` skill). `search` a transcription model (query `"audio to text"`), `model_schema_get`, `model_run`, `jobs_wait`. Instrumental track: say so and move on.
 3. Write one page: what happens, where, how it turns across the sections; name the closing image. Show it to the user before spending anything.
-4. Generate reference stills with an image model (via `search`) at the delivery aspect ratio, one per look. Look at them: they set identity and palette downstream.
+4. Generate reference stills with an image model (via `search`) at the delivery aspect ratio, one per look. Look at them: they set identity and palette downstream. Holding one character across several: see the `scenario-consistency` skill in this repo.
 5. Per shot, decide the conditioning: opening state matters, pass a first-frame `image`; only identity and world matter, pass `referenceImages` (see [references/shots.md](references/shots.md)). Generate each shot one or two seconds longer than its slot for a trim handle.
 6. Write `edit.json` and run `python3 scripts/build.py edit.json out.mp4`:
 
@@ -55,7 +55,7 @@ Ask once before starting: team and project, track clearance, aspect ratio and le
 }
 ```
 
-Each shot runs until the next starts and the last to the master's end, so gaps are impossible. `in` is an optional head trim. `sound` is the gain on the clips' own audio, 0.1 to 0.3 under a mastered track; drop the line for the song alone. The build fails loudly on a clip too short, a mix that would clip, or delivered audio that is not the master.
+Each shot runs until the next starts and the last to the master's end, so gaps are impossible, and every `at` snaps to the nearest frame. `in` is an optional head trim. `sound` is the gain on the clips' own audio, 0.1 to 0.3 under a mastered track; drop the line for the song alone. The build fails loudly on a clip too short, a mix that would clip, or delivered audio that is not the master.
 
 ## Common mistakes
 
@@ -65,5 +65,4 @@ Each shot runs until the next starts and the last to the master's end, so gaps a
 - Prompting an opening state in reference mode: it will not appear; pass a first-frame `image`.
 - Judging a clip from a sparse contact sheet: a continuous camera move looks like a hard cut; measure first (see [references/shots.md](references/shots.md)).
 - Trusting the beat grid: sections and cut candidates are suggestions; check them against what you hear.
-- Passing `format` to `asset_download` for a clip: it converts image formats only, so omit it and `curl -L` the returned URL.
 - Calling it done without watching the delivery with sound, then muted.

--- a/skills/scenario-seedance-music-video/references/shots.md
+++ b/skills/scenario-seedance-music-video/references/shots.md
@@ -18,7 +18,7 @@ Order matters less than presence. Every shot that worked had all five:
 2. The section's function and visual goal in one line: `the pulse enters. Visual goal: arrival.`
 3. One dominant camera move and one dominant action. Two of either produces a mess.
 4. The closing state, explicitly.
-5. An exclusion list: `No people, no text, no captions, no logos, no watermarks. Silent footage.`
+5. An exclusion list, audio included: `No people, no text, no captions, no logos, no watermarks. Diegetic sound only, no music, no score.` (`Silent footage.` instead when the shots run with `generateAudio: false`.)
 
 Keep one shot to one idea. A prompt describing a sequence makes the model cut inside the clip.
 

--- a/skills/scenario-seedance-music-video/references/shots.md
+++ b/skills/scenario-seedance-music-video/references/shots.md
@@ -14,7 +14,7 @@ The side effect of reference mode is that independently generated shots each res
 
 Order matters less than presence. Every shot that worked had all five:
 
-1. What each reference is for, by tag: `@image1 defines the world and the slab. @audio1 is timing only.`
+1. What each reference is for, by tag: `@image1 defines the world and the slab. @audio1 is timing only.` The tags address the reference arrays only. A first-frame `image` has nothing to tag, so name what the opening frame already shows and prompt the motion away from it.
 2. The section's function and visual goal in one line: `the pulse enters. Visual goal: arrival.`
 3. One dominant camera move and one dominant action. Two of either produces a mess.
 4. The closing state, explicitly.

--- a/skills/scenario-seedance-music-video/scripts/build.py
+++ b/skills/scenario-seedance-music-video/scripts/build.py
@@ -8,6 +8,11 @@ muxes the untouched master, and checks the delivery. One ffmpeg pass.
 
 The master is never re-encoded when its codec can live in MP4 as is, so the
 delivered soundtrack is bit for bit the file you supplied.
+
+Set "sound" in the edit file to a linear gain (0.1 to 0.3 is a bed) and the
+clips' own audio is mixed under the master at that level instead of dropped.
+The master still goes in at unity, but the delivery is then one AAC encode
+rather than a copy, so the bit-for-bit guarantee is traded for the sound.
 """
 # MIT. Ported from https://github.com/edemaistre/scenario-seedance-2-5-music-video,
 # Copyright (c) 2026 Emmanuel de Maistre.
@@ -109,6 +114,26 @@ def load_edit(path: Path) -> dict:
     return edit
 
 
+def audio_layout(stream: dict) -> str:
+    layout = stream.get("channel_layout")
+    if layout:
+        return layout
+    named = {1: "mono", 2: "stereo"}.get(int(stream.get("channels", 0)))
+    if named is None:
+        raise BuildError("the master's channel layout is unknown, so clip sound cannot be conformed to it")
+    return named
+
+
+def read_sound(edit: dict) -> float:
+    """Gain applied to the clips' own audio. 0, absent or null keeps the master alone."""
+    sound = edit.get("sound", 0) or 0
+    if isinstance(sound, bool) or not isinstance(sound, (int, float)):
+        raise BuildError('"sound" is a linear gain on the clips\' own audio, a number such as 0.2')
+    if not 0 <= sound <= 4:
+        raise BuildError('"sound" must be between 0 and 4; 0.1 to 0.3 puts a bed under a mastered track')
+    return float(sound)
+
+
 def plan(edit: dict, root: Path) -> dict:
     """Turn 'at' times into exact frame spans and check every clip is long enough."""
     fps = int(edit.get("fps", 24))
@@ -116,6 +141,7 @@ def plan(edit: dict, root: Path) -> dict:
     height = int(edit.get("height", 720))
     if fps <= 0 or width <= 0 or height <= 0:
         raise BuildError("fps, width and height must be positive")
+    sound = read_sound(edit)
 
     master = (root / edit["master"]).resolve()
     if not master.is_file():
@@ -150,18 +176,32 @@ def plan(edit: dict, root: Path) -> dict:
         head = int(round(float(shot.get("in", 0.0)) * fps))
         if head < 0:
             raise BuildError(f"shot {index} has a negative 'in'")
-        available = frames_at_fps(probe(clip), fps) - head
+        clip_info = probe(clip)
+        available = frames_at_fps(clip_info, fps) - head
         if available < span:
             raise BuildError(
                 f"{clip.name} gives {available} frames after the head trim but the edit needs {span}. "
                 f"Generate it longer, or move the following shot later."
             )
-        planned.append({"clip": clip, "head": head, "span": span, "start_frame": bounds[index]})
+        planned.append({
+            "clip": clip,
+            "head": head,
+            "span": span,
+            "start_frame": bounds[index],
+            "has_audio": bool(streams(clip_info, "audio")),
+        })
+
+    if sound and not any(shot["has_audio"] for shot in planned):
+        raise BuildError(
+            'no clip carries audio, so "sound" has nothing to mix. Generate the shots with '
+            'generateAudio: true, or drop "sound" and deliver the master alone.'
+        )
 
     return {
         "fps": fps,
         "width": width,
         "height": height,
+        "sound": sound,
         "master": master,
         "master_info": master_info,
         "master_duration": master_duration,
@@ -188,19 +228,120 @@ def filter_graph(job: dict) -> str:
     return ";".join(parts)
 
 
+def inputs(job: dict) -> tuple[list[str], dict[int, int]]:
+    """Every clip, then the master, then one silence source per clip that has no audio.
+
+    Returns the -i arguments and, for those silent clips, the input index standing in
+    for them, so the sound graph can reach them by number.
+    """
+    args: list[str] = []
+    for shot in job["shots"]:
+        args += ["-i", str(shot["clip"])]
+    args += ["-i", str(job["master"])]
+
+    silence: dict[int, int] = {}
+    if job["sound"]:
+        master_audio = streams(job["master_info"], "audio")[0]
+        source = f"anullsrc=channel_layout={audio_layout(master_audio)}:sample_rate={master_audio['sample_rate']}"
+        for index, shot in enumerate(job["shots"]):
+            if shot["has_audio"]:
+                continue
+            silence[index] = len(job["shots"]) + 1 + len(silence)
+            args += ["-f", "lavfi", "-t", f"{shot['span'] / job['fps']:.9f}", "-i", source]
+    return args, silence
+
+
+def sound_graph(job: dict, silence: dict[int, int]) -> str:
+    """The clips' own audio, cut to the same spans as the picture and mixed under the master.
+
+    The master enters amix first at unity with normalize=0, so nothing rescales it:
+    the gain rides on the bed alone.
+    """
+    master_audio = streams(job["master_info"], "audio")[0]
+    conform = (
+        f"aformat=sample_fmts=fltp:sample_rates={master_audio['sample_rate']}"
+        f":channel_layouts={audio_layout(master_audio)}"
+    )
+    parts, labels = [], []
+    for index, shot in enumerate(job["shots"]):
+        seconds = shot["span"] / job["fps"]
+        if shot["has_audio"]:
+            head = shot["head"] / job["fps"]
+            source = f"[{index}:a]atrim=start={head:.9f}:end={head + seconds:.9f},asetpts=PTS-STARTPTS,"
+        else:
+            source = f"[{silence[index]}:a]"
+        labels.append(f"[a{index}]")
+        # apad before the final atrim: a clip whose audio stops short of its picture
+        # would otherwise pull every later shot's sound early.
+        parts.append(f"{source}{conform},apad,atrim=end={seconds:.9f},asetpts=PTS-STARTPTS[a{index}]")
+    parts.append(f"{''.join(labels)}concat=n={len(labels)}:v=0:a=1[bed]")
+    parts.append(f"[bed]volume={job['sound']}[bedgain]")
+    parts.append(f"[{len(job['shots'])}:a:0]{conform}[master]")
+    parts.append("[master][bedgain]amix=inputs=2:duration=first:normalize=0[aout]")
+    return ";".join(parts)
+
+
+def measure(args: list[str], graph: str, label: str) -> dict[str, float]:
+    """Peak level in dBFS and sample count of one graph output, from a single decode.
+
+    The stats run on float samples, so an over reads above 0 instead of being clamped
+    out of sight. Overall values accumulate frame by frame, so the largest is the total.
+    """
+    printed = run(
+        ["ffmpeg", "-v", "error", *args, "-filter_complex",
+         f"{graph};[{label}]astats=metadata=1:reset=0:measure_perchannel=none"
+         ":measure_overall=Peak_level+Number_of_samples,ametadata=mode=print:file=-[stats]",
+         "-map", "[stats]", "-f", "null", "-"]
+    ).decode("utf-8", "replace")
+    stats: dict[str, float] = {}
+    for line in printed.splitlines():
+        name, _, value = line.partition("=")
+        key = name.removeprefix("lavfi.astats.Overall.")
+        if key == name:
+            continue
+        try:
+            stats[key] = max(stats.get(key, float("-inf")), float(value))
+        except ValueError:
+            continue
+    if "Peak_level" not in stats or "Number_of_samples" not in stats:
+        raise BuildError("ffmpeg reported no audio statistics, so the mix could not be checked")
+    return stats
+
+
+def check_headroom(job: dict) -> dict[str, float]:
+    """Measure the mix before paying for the video encode, and never reshape the song to fit."""
+    args, silence = inputs(job)
+    stats = measure(args, sound_graph(job, silence), "aout")
+    peak = stats["Peak_level"]
+    if peak > 0:
+        master_peak = measure(["-i", str(job["master"])], "[0:a:0]anull[m]", "m")["Peak_level"]
+        if master_peak > -0.1:
+            raise BuildError(
+                f"the master already peaks at {master_peak:.2f} dBFS, so any bed clips it. "
+                f'Deliver without "sound", or supply a master with headroom.'
+            )
+        raise BuildError(
+            f'the mix peaks at {peak:.2f} dBFS and would clip. Lower "sound" from {job["sound"]} '
+            f"to about {job['sound'] * 10 ** (-peak / 20):.3f} and build again."
+        )
+    return {"peak_dbfs": peak, "samples": stats["Number_of_samples"]}
+
+
 def render(job: dict, output: Path, crf: int) -> str:
     master_codec = streams(job["master_info"], "audio")[0]["codec_name"]
-    copyable = master_codec in COPYABLE
+    copyable = master_codec in COPYABLE and not job["sound"]
     audio_index = len(job["shots"])
+    args, silence = inputs(job)
 
-    command = ["ffmpeg", "-y", "-v", "error"]
-    for shot in job["shots"]:
-        command += ["-i", str(shot["clip"])]
-    command += ["-i", str(job["master"])]
+    graph = filter_graph(job)
+    if job["sound"]:
+        graph = f"{graph};{sound_graph(job, silence)}"
+
+    command = ["ffmpeg", "-y", "-v", "error", *args]
     command += [
-        "-filter_complex", filter_graph(job),
+        "-filter_complex", graph,
         "-map", "[vout]",
-        "-map", f"{audio_index}:a:0",
+        "-map", "[aout]" if job["sound"] else f"{audio_index}:a:0",
         # No -frames:v here. It ends the whole output once the video hits the limit, which
         # truncates the master whenever the audio runs past the last video frame. The trim
         # filter in the graph already fixes the count exactly.
@@ -212,7 +353,9 @@ def render(job: dict, output: Path, crf: int) -> str:
 
     output.parent.mkdir(parents=True, exist_ok=True)
     run(command)
-    return "copy" if copyable else "aac_320k"
+    if copyable:
+        return "copy"
+    return "mix_aac_320k" if job["sound"] else "aac_320k"
 
 
 def verify(job: dict, output: Path, audio_mode: str, master_sha_before: str) -> dict:
@@ -245,9 +388,12 @@ def verify(job: dict, output: Path, audio_mode: str, master_sha_before: str) -> 
         # There is nothing to compare bit for bit, but it must still be a single pass.
         checks["audio_encoded_once"] = audio[0]["codec_name"] == "aac"
 
-    master_duration = job["master_duration"]
-    final_audio_duration = float(audio[0].get("duration", master_duration))
-    checks["audio_duration_preserved"] = abs(final_audio_duration - master_duration) <= 1.0 / job["fps"]
+    # A mix delivers decoded samples, so it lands on the master's true length; the container
+    # duration of an MP3 counts the encoder's padding on top of it and would read as a drift.
+    mix = job.get("mix")
+    expected_audio = mix["samples"] / int(master_audio["sample_rate"]) if mix else job["master_duration"]
+    final_audio_duration = float(audio[0].get("duration", expected_audio))
+    checks["audio_duration_preserved"] = abs(final_audio_duration - expected_audio) <= 1.0 / job["fps"]
 
     checks["master_untouched"] = sha256_file(job["master"]) == master_sha_before
 
@@ -262,7 +408,7 @@ def verify(job: dict, output: Path, audio_mode: str, master_sha_before: str) -> 
             "video_codec": video[0]["codec_name"],
             "audio_codec": audio[0]["codec_name"],
             "audio_mode": audio_mode,
-            "master_duration_seconds": round(master_duration, 6),
+            "master_duration_seconds": round(job["master_duration"], 6),
             "output_duration_seconds": round(float(info["format"]["duration"]), 6),
         },
     }
@@ -273,10 +419,15 @@ def build(edit_path: Path, output: Path, root: Path | None = None, crf: int = 18
     root = Path(root) if root else edit_path.parent
     job = plan(load_edit(edit_path), root)
     master_sha = sha256_file(job["master"])
+    if job["sound"]:
+        job["mix"] = check_headroom(job)
     audio_mode = render(job, Path(output), crf)
     report = verify(job, Path(output), audio_mode, master_sha)
     report["output"] = str(output)
     report["master_sha256"] = master_sha
+    if job["sound"]:
+        report["detail"]["sound_gain"] = job["sound"]
+        report["detail"]["mix_peak_dbfs"] = round(job["mix"]["peak_dbfs"], 2)
     report["shots"] = [
         {
             "clip": shot["clip"].name,

--- a/skills/scenario-seedance-music-video/scripts/build.py
+++ b/skills/scenario-seedance-music-video/scripts/build.py
@@ -251,11 +251,12 @@ def inputs(job: dict) -> tuple[list[str], dict[int, int]]:
     return args, silence
 
 
-def sound_graph(job: dict, silence: dict[int, int]) -> str:
+def sound_graph(job: dict, silence: dict[int, int], mix: bool = True) -> str:
     """The clips' own audio, cut to the same spans as the picture and mixed under the master.
 
     The master enters amix first at unity with normalize=0, so nothing rescales it:
-    the gain rides on the bed alone.
+    the gain rides on the bed alone. With mix off the graph stops at the gained bed,
+    which is what a failed headroom check measures to size the gain that would fit.
     """
     master_audio = streams(job["master_info"], "audio")[0]
     conform = (
@@ -276,9 +277,16 @@ def sound_graph(job: dict, silence: dict[int, int]) -> str:
         parts.append(f"{source}{conform},apad,atrim=end={seconds:.9f},asetpts=PTS-STARTPTS[a{index}]")
     parts.append(f"{''.join(labels)}concat=n={len(labels)}:v=0:a=1[bed]")
     parts.append(f"[bed]volume={job['sound']}[bedgain]")
+    if not mix:
+        return ";".join(parts)
     parts.append(f"[{len(job['shots'])}:a:0]{conform}[master]")
     parts.append("[master][bedgain]amix=inputs=2:duration=first:normalize=0[aout]")
     return ";".join(parts)
+
+
+def level(dbfs: float) -> float:
+    """A dBFS reading as a linear amplitude, where full scale is 1."""
+    return 10 ** (dbfs / 20)
 
 
 def measure(args: list[str], graph: str, label: str) -> dict[str, float]:
@@ -314,15 +322,21 @@ def check_headroom(job: dict) -> dict[str, float]:
     stats = measure(args, sound_graph(job, silence), "aout")
     peak = stats["Peak_level"]
     if peak > 0:
+        # Scaling the whole mix down would be the wrong sum: the master rides at unity and
+        # only the bed carries the gain, so the gain that fits is the one leaving the bed
+        # exactly the room the master's own peak does not use.
         master_peak = measure(["-i", str(job["master"])], "[0:a:0]anull[m]", "m")["Peak_level"]
-        if master_peak > -0.1:
+        master_level = level(master_peak)
+        bed_level = level(measure(args, sound_graph(job, silence, mix=False), "bedgain")["Peak_level"])
+        room = level(-0.3) - master_level
+        if room <= 0 or bed_level <= 0:
             raise BuildError(
                 f"the master already peaks at {master_peak:.2f} dBFS, so any bed clips it. "
                 f'Deliver without "sound", or supply a master with headroom.'
             )
         raise BuildError(
             f'the mix peaks at {peak:.2f} dBFS and would clip. Lower "sound" from {job["sound"]} '
-            f"to about {job['sound'] * 10 ** (-peak / 20):.3f} and build again."
+            f"to at most {job['sound'] * room / bed_level:.3f} and build again."
         )
     return {"peak_dbfs": peak, "samples": stats["Number_of_samples"]}
 

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -16,14 +16,14 @@ Connection and the core loop: see the `scenario` skill in this repo; model-agnos
 
 Mode follows from the inputs (names from the live schema):
 
-| Mode         | Inputs                              | Behavior                                                              |
-| ------------ | ----------------------------------- | --------------------------------------------------------------------- |
-| Text         | `prompt`                            | `aspectRatio` honored (21:9 through 9:16)                             |
-| First frame  | `image` (+ `prompt`)                | opens on that frame; `aspectRatio` ignored, size follows `resolution` |
-| First + last | `image` + `lastFrameImage`          | `lastFrameImage` is only valid alongside `image`                      |
-| Reference    | `referenceImages`                   | carries identity and world, not the opening state                     |
-| Edit         | `referenceVideos` + edit prompt     | requires `duration: -1`; output follows the source                    |
-| Extend       | `referenceVideos` + boundary prompt | continues the clip; geometry follows the source                       |
+| Mode         | Inputs                              | Behavior                                                                                               |
+| ------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Text         | `prompt`                            | `aspectRatio` honored (21:9 through 9:16)                                                              |
+| First frame  | `image` (+ `prompt`)                | opens on that frame; `aspectRatio` ignored, size follows `resolution` and may land only near the ratio |
+| First + last | `image` + `lastFrameImage`          | `lastFrameImage` is only valid alongside `image`                                                       |
+| Reference    | `referenceImages`                   | carries identity and world, not the opening state                                                      |
+| Edit         | `referenceVideos` + edit prompt     | requires `duration: -1`; output follows the source                                                     |
+| Extend       | `referenceVideos` + boundary prompt | continues the clip; geometry follows the source                                                        |
 
 `image` and the reference arrays are mutually exclusive. `referenceVideos` and `referenceAudio` (timing and energy conditioning) combine with `referenceImages`; on the 2.0 line reference audio also requires one image or video reference, where 2.5 takes it alone. Reference parameters are arrays even for one asset. Prompt tags bind by array order: `@image1` is `referenceImages[0]`, likewise `@video1` and `@audio1`. No seed, mask, or camera parameter exists: camera moves live in the prompt, one dominant move per shot.
 

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-seedance
-description: "Use when generating or editing video with Seedance models on Scenario via MCP: text-to-video, image-to-video from a first frame, first and last frame anchors, reference-to-video with identity, product, or world references, prompt-based video editing, extending a clip, audio-conditioned motion, keeping native sound while the music is scored elsewhere, or deciding between first-frame and reference conditioning. Keywords: Seedance 2.5, Seedance 2.0, ByteDance, T2V, I2V, V2V, multimodal references, native audio, video extension."
+description: "Use when generating or editing video with Seedance models on Scenario via MCP: text-to-video, image-to-video from a first frame, first and last frame anchors, reference-to-video with identity, product, or world references, prompt-based editing, extending a clip, audio-conditioned motion, shot sound without music, or deciding between first-frame and reference conditioning. Keywords: Seedance 2.5 and 2.0, ByteDance, T2V, I2V, V2V, multimodal references, native audio, video extension."
 license: MIT
 ---
 
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Seedance, ByteDance's video family on Scenario, folds text-to-video, first/last frame, reference-to-video, editing, and extension into one model that infers the mode from your inputs and prompt, so the conditioning you pass decides more than prompt wording does. Discover it with `search` and treat `model_schema_get` as the contract: members ship side by side, agreeing on the shape and disagreeing on every number.
+Seedance, ByteDance's video family on Scenario, folds text-to-video, first/last frame, reference-to-video, editing, and extension into one model that infers the mode from your inputs, so the conditioning you pass decides more than prompt wording. Discover it with `search` and treat `model_schema_get` as the contract: members ship side by side, agreeing on the shape and disagreeing on every number.
 
 Connection and the core generation loop: see the `scenario` skill in this repo. Model-agnostic video work: see the `scenario-video` skill in this repo.
 
@@ -27,7 +27,7 @@ Mode follows from the inputs (names from the live schema):
 
 `image` and the reference arrays are mutually exclusive. `referenceVideos` and `referenceAudio` (timing and energy conditioning) combine with `referenceImages`; on the 2.0 line reference audio also requires one image or video reference, where 2.5 takes it alone. Reference parameters are arrays even for one asset. Prompt tags bind by array order: `@image1` is `referenceImages[0]`, likewise `@video1` and `@audio1`. No seed, mask, or camera parameter exists: camera moves live in the prompt, one dominant move per shot.
 
-Caps are per member, so read them off `model_schema_get`. At authoring time 2.5 took 30 reference images, 10 videos, 10 audio, and 4 to 30 seconds at 480p or 720p, against 9, 3, 3, and 4 to 15 seconds on the 2.0, Fast, and Mini hits, with 1080p and 4k on 2.0 alone and no `lastFrameImage` on Mini.
+Caps are per member, so read them off `model_schema_get`. At authoring time 2.5 took 30 reference images, 10 videos, 10 audio, 4 to 30 seconds, 480p or 720p; the 2.0, Fast, and Mini hits took 9, 3, 3, and 4 to 15, with 1080p and 4k on 2.0 alone and no `lastFrameImage` on Mini.
 
 ## The conditioning rule
 
@@ -39,7 +39,7 @@ In reference mode, frame one anchors to the base state of the reference world, a
 
 So run the lanes apart. Keep `generateAudio: true` for what the picture makes, footsteps, impacts, room tone, dialogue, each landing on frame, and exclude the score in the prompt ("diegetic sound only, no music, no score"). Score the sequence once with a music model (see the `scenario-audio` skill) and lay that track over the assembled cut (see the `scenario-video-assembly` skill, or `scenario-seedance-music-video` when the song comes first): re-scoring then costs one audio run, not every shot again.
 
-The prompt is the only lever here, so listen to what comes back: when music leaks in anyway, re-run that shot with `generateAudio: false` and add sound from a sound-effects or video-to-audio model.
+The prompt is the only lever, so listen to what comes back: when music leaks in anyway, re-run that shot with `generateAudio: false` and add sound from a sound-effects or video-to-audio model.
 
 ## Worked example: a product shot from references
 
@@ -48,7 +48,7 @@ The prompt is the only lever here, so listen to what comes back: when music leak
 3. `upload_asset` the product stills (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. Diegetic sound only, no music. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": true}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
 5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
-6. `asset_display` the output and watch it with sound before the music goes on. For a file, `asset_download` with no `format` returns a download URL; fetch it with `curl -L`.
+6. `asset_display` the output and watch it with sound before the music goes on.
 
 ## Common mistakes
 

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-seedance
-description: "Use when generating or editing video with Seedance models on Scenario via MCP: text-to-video, image-to-video from a first frame, first and last frame anchors, reference-to-video with identity, product, or world references, prompt-based video editing, extending a clip, audio-conditioned motion, or deciding between first-frame and reference conditioning. Keywords: Seedance 2.5, ByteDance, T2V, I2V, V2V, multimodal references, video extension."
+description: "Use when generating or editing video with Seedance models on Scenario via MCP: text-to-video, image-to-video from a first frame, first and last frame anchors, reference-to-video with identity, product, or world references, prompt-based video editing, extending a clip, audio-conditioned motion, keeping native sound while the music is scored elsewhere, or deciding between first-frame and reference conditioning. Keywords: Seedance 2.5, Seedance 2.0, ByteDance, T2V, I2V, V2V, multimodal references, native audio, video extension."
 license: MIT
 ---
 
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Seedance, ByteDance's video family on Scenario, folds text-to-video, first/last frame, reference-to-video, editing, and extension into one model that infers the mode from your inputs and prompt, so the conditioning inputs you pass decide more than prompt wording does. Discover it with `search` and treat `model_schema_get` as the contract: the family evolves and availability differs per team.
+Seedance, ByteDance's video family on Scenario, folds text-to-video, first/last frame, reference-to-video, editing, and extension into one model that infers the mode from your inputs and prompt, so the conditioning you pass decides more than prompt wording does. Discover it with `search` and treat `model_schema_get` as the contract: members ship side by side, agreeing on the shape and disagreeing on every number.
 
 Connection and the core generation loop: see the `scenario` skill in this repo. Model-agnostic video work: see the `scenario-video` skill in this repo.
 
@@ -21,24 +21,34 @@ Mode follows from the inputs (names from the live schema):
 | Text         | `prompt`                            | `aspectRatio` honored (21:9 through 9:16)          |
 | First frame  | `image` (+ `prompt`)                | opens on that frame; `aspectRatio` ignored         |
 | First + last | `image` + `lastFrameImage`          | `lastFrameImage` is only valid alongside `image`   |
-| Reference    | `referenceImages` (up to 30)        | carries identity and world, not the opening state  |
+| Reference    | `referenceImages`                   | carries identity and world, not the opening state  |
 | Edit         | `referenceVideos` + edit prompt     | requires `duration: -1`; output follows the source |
 | Extend       | `referenceVideos` + boundary prompt | continues the clip; geometry follows the source    |
 
-`image` and the reference arrays are mutually exclusive. `referenceVideos` (up to 10) and `referenceAudio` (up to 10, timing and energy conditioning) combine with `referenceImages`. Reference parameters are arrays even for one asset. Prompt tags bind by array order: `@image1` is `referenceImages[0]`; likewise `@video1`, `@audio1`. Duration: 4 to 30 seconds or -1 auto (the longest reference clip's length). Resolution: `480p` or `720p`. `generateAudio` defaults to true. No seed, mask, or camera parameter exists: camera moves live in the prompt, one dominant move per shot.
+`image` and the reference arrays are mutually exclusive. `referenceVideos` and `referenceAudio` (timing and energy conditioning) combine with `referenceImages`; on the 2.0 line reference audio also requires one image or video reference, where 2.5 takes it alone. Reference parameters are arrays even for one asset. Prompt tags bind by array order: `@image1` is `referenceImages[0]`, likewise `@video1` and `@audio1`. No seed, mask, or camera parameter exists: camera moves live in the prompt, one dominant move per shot.
+
+Caps are per member, so read them off `model_schema_get`. At authoring time 2.5 took 30 reference images, 10 videos, 10 audio, and 4 to 30 seconds at 480p or 720p, against 9, 3, 3, and 4 to 15 seconds on the 2.0, Fast, and Mini hits, with 1080p and 4k on 2.0 alone and no `lastFrameImage` on Mini.
 
 ## The conditioning rule
 
 In reference mode, frame one anchors to the base state of the reference world, and no prompt wording overrides it. If the shot must open in a specific state, render a still of it and pass it as `image`; use `referenceImages` when only identity, world, and palette matter. Deciding this per shot before generating is worth more than any prompt tuning.
+
+## Sound from the shot, music from elsewhere
+
+`generateAudio` (default true) is one switch over the whole track: it scores the shot as well as sounding it, and no field separates the two. A score written inside a shot survives no cut, since each shot invents its own key and tempo and the next one restarts them.
+
+So run the lanes apart. Keep `generateAudio: true` for what the picture makes, footsteps, impacts, room tone, dialogue, each landing on frame, and exclude the score in the prompt ("diegetic sound only, no music, no score"). Score the sequence once with a music model (see the `scenario-audio` skill) and lay that track over the assembled cut (see the `scenario-video-assembly` skill, or `scenario-seedance-music-video` when the song comes first): re-scoring then costs one audio run, not every shot again.
+
+The prompt is the only lever here, so listen to what comes back: when music leaks in anyway, re-run that shot with `generateAudio: false` and add sound from a sound-effects or video-to-audio model.
 
 ## Worked example: a product shot from references
 
 1. `search` with `target="models"`, `query="seedance"`, `public=true`. Prefer the newest non-deprecated hit, e.g. `model_bytedance-seedance-2-5` (a live hit at authoring time: re-discover each session).
 2. `model_schema_get` with that id: confirm fields, caps, and defaults first.
 3. `upload_asset` the product stills (see the `scenario` skill) to get asset ids.
-4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": false}}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
+4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. Diegetic sound only, no music. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": true}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
 5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
-6. `asset_display` the output. For a file, `asset_download` with no `format` returns a download URL; fetch it with `curl -L` (`format` converts image formats only).
+6. `asset_display` the output and watch it with sound before the music goes on. For a file, `asset_download` with no `format` returns a download URL; fetch it with `curl -L`.
 
 ## Common mistakes
 
@@ -46,6 +56,6 @@ In reference mode, frame one anchors to the base state of the reference world, a
 - A bare string where the schema says array: one reference still goes as `["asset_x"]`.
 - Combining `image` with `referenceImages` or `referenceVideos`: mutually exclusive inputs.
 - Edit mode with a fixed duration: editing requires `duration: -1`.
-- Setting `aspectRatio` in first-frame, edit, or extend modes: ignored; geometry follows the input.
-- Leaving `generateAudio` at its default (true) when the soundtrack comes later.
+- Carrying one member's caps to another: 30 references, 30 seconds, and 1080p are each true of one and false of the next.
+- Letting shots score themselves and then cutting them together: the music restarts at every cut.
 - Rendering captions, prices, logos, or UI: reserve clean space and composite text in post.

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -8,26 +8,26 @@ license: MIT
 
 ## Overview
 
-Seedance, ByteDance's video family on Scenario, folds text-to-video, first/last frame, reference-to-video, editing, and extension into one model that infers the mode from your inputs, so the conditioning you pass decides more than prompt wording. Discover it with `search` and treat `model_schema_get` as the contract: members ship side by side, agreeing on the shape and disagreeing on every number.
+Seedance, ByteDance's video family on Scenario, folds every mode below into one model that infers which from your inputs, so the conditioning you pass decides more than prompt wording. Discover it with `search` and treat `model_schema_get` as the contract: members ship side by side, agreeing on the shape and disagreeing on every number.
 
-Connection and the core generation loop: see the `scenario` skill in this repo. Model-agnostic video work: see the `scenario-video` skill in this repo.
+Connection and the core loop: see the `scenario` skill in this repo; model-agnostic video work: the `scenario-video` skill.
 
 ## Quick reference
 
 Mode follows from the inputs (names from the live schema):
 
-| Mode         | Inputs                              | Behavior                                           |
-| ------------ | ----------------------------------- | -------------------------------------------------- |
-| Text         | `prompt`                            | `aspectRatio` honored (21:9 through 9:16)          |
-| First frame  | `image` (+ `prompt`)                | opens on that frame; `aspectRatio` ignored         |
-| First + last | `image` + `lastFrameImage`          | `lastFrameImage` is only valid alongside `image`   |
-| Reference    | `referenceImages`                   | carries identity and world, not the opening state  |
-| Edit         | `referenceVideos` + edit prompt     | requires `duration: -1`; output follows the source |
-| Extend       | `referenceVideos` + boundary prompt | continues the clip; geometry follows the source    |
+| Mode         | Inputs                              | Behavior                                                              |
+| ------------ | ----------------------------------- | --------------------------------------------------------------------- |
+| Text         | `prompt`                            | `aspectRatio` honored (21:9 through 9:16)                             |
+| First frame  | `image` (+ `prompt`)                | opens on that frame; `aspectRatio` ignored, size follows `resolution` |
+| First + last | `image` + `lastFrameImage`          | `lastFrameImage` is only valid alongside `image`                      |
+| Reference    | `referenceImages`                   | carries identity and world, not the opening state                     |
+| Edit         | `referenceVideos` + edit prompt     | requires `duration: -1`; output follows the source                    |
+| Extend       | `referenceVideos` + boundary prompt | continues the clip; geometry follows the source                       |
 
 `image` and the reference arrays are mutually exclusive. `referenceVideos` and `referenceAudio` (timing and energy conditioning) combine with `referenceImages`; on the 2.0 line reference audio also requires one image or video reference, where 2.5 takes it alone. Reference parameters are arrays even for one asset. Prompt tags bind by array order: `@image1` is `referenceImages[0]`, likewise `@video1` and `@audio1`. No seed, mask, or camera parameter exists: camera moves live in the prompt, one dominant move per shot.
 
-Caps are per member, so read them off `model_schema_get`. At authoring time 2.5 took 30 reference images, 10 videos, 10 audio, 4 to 30 seconds, 480p or 720p; the 2.0, Fast, and Mini hits took 9, 3, 3, and 4 to 15, with 1080p and 4k on 2.0 alone and no `lastFrameImage` on Mini.
+Caps are per member, so read them off `model_schema_get`. At authoring time 2.5 took 30 reference images, 10 videos, 10 audio, 4 to 30 seconds, 480p or 720p; the 2.0, Fast, and Mini hits took 9, 3, 3, and 4 to 15, with 1080p and 4k on 2.0 alone and no `lastFrameImage` on Mini. Price moves further than the caps do, six times across the family for one 4 second 480p job, so `dry_run` the same job on two members before a batch.
 
 ## The conditioning rule
 
@@ -35,7 +35,7 @@ In reference mode, frame one anchors to the base state of the reference world, a
 
 ## Sound from the shot, music from elsewhere
 
-`generateAudio` (default true) is one switch over the whole track: it scores the shot as well as sounding it, and no field separates the two. A score written inside a shot survives no cut, since each shot invents its own key and tempo and the next one restarts them.
+`generateAudio` (default true) is one switch over the whole track: it scores the shot as well as sounding it. A score written inside a shot survives no cut, since each shot invents its own key and tempo and the next one restarts them.
 
 So run the lanes apart. Keep `generateAudio: true` for what the picture makes, footsteps, impacts, room tone, dialogue, each landing on frame, and exclude the score in the prompt ("diegetic sound only, no music, no score"). Score the sequence once with a music model (see the `scenario-audio` skill) and lay that track over the assembled cut (see the `scenario-video-assembly` skill, or `scenario-seedance-music-video` when the song comes first): re-scoring then costs one audio run, not every shot again.
 
@@ -44,7 +44,7 @@ The prompt is the only lever, so listen to what comes back: when music leaks in 
 ## Worked example: a product shot from references
 
 1. `search` with `target="models"`, `query="seedance"`, `public=true`. Prefer the newest non-deprecated hit, e.g. `model_bytedance-seedance-2-5` (a live hit at authoring time: re-discover each session).
-2. `model_schema_get` with that id: confirm fields, caps, and defaults first.
+2. `model_schema_get` with that id: fields, caps, and defaults before anything else.
 3. `upload_asset` the product stills (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. Diegetic sound only, no music. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": true}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
 5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
@@ -55,7 +55,6 @@ The prompt is the only lever, so listen to what comes back: when music leaks in 
 - Prompting an opening state in reference mode: it will not appear; pass it as `image`.
 - A bare string where the schema says array: one reference still goes as `["asset_x"]`.
 - Combining `image` with `referenceImages` or `referenceVideos`: mutually exclusive inputs.
-- Edit mode with a fixed duration: editing requires `duration: -1`.
-- Carrying one member's caps to another: 30 references, 30 seconds, and 1080p are each true of one and false of the next.
+- Carrying one member's caps or price to another: 30 references, 30 seconds, and 1080p are each true of one and false of the next.
 - Letting shots score themselves and then cutting them together: the music restarts at every cut.
 - Rendering captions, prices, logos, or UI: reserve clean space and composite text in post.

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Scenario (scenario.com) generates AI images, video, 3D, and audio across 500+ models plus custom model training; its MCP server exposes the full pipeline; the Quick reference below is the core loop.
+Scenario (scenario.com) generates AI images, video, 3D, and audio across 500+ models plus custom training; its MCP server exposes the full pipeline; the core loop is below.
 
 ## Setup
 
@@ -20,7 +20,7 @@ The default toolset is the core loop below; `?toolsets=full` exposes everything.
 
 Resolve scope first, then pass `team_id` and `project_id` on every later call. `teams_list` returns the teams with their projects; `projects_list` requires a `team_id`, so it cannot come first. Confirm the pair with the user rather than picking.
 
-The server fills scope in only for read-only tools, and only while one candidate remains, so an unresolved scope fails the call rather than guessing, and the error names which half is wrong. `context_missing` means nothing resolved: run `teams_list`, then `projects_list`. `context_ambiguous` means several fit: present them and let the user choose, because a guess here writes assets into someone else's project. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices. Together these are the most common failure across every tool below, and they surface mid-session on the first call that drops the pair once a second team or project is in play. A Forbidden error usually means wrong scope rather than missing scope.
+The server fills scope in only for read-only tools while one candidate remains, so an unresolved scope fails rather than guessing, and the error names which half is wrong. `context_missing` means nothing resolved: run `teams_list`, then `projects_list`. `context_ambiguous` means several fit: present them and let the user choose, because a guess here writes assets into someone else's project. A non-interactive run takes the pair from its task instructions; when they name none, stop and list the choices. These are the most common failure across every tool below, surfacing mid-session on the first call that drops the pair once a second team or project is in play. A Forbidden error usually means wrong scope rather than missing scope.
 
 ## Quick reference
 
@@ -45,7 +45,7 @@ Generating a stylized game prop image:
 3. If the schema carries `runs_as` (`"lora"` or `"composition"`), never send that model's own id to `model_run`. Its `run_with.required_arguments` holds the real call: `model_id` there is the base model, and its `parameters` (the `loras` or `modelId` wiring) merge into inputs from the same schema. Sending `required_arguments` alone discards your prompt.
 4. Optional: `prompt_spark` rewrites a thin prompt into an on-model one; pass the discovered id (for a LoRA, its own, not the base) and your draft as `prompt`. Skip a deliberate prompt.
 5. `model_run` with `model_id` and schema-conformant `parameters`. Returns asset_ids, or `status="in_progress"` with a `job_id`.
-6. `jobs_wait` with `job_ids=[...]` (up to 32). A timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`.
+6. `jobs_wait` with `job_ids=[...]` (up to 32). A timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`. Failed jobs are reimbursed, except xAI generations stopped by moderation.
 7. `asset_display` shows the asset inline. `asset_download` returns a file URL. Save it with `curl -L`, it may redirect. `format` is an image conversion (`png`, `webp`, `jpg`) and nothing else: any other value returns 400 `Invalid target format`, so omit `format` entirely for video, 3D, and audio.
 
 Local inputs go up with `upload_asset`, which always needs `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Prefer multipart: add `file_size`, follow the returned `instructions` to PUT every part URL, then `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both; beyond the fields named here they take nothing: no parts list, no etags.

--- a/tests/scenario-seedance-music-video/helpers.py
+++ b/tests/scenario-seedance-music-video/helpers.py
@@ -16,23 +16,40 @@ def ffmpeg(args: list[str]) -> None:
     subprocess.run(["ffmpeg", "-v", "error", "-y", *args], check=True, capture_output=True)
 
 
-def make_clip(path: Path, seconds: float, color: str = "blue", fps: int = 24, size: str = "320x240") -> Path:
-    ffmpeg(
-        [
-            "-f", "lavfi", "-i", f"color=c={color}:s={size}:r={fps}:d={seconds}",
-            "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", str(path),
+def make_clip(
+    path: Path,
+    seconds: float,
+    color: str = "blue",
+    fps: int = 24,
+    size: str = "320x240",
+    tone: int | None = None,
+    gain: float = 1.0,
+) -> Path:
+    """A flat colour clip. With a tone it also carries its own audio, as a generated shot does."""
+    args = ["-f", "lavfi", "-i", f"color=c={color}:s={size}:r={fps}:d={seconds}"]
+    if tone is not None:
+        args += [
+            "-f", "lavfi", "-i", f"sine=frequency={tone}:duration={seconds}",
+            "-filter_complex", f"[1:a]volume={gain},aformat=channel_layouts=stereo[a]",
+            "-map", "0:v", "-map", "[a]", "-c:a", "aac",
         ]
-    )
+    args += ["-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", str(path)]
+    ffmpeg(args)
     return path
 
 
-def make_master(path: Path, seconds: float = 4.0, codec: str = "mp3") -> Path:
+def make_master(path: Path, seconds: float = 4.0, codec: str = "mp3", gain: float = 1.0) -> Path:
     codec_args = {
         "mp3": ["-c:a", "libmp3lame", "-b:a", "128k"],
         "wav": ["-c:a", "pcm_s16le"],
         "aac": ["-c:a", "aac", "-b:a", "128k"],
     }[codec]
-    ffmpeg(["-f", "lavfi", "-i", f"sine=frequency=440:duration={seconds}", "-ac", "2", *codec_args, str(path)])
+    ffmpeg(
+        [
+            "-f", "lavfi", "-i", f"sine=frequency=440:duration={seconds}",
+            "-af", f"volume={gain}", "-ac", "2", *codec_args, str(path),
+        ]
+    )
     return path
 
 

--- a/tests/scenario-seedance-music-video/test_build.py
+++ b/tests/scenario-seedance-music-video/test_build.py
@@ -142,6 +142,83 @@ class BuildTestCase(unittest.TestCase):
         self.assertTrue(report["passed"], report["checks"])
         self.assertEqual(report["detail"]["size"], "320x240")
 
+    # the clips' own sound, mixed under the master
+
+    def test_sound_mixes_the_clips_under_the_master(self) -> None:
+        make_clip(self.root / "sa.mp4", 3.0, "blue", tone=880)
+        make_clip(self.root / "sb.mp4", 3.0, "red", tone=660)
+        edit = write_edit(
+            self.root / "edit.json", "master.mp3",
+            [{"clip": "sa.mp4", "at": 0}, {"clip": "sb.mp4", "at": 2.0}],
+            sound=0.25,
+        )
+        report = build.build(edit, self.root / "out.mp4", self.root)
+
+        self.assertTrue(report["passed"], report["checks"])
+        self.assertEqual(report["detail"]["audio_mode"], "mix_aac_320k")
+        self.assertTrue(report["checks"]["audio_encoded_once"])
+        self.assertTrue(report["checks"]["master_untouched"])
+        self.assertEqual(report["detail"]["sound_gain"], 0.25)
+
+        # The bed is audible: the mix sits above the master's own peak, and under full scale.
+        alone = build.measure(["-i", str(self.master)], "[0:a:0]anull[m]", "m")["Peak_level"]
+        self.assertGreater(report["detail"]["mix_peak_dbfs"], alone)
+        self.assertLess(report["detail"]["mix_peak_dbfs"], 0)
+
+    def test_a_clip_without_audio_is_covered_by_silence(self) -> None:
+        make_clip(self.root / "sa.mp4", 3.0, "blue", tone=880)
+        edit = write_edit(
+            self.root / "edit.json", "master.mp3",
+            [{"clip": "sa.mp4", "at": 0}, {"clip": "b.mp4", "at": 2.0}],
+            sound=0.25,
+        )
+        report = build.build(edit, self.root / "out.mp4", self.root)
+        self.assertTrue(report["passed"], report["checks"])
+        self.assertEqual(report["detail"]["frames"], report["detail"]["expected_frames"])
+
+    def test_a_mix_that_would_clip_is_refused_before_rendering(self) -> None:
+        make_master(self.root / "hot.mp3", 4.0, gain=7)
+        make_clip(self.root / "hot.mp4", 3.0, "blue", tone=880, gain=7)
+        edit = write_edit(
+            self.root / "edit.json", "hot.mp3",
+            [{"clip": "hot.mp4", "at": 0}, {"clip": "b.mp4", "at": 2.0}],
+            sound=1.0,
+        )
+        out = self.root / "clipped.mp4"
+        with self.assertRaisesRegex(build.BuildError, "would clip"):
+            build.build(edit, out, self.root)
+        self.assertFalse(out.exists())
+
+    def test_a_master_without_headroom_is_named_as_the_cause(self) -> None:
+        make_master(self.root / "full.wav", 4.0, codec="wav", gain=16)
+        make_clip(self.root / "hot.mp4", 3.0, "blue", tone=880, gain=7)
+        edit = write_edit(
+            self.root / "edit.json", "full.wav",
+            [{"clip": "hot.mp4", "at": 0}, {"clip": "b.mp4", "at": 2.0}],
+            sound=0.2,
+        )
+        with self.assertRaisesRegex(build.BuildError, "master already peaks"):
+            build.build(edit, self.root / "clipped.mp4", self.root)
+
+    def test_sound_with_no_clip_audio_anywhere_is_rejected(self) -> None:
+        with self.assertRaisesRegex(build.BuildError, "nothing to mix"):
+            self.plan_for(
+                [{"clip": "a.mp4", "at": 0}, {"clip": "b.mp4", "at": 2.0}],
+                sound=0.2,
+            )
+
+    def test_sound_must_be_a_number(self) -> None:
+        with self.assertRaisesRegex(build.BuildError, "linear gain"):
+            self.plan_for([{"clip": "a.mp4", "at": 0}], sound="loud")
+
+    def test_sound_outside_its_range_is_rejected(self) -> None:
+        with self.assertRaisesRegex(build.BuildError, "between 0 and 4"):
+            self.plan_for([{"clip": "a.mp4", "at": 0}], sound=12)
+
+    def test_no_sound_key_keeps_the_master_alone(self) -> None:
+        job = self.plan_for([{"clip": "a.mp4", "at": 0}, {"clip": "b.mp4", "at": 2.0}])
+        self.assertEqual(job["sound"], 0)
+
     def test_cli_returns_zero_and_writes_the_file(self) -> None:
         edit = write_edit(
             self.root / "edit.json", "master.mp3",

--- a/tests/scenario-seedance-music-video/test_build.py
+++ b/tests/scenario-seedance-music-video/test_build.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -188,6 +189,24 @@ class BuildTestCase(unittest.TestCase):
         with self.assertRaisesRegex(build.BuildError, "would clip"):
             build.build(edit, out, self.root)
         self.assertFalse(out.exists())
+
+    def test_the_gain_the_refusal_suggests_actually_fits(self) -> None:
+        # Only the bed carries the gain, so a suggestion that scales the whole mix would
+        # still clip and send the next build round the same loop.
+        make_master(self.root / "hot.mp3", 4.0, gain=7)
+        make_clip(self.root / "hot.mp4", 3.0, "blue", tone=880, gain=7)
+        shots = [{"clip": "hot.mp4", "at": 0}, {"clip": "b.mp4", "at": 2.0}]
+        edit = write_edit(self.root / "edit.json", "hot.mp3", shots, sound=1.0)
+
+        with self.assertRaises(build.BuildError) as refusal:
+            build.build(edit, self.root / "clipped.mp4", self.root)
+        suggested = re.search(r"to at most ([0-9.]+)", str(refusal.exception))
+        self.assertIsNotNone(suggested, str(refusal.exception))
+
+        retry = write_edit(self.root / "retry.json", "hot.mp3", shots, sound=float(suggested.group(1)))
+        report = build.build(retry, self.root / "fitted.mp4", self.root)
+        self.assertTrue(report["passed"], report["checks"])
+        self.assertLessEqual(report["detail"]["mix_peak_dbfs"], 0)
 
     def test_a_master_without_headroom_is_named_as_the_cause(self) -> None:
         make_master(self.root / "full.wav", 4.0, codec="wav", gain=16)


### PR DESCRIPTION
Review of the two Seedance skills against the live schemas, with one rule added: generate the picture and its sound on one side, the music on the other.

## The audio rule

`generateAudio` is a single switch that scores a shot as well as sounding it, and nothing in the schema separates the two. A score written inside a shot restarts in a new key and tempo at every cut, so it is the part that never survives an edit, while the sound bolted to the picture (footsteps, impacts, room tone, dialogue) is exactly what the video model is good at.

Both skills now teach the split: keep `generateAudio: true`, exclude the score in the prompt ("diegetic sound only, no music, no score"), generate one track for the whole sequence with a music model, and lay it over the assembled cut. Re-scoring then costs one audio run instead of every shot again.

## scenario-seedance

- New "Sound from the shot, music from elsewhere" section, replacing the advice to turn `generateAudio` off whenever a soundtrack came later. It also says what to do when music leaks in anyway, since the prompt is the only lever.
- Caps no longer read as family-wide. The live hits disagree: 30 / 10 / 10 references and 4 to 30 seconds on 2.5, against 9 / 3 / 3 and 4 to 15 on the 2.0, Fast, and Mini hits, with 1080p and 4k on 2.0 alone and no `lastFrameImage` on Mini.
- Price moves per member further than the caps do, six times across the family for one 4 second 480p job, so the same sentence says to `dry_run` two members before a batch.
- Reference audio needs at least one image or video reference on the 2.0 line, where 2.5 takes it alone.
- First frame sets the composition, not the pixels: the size follows `resolution` and lands near the requested ratio rather than on it.
- The worked example now demonstrates the sound-without-music prompt.

## scenario-seedance-music-video

- New "The two soundtracks" section naming both valid deliveries, and the question moves into the up-front checklist because it sets `generateAudio` on every shot. With nobody to answer, the default is the song alone and the story gets written down rather than shown.
  - Song alone: `generateAudio: false`, master stream-copied, bit for bit.
  - Song over the shots' own sound: `generateAudio: true` with music excluded in the prompt, plus `"sound"` in the edit file, sized to what the clips actually carry.
- `scripts/build.py` gains the opt-in `sound` gain. Each clip's audio is cut to its slot (silence stands in for a clip that has none), conformed to the master's rate and layout, and mixed under the master, which enters at unity with `normalize=0` so only the bed carries the gain.
- The mix is measured before the video encode: a mix that would clip fails with the numbers rather than a limiter quietly reshaping the song, and a master with no headroom is named as the cause. Since only the bed is gained, the suggested gain is sized against the bed's own peak and the room the master leaves, so following it converges in one rebuild. A `sound` value no clip can feed is refused at plan time.
- Delivery in that mode is one AAC encode, so the report swaps the bit-exact check for the single-encode one and carries `sound_gain` and `mix_peak_dbfs`; the master file itself is still hash-checked. Without the key the build is byte-for-byte the old one.
- The stills step points at `scenario-consistency` for holding one character, `at` times are documented as snapping to the frame grid, and a new mistake warns that requested aspect ratios land near rather than on, which build.py pads.
- `references/shots.md`: the exclusion list excludes music instead of all sound, and the `@` tags are marked as addressing the reference arrays, not a first-frame `image`.

## Validation

- `pnpm validate` and `pnpm test` pass. The build suite grew from 28 to 37 tests, covering the mix, a clip with no audio of its own, the clipping refusal, a round trip proving the suggested gain fits, the no-headroom master, and the `sound` input contract.
- Every parameter claim was re-checked against `model_schema_get` for `model_bytedance-seedance-2-5`, `-2-0`, `-2-0-fast`, and `-2-0-mini`, and against the tool reference at mcp.scenario.com/docs/tools.
- The clean-room application test ran on both skills at 7ca8e4c, both passed, and four defects came out of the two runs. Both re-runs on 762d650 pass with every original defect verified closed, and the music-video re-run turned up two more, fixed in dc66396.
- The music-video run exercised the new lane end to end twice: Seedance shots with diegetic-only prompts, the `sound` gain, all ten build checks green (mix peak -1.17 then -0.91 dBFS) with the master's hash intact both times.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gw3Hc8EykRtCH2345hmYr)_