### PR TITLE
feat(scenario-asset-analysis): teach retrieval by text, filters, and visual similarity

### DIFF
--- a/skills/scenario-asset-analysis/SKILL.md
+++ b/skills/scenario-asset-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-asset-analysis
-description: "Use when Scenario assets need reading or finding rather than generating: captioning images for a dataset or alt text, extracting a style description or a canny, depth, pose, or segmentation control map, asking what an asset shows, checking a batch against a brief, finding an asset by text, tags, or visual similarity to a reference, or filing assets into collections. Keywords: caption, describe, analyze, QA, control map, find similar, reverse image search, semantic search, tag, collection."
+description: "Use when finished Scenario assets have to give something back: a caption for a dataset or alt text, a reusable style description, a verdict against a brief, a canny, depth, pose, or segmentation control map for the next model, or the asset itself found again by text, tags, or visual similarity and filed into a collection. Keywords: caption, describe, analyze, QA, control map, find similar, reverse image search, semantic search, tag, collection."
 license: MIT
 ---
 

--- a/skills/scenario-asset-analysis/SKILL.md
+++ b/skills/scenario-asset-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-asset-analysis
-description: "Use when Scenario assets need reading rather than generating: captioning images for a dataset or alt text, extracting a reusable style description from an on-model reference, asking what an asset shows, checking a batch against a brief before delivery, or extracting a canny, depth, pose, or segmentation control map. Also when finished assets need filing into collections or tagging. Keywords: caption, describe, analyze, review, QA, control map, ControlNet, segmentation, tag, collection."
+description: "Use when Scenario assets need reading or finding rather than generating: captioning images for a dataset or alt text, extracting a style description or a canny, depth, pose, or segmentation control map, asking what an asset shows, checking a batch against a brief, finding an asset by text, tags, or visual similarity to a reference, or filing assets into collections. Keywords: caption, describe, analyze, QA, control map, find similar, reverse image search, semantic search, tag, collection."
 license: MIT
 ---
 
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Four tools read assets back instead of making new ones: three fixed-purpose, one open-ended. They answer the questions that come after a batch lands, which is where most of the work actually is: is this on brief, what look is this, what does this show, what can the next model condition on.
+Four tools read assets back instead of making new ones: three fixed-purpose, one open-ended. With `search` (default toolset) they answer the questions that come after a batch lands, which is where most of the work actually is: is this on brief, what look is this, what does this show, what can the next model condition on, where did last week's approved version go.
 
 None of them are in the default toolset. Get schemas with `scenario_tools_search`, then run each through the executor matching its `permission`: `asset_caption` and `asset_describe` are read-class, `asset_analyze` and `asset_detect` are write-class. Or reconnect with `?toolsets=full`. Connection and scope: see the `scenario` skill in this repo. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
 
@@ -31,13 +31,21 @@ All four bill credits and all four take `dry_run: true` for an estimate first. R
 
 `asset_analyze` and `asset_detect` wait up to 180s and then hand back a `job_id`; carry on with `jobs_wait` as anywhere else.
 
+## Finding an asset again
+
+Retrieval is `search` with `target="assets"`, and at least one of `query`, `filters`, `filter`, `image`, or `images` must be set: an empty call is a 400, not an everything-list.
+
+- **By text.** `query` is keyword matching by default; `query_semantic_ratio` moves it toward meaning (0.5 to 0.8 suits mood queries like "dark medieval atmosphere", 1 is pure semantic). `sort_by` (say `["createdAt:desc"]`) is ignored while that ratio is above 0, so a newest-first list needs keyword mode.
+- **By similarity.** `image` takes one asset id or image URL and returns lookalikes; `images` takes `{"like": [...], "unlike": [...]}` to steer with positive and negative examples (the two fields are mutually exclusive). `image_semantic_ratio` decides what similar means: 1, the default, matches subject and mood; 0 matches image features, the setting for hunting near-duplicates and crops. Add a `query` beside it for "like these, but more stylized".
+- **By structure.** `filters` narrows on `kind`, `tags`, `model_id`, `collection_ids`, and `created_after`/`created_before`, ANDed with everything above.
+
 ## Worked example: reviewing a batch against a brief
 
 1. Collect the asset ids from the run (`jobs_wait` returns them).
 2. `asset_analyze` with `dry_run: true` on the first chunk to price the pass.
 3. `asset_analyze` with `images` set to 10 ids and an `instruction` that states the brief and fixes the output: "For each image in order, reply `<index>: pass|fail, <reason in under 12 words>`, a reason on every line, passes included. Fail anything not centered, not on a plain field, or carrying text." Repeat per chunk. Answers land as text assets (one, or one per image): `asset_download` them to read the verdicts.
 4. `asset_describe` on the strongest pass. Its promptable synthesis goes straight into the next batch's prompt, which holds the look without a training run (see `scenario-consistency`); when the synthesis is only a short title, prompt with the description instead.
-5. File the result: `collection_create`, then `collection_add_assets` in chunks of at most 49 ids. `asset_add_tags` is additive, so tag the failures rather than rebuilding a tag set.
+5. File the result: `collection_create`, then `collection_add_assets` in chunks of at most 49 ids. `asset_add_tags` is additive, so tag the failures rather than rebuilding a tag set. The set comes back later with `search` `filters={"collection_ids": [...]}`, and its lookalikes with `images={"like": [...]}`.
 
 ## Common mistakes
 


### PR DESCRIPTION
## Why

- `search` supports visual similarity (`image`, `images` with `like`/`unlike`), a feature-vs-semantic dial (`image_semantic_ratio`), and hybrid text search (`query_semantic_ratio`), per the [tool reference](https://mcp.scenario.com/docs/tools). No skill in the repo taught any of it.
- Live MCP traffic over the last 30 days shows `search` erroring repeatedly with `At least one of query, filter, image, or images must be provided`: agents treat it as an everything-list. The `sort_by`/semantic exclusion is also invisible until it silently reorders results.
- Reference-driven workflows ("find assets like this one", "pull last week's approved set back") are a recurring customer pattern, and retrieval is the natural completion of this skill's reading-and-filing scope.

## What changed

- New **Finding an asset again** section in `scenario-asset-analysis`, read off the live `search` schema: the at-least-one-input rule, keyword vs semantic text search and the `sort_by` exclusion, single-anchor (`image`) and multi-anchor (`images.like`/`unlike`, mutually exclusive with `image`) similarity, `image_semantic_ratio` 0 for near-duplicates vs 1 (default) for subject and mood, and structured `filters` (`kind`, `tags`, `model_id`, `collection_ids`, dates).
- Worked example's filing step now closes the loop: retrieve the collection with `filters={"collection_ids": [...]}` or its lookalikes with `images={"like": [...]}`.
- Description gains the triggers agents actually search for: find similar, reverse image search, semantic search (kept under 500 chars).

Body stays under the 900-word cap (867). `pnpm validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyUwfcdeR3SN2n2pWgHBgL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyUwfcdeR3SN2n2pWgHBgL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4f27bf775b8bd12e354a10703a9aae1a8b85cbfd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->