### PR TITLE
feat(skills): route hub skills to their model-family siblings

### DIFF
--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -25,10 +25,10 @@ Scenario runs text-to-3D, image-to-3D, and 3D-to-3D models behind the same MCP g
 
 A realistic sequence for "make a 3D treasure chest prop":
 
-1. Generate the concept: pick a text-to-image model via `search`, then `model_schema_get` and `model_run` with a prompt describing a single centered subject on a plain background. If the user already has a reference, `upload_asset` it (plus `upload_asset_complete` for multipart uploads) and pass the returned asset ID instead.
-2. `search` `target="models"`, `query="image to 3d"`, `public=true`. Live hits include the Hunyuan 3D, Meshy, Tripo, and Trellis families; re-discover instead of hardcoding, availability evolves per team.
+1. Generate the concept: pick a text-to-image model via `search`, then `model_schema_get` and `model_run` with a prompt describing a single centered subject on a plain background. If the user has a reference, `upload_asset` it (plus `upload_asset_complete` when multipart) and pass that asset ID instead.
+2. `search` `target="models"`, `query="image to 3d"`, `public=true`. Live hits include the Hunyuan 3D, Meshy, Tripo, and Trellis families.
 3. `model_schema_get` on the chosen model. 3D schemas vary widely: single image vs multi-view arrays, polycount targets, PBR toggles, topology choices.
-4. `model_run` with `parameters={"image": "asset_xxx", ...}` and `wait=false` (`dry_run=true` first to price a batch), then `jobs_wait` with `job_ids=["<job_id>"]` (it accepts up to 32 ids; re-call it with the returned `pending_job_ids` as `job_ids` if it times out).
+4. `model_run` with `parameters={"image": "asset_xxx", ...}` and `wait=false` (`dry_run=true` first to price a batch), then `jobs_wait` with `job_ids=["<job_id>"]` (re-call it with the returned `pending_job_ids` as `job_ids` if it times out).
 5. `asset_display` with the output `asset_id` to preview, then `asset_download` and `curl -L -o chest.glb "<url>"` for engine import.
 
 Multi-view models accept several images of one subject from different angles; the count and the ordering vary per model, so take both from `model_schema_get` (the first image is usually the front view).
@@ -39,7 +39,7 @@ Multi-view models accept several images of one subject from different angles; th
 
 ## Refining meshes
 
-3D-to-3D utilities (`3d23d` capability) cover retexturing, remeshing, UV unwrapping, and part segmentation. Find them with `search` `target="models"`, `query="mesh"` or `query="retexture"`. Most take an existing 3D `asset_id` as input.
+3D-to-3D utilities (`3d23d` capability) cover retexturing, remeshing, UV unwrapping, and part segmentation. Find them with `search` `target="models"`, `query="mesh"` or `query="retexture"`. Most take the source `asset_id` in a `kind: "3d"` file field, usually named `model` (also `mesh`, `file3d`).
 
 ## Rigging and animation
 
@@ -51,7 +51,7 @@ Three schema details decide whether the output is usable:
 
 - **Formats.** Rigging models accept GLB, and often OBJ, FBX, or STL. None exposes an output-format field, so the rig comes back as GLB or FBX and most descriptions do not say which: expect a DCC pass when the engine needs the other.
 - **Size ceiling.** A `max_size` on the file input is the exception rather than the rule (one humanoid rigging model caps at 30 MB). Check the schema before assuming a large mesh needs decimating.
-- **Animation versus rig.** Setting the optional `animation` field retargets a preset clip, and by default only the retarget file comes back. Set `includeRiggedModel` to keep the plain rigged mesh too.
+- **Animation versus rig.** Where a rigger exposes `animation` it retargets a preset clip, and its `allowed_values` are rig-type prefixed (`quadruped:walk`), so read them rather than guess. By default only the retarget file comes back: set `includeRiggedModel` to keep the plain rigged mesh too.
 
 When only motion is wanted, motion-transfer video models animate a still character image with no skeleton at all: see `scenario-video`. Video-to-motion models that auto-rig an uploaded mesh are the one place an `outputFormat` enum picks the engine target.
 
@@ -62,5 +62,5 @@ When only motion is wanted, motion-transfer video models animate a still charact
 - Hardcoding model IDs: catalogs rotate (a `deprecated:<replacement_id>` tag names the successor). Re-discover with `search` each session.
 - Pasting raw asset URLs into chat instead of calling `asset_display`.
 - Forgetting `-L` with curl: download URLs may redirect before serving the file.
-- Promising a named skeleton or a specific influence count: pick the body plan, then finish the rest in a DCC.
+- Promising a named skeleton, an influence count, or bones for wings and extra limbs: pick the closest body plan, then finish the rest in a DCC.
 - Sending a biped to a `rigType` model: the enum has no biped value, because humanoids have their own rigging models.

--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Scenario runs text-to-3D, image-to-3D, and 3D-to-3D models behind the same MCP generation loop used for images. The most reliable pipeline generates a concept image first, then feeds it to an image-to-3D model; direct text-to-3D models exist (`txt23d` capability) but the image-to-3D catalog is larger and gives more art direction control. Connection and the core generation loop: see the `scenario` skill in this repo. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+Scenario runs text-to-3D, image-to-3D, and 3D-to-3D models behind the same MCP generation loop used for images. The most reliable pipeline generates a concept image first, then feeds it to an image-to-3D model; direct text-to-3D exists (`txt23d`) but image-to-3D has the larger catalog and more art direction control. Per-family contracts: `scenario-meshy`, `scenario-rodin`, `scenario-sparc3d`. Walkable scenes and Gaussian splats: `scenario-3d-worlds`. Connection and the core generation loop: see the `scenario` skill. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
 
 ## Quick reference
 
@@ -21,14 +21,14 @@ Scenario runs text-to-3D, image-to-3D, and 3D-to-3D models behind the same MCP g
 | Preview        | `asset_display`                                                    | Interactive GLB/FBX/VOX/OBJ viewer on MCP App hosts                                                  |
 | Download       | `asset_download`                                                   | Returns a URL; save with `curl -L`                                                                   |
 
-## Workflow: concept image to game-ready mesh
+## Worked example: concept image to game-ready mesh
 
 A realistic sequence for "make a 3D treasure chest prop":
 
 1. Generate the concept: pick a text-to-image model via `search`, then `model_schema_get` and `model_run` with a prompt describing a single centered subject on a plain background. If the user already has a reference, `upload_asset` it (plus `upload_asset_complete` for multipart uploads) and pass the returned asset ID instead.
-2. `search` `target="models"`, `query="image to 3d"`, `public=true`. Live results include families like Hunyuan 3D, Meshy, Tripo, and Trellis (for example `model_meshy-7-img23d`); re-discover instead of hardcoding, availability evolves per team.
+2. `search` `target="models"`, `query="image to 3d"`, `public=true`. Live hits include the Hunyuan 3D, Meshy, Tripo, and Trellis families; re-discover instead of hardcoding, availability evolves per team.
 3. `model_schema_get` on the chosen model. 3D schemas vary widely: single image vs multi-view arrays, polycount targets, PBR toggles, topology choices.
-4. `model_run` with `parameters={"image": "asset_xxx", ...}` and `wait=false`, then `jobs_wait` with `job_ids=["<job_id>"]` (it accepts up to 32 ids; re-call it with the returned `pending_job_ids` as `job_ids` if it times out).
+4. `model_run` with `parameters={"image": "asset_xxx", ...}` and `wait=false` (`dry_run=true` first to price a batch), then `jobs_wait` with `job_ids=["<job_id>"]` (it accepts up to 32 ids; re-call it with the returned `pending_job_ids` as `job_ids` if it times out).
 5. `asset_display` with the output `asset_id` to preview, then `asset_download` and `curl -L -o chest.glb "<url>"` for engine import.
 
 Multi-view models accept several images of the same subject from different angles; the accepted count varies per model (from 1-4 up to 8), so take it and the image ordering from `model_schema_get` (the first image is usually the front view).
@@ -59,7 +59,7 @@ When only motion is wanted, motion-transfer video models animate a still charact
 
 - Running `model_run` without `model_schema_get`: 3D model parameters differ far more between models than image models do.
 - Passing a local file path as an image input: `upload_asset` first, then pass the returned asset ID.
-- Hardcoding model IDs: catalogs rotate (live search shows Meshy 6 models tagged deprecated in favor of Meshy 7). Re-discover with `search` each session.
+- Hardcoding model IDs: catalogs rotate (a `deprecated:<replacement_id>` tag names the successor). Re-discover with `search` each session.
 - Pasting raw asset URLs into chat instead of calling `asset_display`.
 - Forgetting `-L` with curl: download URLs may redirect before serving the file.
 - Promising a named skeleton or a specific influence count: pick the body plan and the export format, then finish the rest in a DCC.

--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -31,7 +31,7 @@ A realistic sequence for "make a 3D treasure chest prop":
 4. `model_run` with `parameters={"image": "asset_xxx", ...}` and `wait=false` (`dry_run=true` first to price a batch), then `jobs_wait` with `job_ids=["<job_id>"]` (it accepts up to 32 ids; re-call it with the returned `pending_job_ids` as `job_ids` if it times out).
 5. `asset_display` with the output `asset_id` to preview, then `asset_download` and `curl -L -o chest.glb "<url>"` for engine import.
 
-Multi-view models accept several images of the same subject from different angles; the accepted count varies per model (from 1-4 up to 8), so take it and the image ordering from `model_schema_get` (the first image is usually the front view).
+Multi-view models accept several images of one subject from different angles; the count and the ordering vary per model, so take both from `model_schema_get` (the first image is usually the front view).
 
 ## Inspecting results
 
@@ -45,15 +45,15 @@ Multi-view models accept several images of the same subject from different angle
 
 Rigging is a separate `3d23d` step run on a finished mesh, not a flag on the generator. Find the models with `search` `query="rigging"`.
 
-Body plan picks the model. Humanoid models take the mesh and little else (a front-facing hint, or an approximate height, depending on the model) and infer a biped skeleton. Non-biped work goes to a model exposing `rigType`, whose values cover `quadruped`, `hexapod`, `octopod`, `avian`, `serpentine`, and `aquatic`. Nothing exposes a custom bone hierarchy or a skin-influence count, so export the rigged file and finish weighting or retargeting in a DCC such as Blender or Maya.
+Body plan picks the model. Humanoid models take the mesh and little else (a front-facing hint, or an approximate height, depending on the model) and infer a biped skeleton. Non-biped work goes to a model exposing `rigType`, whose values cover `quadruped`, `hexapod`, `octopod`, `avian`, `serpentine`, and `aquatic`.
 
 Three schema details decide whether the output is usable:
 
-- **Input format.** Rigging models accept GLB, and often OBJ, FBX, or STL. OBJ cannot carry a rig, so the output goes out as GLB or FBX.
+- **Formats.** Rigging models accept GLB, and often OBJ, FBX, or STL. None exposes an output-format field, so the rig comes back as GLB or FBX and most descriptions do not say which: expect a DCC pass when the engine needs the other.
 - **Size ceiling.** A `max_size` on the file input is the exception rather than the rule (one humanoid rigging model caps at 30 MB). Check the schema before assuming a large mesh needs decimating.
 - **Animation versus rig.** Setting the optional `animation` field retargets a preset clip, and by default only the retarget file comes back. Set `includeRiggedModel` to keep the plain rigged mesh too.
 
-When only motion is wanted, motion-transfer video models animate a still character image with no skeleton at all: see `scenario-video`.
+When only motion is wanted, motion-transfer video models animate a still character image with no skeleton at all: see `scenario-video`. Video-to-motion models that auto-rig an uploaded mesh are the one place an `outputFormat` enum picks the engine target.
 
 ## Common mistakes
 
@@ -62,5 +62,5 @@ When only motion is wanted, motion-transfer video models animate a still charact
 - Hardcoding model IDs: catalogs rotate (a `deprecated:<replacement_id>` tag names the successor). Re-discover with `search` each session.
 - Pasting raw asset URLs into chat instead of calling `asset_display`.
 - Forgetting `-L` with curl: download URLs may redirect before serving the file.
-- Promising a named skeleton or a specific influence count: pick the body plan and the export format, then finish the rest in a DCC.
+- Promising a named skeleton or a specific influence count: pick the body plan, then finish the rest in a DCC.
 - Sending a biped to a `rigType` model: the enum has no biped value, because humanoids have their own rigging models.

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -31,6 +31,8 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 - Video to audio: models that score a silent video or add synchronized sound effects, taking a video asset as input.
 - Utilities: audio cut, split, and extract tools plus speech-to-text transcription; discover with `search` query="audio" or query="tool".
 
+Per-family contracts: `scenario-elevenlabs` (speech, dubbing, re-voicing, music, SFX), `scenario-ace-step` and `scenario-minimax-music` (songs), `scenario-sonilo` (SFX and video scoring).
+
 ## Worked example: a game sound effect
 
 1. `search` target="models", query="sound effect", public=true. Returns txt2audio models such as `model_elevenlabs-sound-effects-v2` (example only).
@@ -48,12 +50,11 @@ Prompting tips:
 
 ## Songs with vocals
 
-A full-length song is not a longer music bed, and song schemas vary more than the rest of the audio lane, so `model_schema_get` decides everything. Current families shape the request three ways: a style prompt plus a separate lyric sheet, a single prose prompt carrying style and structure, or an ordered section array with per-section lyrics, styles, and durations.
+A full-length song is not a longer music bed; song schemas vary more than the rest of the audio lane, and the per-model contracts live in `scenario-ace-step` and `scenario-minimax-music`. What holds across families:
 
-- **Words never go in a style field.** On split-field models the style field carries genre, mood, tempo in BPM, key, vocal style, and instrumentation; the lyric field carries the words, shaped by section tags such as `[Verse]` and `[Chorus]`.
-- **Instrumental is a flag where the schema has one.** Asking for "no vocals" in the style text does not reliably suppress them; when no flag exists, the schema's text fields are the only lever.
-- **Auto-lyrics is also a flag** on the family that has one: with the lyric field empty, it writes lyrics from the style brief. Empty lyrics with no flag is not the same request.
-- **Text fields are length-capped**, with caps that differ per model and field, and going over is a 400 rather than a truncation.
+- **Words never go in a style field.** The style field carries genre, mood, tempo, key, vocal style, and instrumentation; the lyric field carries the words, shaped by section tags such as `[Verse]` and `[Chorus]`.
+- **Instrumental and auto-lyrics are flags** where the schema has them; asking for either in prose is unreliable.
+- **Text fields are length-capped** per model and field, and going over is a 400 rather than a truncation.
 
 Where the schema exposes a duration field (flagged `cost_impact`), it caps both length and price; where none exists, the lyric sheet or prompt sets both. Either way, price the song with `dry_run: true` before committing, and launch with `wait=false`.
 

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -50,10 +50,10 @@ Prompting tips:
 
 ## Songs with vocals
 
-A full-length song is not a longer music bed; song schemas vary more than the rest of the audio lane, and the per-model contracts live in `scenario-ace-step` and `scenario-minimax-music`. What holds across families:
+A full-length song is not a longer music bed, and song schemas vary more than the rest of the audio lane, so `model_schema_get` decides the shape: a style prompt plus a separate lyric sheet, a single prose prompt carrying style and structure, or an ordered section array with per-section text and styles. Per-model contracts: `scenario-ace-step`, `scenario-minimax-music`, `scenario-elevenlabs`.
 
-- **Words never go in a style field.** The style field carries genre, mood, tempo, key, vocal style, and instrumentation; the lyric field carries the words, shaped by section tags such as `[Verse]` and `[Chorus]`.
-- **Instrumental and auto-lyrics are flags** where the schema has them; asking for either in prose is unreliable.
+- **Words never go in a style field.** Where the schema splits the two, the style field carries genre, mood, tempo, key, vocal style, and instrumentation; the lyric field carries the words, shaped by section tags such as `[Verse]` and `[Chorus]`.
+- **Instrumental and auto-lyrics are flags** where the schema has them; asking for either in prose is unreliable, and where no flag exists the text fields are the only lever.
 - **Text fields are length-capped** per model and field, and going over is a 400 rather than a truncation.
 
 Where the schema exposes a duration field (flagged `cost_impact`), it caps both length and price; where none exists, the lyric sheet or prompt sets both. Either way, price the song with `dry_run: true` before committing, and launch with `wait=false`.

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -12,14 +12,14 @@ Scenario generates audio through the same loop as images. The live catalog cover
 
 ## Quick reference
 
-| Step           | Tool                                                                                     | Notes                                                                     |
-| -------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Find a model   | `search` target="models", query="music" / "sound effect" / "text to speech", public=true | audio generators list `txt2audio` in capabilities                         |
-| Inspect inputs | `model_schema_get`                                                                       | audio schemas vary widely: durations, lyrics, voices, looping             |
-| Generate       | `model_run`                                                                              | schema-conformant parameters; wait=false for long jobs                    |
-| Wait           | `jobs_wait`                                                                              | blocks server-side; re-call passing pending_job_ids as job_ids on timeout |
-| Listen         | `asset_display`                                                                          | renders an inline audio player                                            |
-| Save           | `asset_download`                                                                         | returns a download URL: `curl -L -o out.mp3 "<url>"`                      |
+| Step           | Tool                                                                                     | Notes                                                         |
+| -------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Find a model   | `search` target="models", query="music" / "sound effect" / "text to speech", public=true | audio generators list `txt2audio` in capabilities             |
+| Inspect inputs | `model_schema_get`                                                                       | audio schemas vary widely: durations, lyrics, voices, looping |
+| Generate       | `model_run`                                                                              | schema-conformant parameters; wait=false for long jobs        |
+| Wait           | `jobs_wait`                                                                              | blocks server-side; on timeout re-call with pending_job_ids   |
+| Listen         | `asset_display`                                                                          | renders an inline audio player                                |
+| Save           | `asset_download`                                                                         | returns a download URL: `curl -L -o out.mp3 "<url>"`          |
 
 Find existing audio assets with `search` target="assets", filters={kind: "audio"}. Team and project scope (`team_id`, `project_id`): see the `scenario` skill.
 
@@ -27,8 +27,8 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 
 - Music: text-to-music models produce short beds or full-length songs with vocals; the song lane has its own contract, below.
 - Sound effects: text-to-SFX models generate short clips from a description; some support seamless looping.
-- Voice and speech: text-to-speech models with preset voices, multilingual output, and emotion or pacing controls; some clone a voice from a short reference clip; speech-to-speech re-voices an existing recording.
-- Video to audio: models that score a silent video or add synchronized sound effects, taking a video asset as input.
+- Voice and speech: text-to-speech with preset voices, multilingual output, and emotion or pacing controls; some clone a voice from a short clip, and speech-to-speech re-voices a recording.
+- Video to audio: models that score a silent video or add synchronized effects.
 - Utilities: audio cut, split, and extract tools plus speech-to-text transcription; discover with `search` query="audio" or query="tool".
 
 Per-family contracts: `scenario-elevenlabs` (speech, dubbing, re-voicing, music, SFX), `scenario-ace-step` and `scenario-minimax-music` (songs), `scenario-sonilo` (SFX and video scoring).
@@ -36,27 +36,27 @@ Per-family contracts: `scenario-elevenlabs` (speech, dubbing, re-voicing, music,
 ## Worked example: a game sound effect
 
 1. `search` target="models", query="sound effect", public=true. Returns txt2audio models such as `model_elevenlabs-sound-effects-v2` (example only).
-2. `model_schema_get` model_id="model_elevenlabs-sound-effects-v2". Returns the exact fields: prompt plus model-specific controls such as duration or looping.
-3. `model_run` model_id="model_elevenlabs-sound-effects-v2", parameters={"prompt": "heavy wooden treasure chest creaking open, single event, dry, no music"}.
-4. If the response is status='in_progress', `jobs_wait` job_ids=["job_xxx"]. Timeout is not an error; re-call with the returned pending_job_ids as job_ids.
+2. `model_schema_get` with that `model_id`. Returns the exact fields: prompt plus controls such as duration or looping.
+3. `model_run` with the same `model_id` and parameters={"prompt": "heavy wooden treasure chest creaking open, single event, dry, no music"}.
+4. If status='in_progress', `jobs_wait` job_ids=["job_xxx"], re-calling with the returned pending_job_ids on timeout.
 5. `asset_display` asset_id="asset_xxx" to play it inline.
-6. `asset_download` asset_id="asset_xxx" with no `format`, then save the returned URL with `curl -L`.
+6. `asset_download` with no `format`, then save the returned URL with `curl -L`.
 
 Prompting tips:
 
 - SFX: name the source, material, action, and acoustic space, and say what to exclude ("no music", "no reverb"). One event per clip; generate variations as separate runs.
-- Music: give genre, mood, tempo, and instrumentation. Short beds usually take a single prompt, with duration or looping in the schema; songs with vocals are their own lane, below.
-- Speech: keep the text field to the words to speak. Voice choice, language, emotion, and pacing live in separate schema fields or inline tags depending on the model; check the schema instead of packing direction into the text.
+- Music: give genre, mood, tempo, and instrumentation. Short beds usually take a single prompt, with duration or looping in the schema.
+- Speech: keep the text field to the words to speak; voice, language, emotion, and pacing live in separate schema fields or inline tags.
 
 ## Songs with vocals
 
-A full-length song is not a longer music bed, and song schemas vary more than the rest of the audio lane, so `model_schema_get` decides the shape: a style prompt plus a separate lyric sheet, a single prose prompt carrying style and structure, or an ordered section array with per-section text and styles. Per-model contracts: `scenario-ace-step`, `scenario-minimax-music`, `scenario-elevenlabs`.
+A full-length song is not a longer music bed, and song schemas vary more than the rest of the lane, so `model_schema_get` decides the shape: a style prompt plus a separate lyric sheet, one prose prompt carrying both, or an ordered section array with per-section text and styles.
 
 - **Words never go in a style field.** Where the schema splits the two, the style field carries genre, mood, tempo, key, vocal style, and instrumentation; the lyric field carries the words, shaped by section tags such as `[Verse]` and `[Chorus]`.
-- **Instrumental and auto-lyrics are flags** where the schema has them; asking for either in prose is unreliable, and where no flag exists the text fields are the only lever.
+- **Instrumental and auto-lyrics are flags** where the schema has them; asking for either in prose is unreliable, and where no flag exists the text fields are the only lever. Flipping the instrumental flag on a rerun gives a different take, not the same song: `seed`, where a model has one, only repeats identical settings. For an instrumental of a track you already have, try an audio2audio cover model (`search` `query="cover"`), checking the schema since not all carry the flag.
 - **Text fields are length-capped** per model and field, and going over is a 400 rather than a truncation.
 
-Where the schema exposes a duration field (flagged `cost_impact`), it caps both length and price; where none exists, the lyric sheet or prompt sets both. Either way, price the song with `dry_run: true` before committing, and launch with `wait=false`.
+Where the schema exposes a duration field (flagged `cost_impact`), it caps both length and price; where none exists, the lyric sheet or prompt sets both. Either way, price the song with `dry_run: true` before committing, then launch with `wait: false`; both are `model_run` arguments, not `parameters` keys.
 
 ## Common mistakes
 
@@ -68,4 +68,4 @@ Where the schema exposes a duration field (flagged `cost_impact`), it caps both 
 - Putting voice direction inside TTS text ("say this angrily"): direction can end up spoken. Use the schema's emotion or voice fields.
 - Sending image parameters (width, height) to audio models: their schemas do not accept them.
 - Pasting lyrics into the style field: the model then describes a song instead of singing one.
-- Running a full-length song without `dry_run`: when the schema has no duration field, the lyric sheet sets both the length and the bill.
+- Putting `dry_run` or `wait` inside `parameters`: they are `model_run`'s own arguments, so a stray `dry_run` still charges and a stray `wait` blocks up to 180s.

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -30,6 +30,7 @@ Find existing audio assets with `search` target="assets", filters={kind: "audio"
 - Voice and speech: text-to-speech with preset voices, multilingual output, and emotion or pacing controls; some clone a voice from a short clip, and speech-to-speech re-voices a recording.
 - Video to audio: models that score a silent video or add synchronized effects.
 - Utilities: audio cut, split, and extract tools plus speech-to-text transcription; discover with `search` query="audio" or query="tool".
+- Stem separation: one named stem per run (`search` query="stem"), vocals included, with no instrumental option.
 
 Per-family contracts: `scenario-elevenlabs` (speech, dubbing, re-voicing, music, SFX), `scenario-ace-step` and `scenario-minimax-music` (songs), `scenario-sonilo` (SFX and video scoring).
 
@@ -66,6 +67,5 @@ Where the schema exposes a duration field (flagged `cost_impact`), it caps both 
 - Pasting raw asset URLs into chat: use `asset_display` to play audio.
 - Passing `format` to `asset_download` for audio: it converts image formats only, so omit it.
 - Putting voice direction inside TTS text ("say this angrily"): direction can end up spoken. Use the schema's emotion or voice fields.
-- Sending image parameters (width, height) to audio models: their schemas do not accept them.
 - Pasting lyrics into the style field: the model then describes a song instead of singing one.
 - Putting `dry_run` or `wait` inside `parameters`: they are `model_run`'s own arguments, so a stray `dry_run` still charges and a stray `wait` blocks up to 180s.

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -34,7 +34,7 @@ A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields
 
 ## Worked example: replacing a label on a product shot
 
-1. `recommend` with `capability="img2img"` and the user's own words as `prompt`. On `next_step.type="ask_user"`, present the options instead of picking; skip any `requires_plan_upgrade` entry.
+1. `recommend` with `capability="img2img"` and the user's own words as `prompt`. Handle `next_step` as the `scenario` skill directs, and never run a `requires_plan_upgrade` entry.
 2. `upload_asset` the product photo, then `upload_asset_complete`, which returns the `asset_id`. Only the inline path under ~100KB skips the second call.
 3. `model_schema_get` on the pick: the reference field's name and cap, which sizing family it uses, the prompt `max_length`, and whether a `mask` field exists.
 4. For a masked edit, read the `mask` field's own description before building anything. Masks are not interchangeable: one model wants an alpha channel at the source's exact dimensions, another wants a black and white image it resizes itself, and which pixels get painted differs too. With no mask in hand, `search` (`target="models"`, `query="segment"`, `public=true`) finds `img2img` segmentation models that take a short noun phrase or a box and return one mask per object; most hits segment 3D meshes, so check `capabilities`. Where no convention fits, an instruction editor scopes the edit in prose instead.

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Scenario runs hundreds of image models, split across `txt2img` (generate from a prompt) and `img2img` (edit, restyle, inpaint, upscale). The loop is the one the `scenario` skill teaches. What breaks image runs is the per-model contract: sizing fields, prompt limits, and reference caps differ between two models that do the same job, so read `model_schema_get` every time. Grading, effects, expand, resize and the other deterministic tool models: see `scenario-image-editing`. Holding one look across a set: see `scenario-consistency`. Sprites, icons, and tilesets: see `scenario-game-assets`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+Scenario runs hundreds of image models, split across `txt2img` (generate from a prompt) and `img2img` (edit, restyle, inpaint, upscale). The loop is the one the `scenario` skill teaches. What breaks image runs is the per-model contract: sizing fields, prompt limits, and reference caps differ between two models that do the same job, so read `model_schema_get` every time. Per-family contracts (sizing families, reference caps, edit modes): `scenario-seedream`, `scenario-gpt-image`, `scenario-gemini-image`, `scenario-ideogram`, `scenario-reve`, `scenario-luma-image`, `scenario-mai-image`, `scenario-grok-imagine-image`. Grading, effects, expand, resize and the other deterministic tool models: see `scenario-image-editing`. Holding one look across a set: see `scenario-consistency`. Sprites, icons, and tilesets: see `scenario-game-assets`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
 
 ## Quick reference
 
@@ -39,7 +39,7 @@ A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields
 3. `model_schema_get` on the pick: the reference field's name and cap, which sizing family it uses, the prompt `max_length`, and whether a `mask` field exists.
 4. For a masked edit, read the `mask` field's own description before building anything. Masks are not interchangeable: one model wants an alpha channel at the source's exact dimensions, another wants a black and white image it resizes itself, and which pixels get painted differs too.
 5. `model_run` with the schema's own field names: the prompt, the reference (wrapped in an array only where the schema says `array: true`), plus the mask and sizing fields it named. Use `dry_run=true` first when cost matters.
-6. `jobs_wait`, then `asset_display` to review and `asset_download` to save.
+6. `jobs_wait`; its ~180s timeout is not an error, so re-call it with the returned `pending_job_ids` as `job_ids`. Then `asset_display` to review and `asset_download` to save.
 
 ## Common mistakes
 

--- a/skills/scenario-image/SKILL.md
+++ b/skills/scenario-image/SKILL.md
@@ -37,7 +37,7 @@ A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields
 1. `recommend` with `capability="img2img"` and the user's own words as `prompt`. On `next_step.type="ask_user"`, present the options instead of picking; skip any `requires_plan_upgrade` entry.
 2. `upload_asset` the product photo, then `upload_asset_complete`, which returns the `asset_id`. Only the inline path under ~100KB skips the second call.
 3. `model_schema_get` on the pick: the reference field's name and cap, which sizing family it uses, the prompt `max_length`, and whether a `mask` field exists.
-4. For a masked edit, read the `mask` field's own description before building anything. Masks are not interchangeable: one model wants an alpha channel at the source's exact dimensions, another wants a black and white image it resizes itself, and which pixels get painted differs too.
+4. For a masked edit, read the `mask` field's own description before building anything. Masks are not interchangeable: one model wants an alpha channel at the source's exact dimensions, another wants a black and white image it resizes itself, and which pixels get painted differs too. With no mask in hand, `search` (`target="models"`, `query="segment"`, `public=true`) finds `img2img` segmentation models that take a short noun phrase or a box and return one mask per object; most hits segment 3D meshes, so check `capabilities`. Where no convention fits, an instruction editor scopes the edit in prose instead.
 5. `model_run` with the schema's own field names: the prompt, the reference (wrapped in an array only where the schema says `array: true`), plus the mask and sizing fields it named. Use `dry_run=true` first when cost matters.
 6. `jobs_wait`; its ~180s timeout is not an error, so re-call it with the returned `pending_job_ids` as `job_ids`. Then `asset_display` to review and `asset_download` to save.
 
@@ -47,4 +47,4 @@ A batch-count field (`numOutputs`, `numImages`) repeats one prompt, so it yields
 - Reusing one model's parameter block on another: `aspectRatio` and `width`/`height` rarely coexist, and unknown fields are rejected.
 - Retrying a 403 `ModelAccessRestrictedError`: it names `modelId` and `requiredPlan`, so surface the upgrade or pick another model.
 - Prompting "transparent background": diffusion outputs are opaque. Use a `background` field when the schema has one, otherwise run a background-removal model afterwards.
-- Assuming a model can hit a requested pixel size: some expose an aspect ratio and nothing else.
+- Assuming a model can hit a requested pixel size: some expose an aspect ratio and nothing else. Confirm what landed with `asset_get`, which reports `properties.width` and `properties.height`; `jobs_wait` returns asset ids only.

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -39,14 +39,14 @@ The source image already fixes the look, so prompt only motion, camera, and timi
 All editing is `model_run` on a video-input model; discover each with `search`:
 
 - Prompt-driven edits (restyle, swap objects, characters, backgrounds, or reframe to another aspect ratio): query `"video edit"` or `"reframe"`. A reframe outpaints past the frame, unlike a deterministic resize.
-- Lipsync and dubbing: query `"lipsync"` or `"dubbing"`; see the next section.
+- Lipsync and dubbing: see the next section.
 - Upscaling up to 4K: query `"video upscale"`.
 - Deterministic utilities (trim, split, resize, effects, grading, frame extraction, background removal): see `scenario-video-editing`. Assembling a finished cut: see `scenario-video-assembly`.
 - Extending a clip with new footage from its last frame: query `"extend video"`.
 
 ## Dubbing is not lipsync
 
-Dubbing translates the speech and keeps each speaker's own voice, tone, and timing. It does not move the mouth, so a dubbed talking head still has lips forming the original language. Three steps:
+Dubbing translates the speech and keeps each speaker's own voice, tone, and timing. It does not move the mouth, so a dubbed talking head still has lips forming the original language. Three steps, after any trim the limits below require:
 
 1. **Dub.** Takes the clip as `file` and a required `targetLang` from the schema's allowed values. Omit `sourceLang` to auto-detect, since the value that means auto differs between models. When a brand or name must survive translation, pick a hit whose schema carries `keyterms`, as not all do; where it is `array: true`, pass `["Scenario"]` even for one term.
 2. **Extract.** Dubbing returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the speech out with `search` `query="audio extract"`; a generic `query="tool"` buries it.

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Scenario exposes a large video catalog through one MCP loop: text-to-video and image-to-video generators (Kling, Veo, Seedance, LTX, Luma, Runway, Grok) plus video-to-video editors, lipsync, upscalers, and deterministic cut/split/concat tools.
+Scenario exposes a large video catalog through one MCP loop: text-to-video and image-to-video generators plus video-to-video editors, lipsync, upscalers, and deterministic cut/split/concat tools. Per-family contracts: `scenario-kling`, `scenario-veo`, `scenario-seedance`, `scenario-gemini-omni`, `scenario-luma-video`, `scenario-runway`, `scenario-grok-imagine-video`, `scenario-wan`, `scenario-minimax-video`, `scenario-vidu`.
 
 Connection and the core generation loop: see the `scenario` skill. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
 
@@ -26,12 +26,12 @@ Connection and the core generation loop: see the `scenario` skill. If a sibling 
 
 ## Worked example: animate a key art still into a short ad clip
 
-1. `search` with `target="models"`, `query="image to video"`, `public=true`. Live hits include `model_kling-v2-6-i2v-pro` and `model_veo3-1-fast`; re-discover rather than hardcoding, availability shifts per team.
-2. `model_schema_get` with `model_id="model_kling-v2-6-i2v-pro"`. Note the image field, duration options, and any last-frame anchor.
+1. `search` with `target="models"`, `query="image to video"`, `public=true`. Prefer the newest non-deprecated hits; re-discover rather than hardcoding, availability shifts per team and generations churn.
+2. `model_schema_get` on the pick. Note the image field, duration options, and any last-frame anchor.
 3. `upload_asset` the still; it returns `asset_id="asset_abc"`.
 4. `model_run` with `parameters={"image": "asset_abc", "prompt": "slow dolly-in, steam rising from the mug, shallow depth of field"}` and `wait=false`. Returns a `job_id`.
 5. `jobs_wait` with `job_ids=["job_xyz"]`. On `status="in_progress"`, call again, passing the returned `pending_job_ids` as `job_ids`.
-6. `asset_display` the output video; `asset_download` (no `format`) returns the file URL, save it with `curl -L`.
+6. `asset_display` the output; `asset_download` (no `format`), saving the URL with `curl -L`.
 
 The source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several also accept first and last frame anchors or keyframe sequences; take exact parameter names from `model_schema_get`, never from memory.
 
@@ -57,7 +57,7 @@ Building a localized talking head from nothing runs audio, video, dub, extract, 
 
 ## Duration limits
 
-Where a model bounds input length it rejects rather than trims: a 30.08 second reference against a 30.0 second limit fails the whole run, with the error naming both numbers. A ceiling is not a standard field, so look for it in the file field's own description, and expect plenty of models to state none. When one applies, trim first with the deterministic cut or split tools (`search` `query="video cut"`), landing under the limit rather than exactly on it.
+Where a model bounds input length it rejects rather than trims: a 30.08 second reference against a 30.0 second limit fails the whole run, with the error naming both numbers. A ceiling is not a standard field: look for it in the file field's own description; many state none. When one applies, trim first with the deterministic cut or split tools (`search` `query="video cut"`), landing under the limit rather than exactly on it.
 
 ## Common mistakes
 

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -18,7 +18,7 @@ Connection and the core generation loop: see the `scenario` skill. If a sibling 
 | -------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Find a model   | `search`                           | `target="models"`, `public=true`, query `"image to video"`, `"video upscale"`, `"lipsync"`, `"video edit"` |
 | Inspect inputs | `model_schema_get`                 | Always before `model_run`; video schemas differ widely (duration, aspect ratio, frame anchors)             |
-| Upload source  | `upload_asset`                     | A local still or clip becomes an `asset_id`; never pass file paths                                         |
+| Upload source  | `upload_asset`                     | A local still or clip becomes an `asset_id`                                                                |
 | Refine prompt  | `prompt_spark`                     | Optional; rewrites a thin motion idea into an on-model prompt                                              |
 | Generate       | `model_run`                        | `wait=false` for video; `dry_run=true` to estimate cost first                                              |
 | Wait           | `jobs_wait`                        | Re-call with the returned `pending_job_ids` until done                                                     |
@@ -26,22 +26,22 @@ Connection and the core generation loop: see the `scenario` skill. If a sibling 
 
 ## Worked example: animate a key art still into a short ad clip
 
-1. `search` with `target="models"`, `query="image to video"`, `public=true`. Prefer the newest non-deprecated hits; re-discover rather than hardcoding, availability shifts per team and generations churn.
+1. `search` with `target="models"`, `query="image to video"`, `public=true`. Prefer the newest non-deprecated hits.
 2. `model_schema_get` on the pick. Note the image field, duration options, and any last-frame anchor.
 3. `upload_asset` the still; it returns `asset_id="asset_abc"`.
 4. `model_run` with `parameters={"image": "asset_abc", "prompt": "slow dolly-in, steam rising from the mug, shallow depth of field"}` and `wait=false`. Returns a `job_id`.
-5. `jobs_wait` with `job_ids=["job_xyz"]`. On `status="in_progress"`, call again, passing the returned `pending_job_ids` as `job_ids`.
-6. `asset_display` the output; `asset_download` (no `format`), saving the URL with `curl -L`.
+5. `jobs_wait` with `job_ids=["job_xyz"]`, re-calling with the returned `pending_job_ids` while any remain.
+6. `asset_display` the output, then `asset_download` (no `format`).
 
-The source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several also accept first and last frame anchors or keyframe sequences; take exact parameter names from `model_schema_get`, never from memory.
+The source image already fixes the look, so prompt only motion, camera, and timing ("orbit left", "hold on the final pose"), changing one clause per retry. Several also accept first and last frame anchors or keyframe sequences; take the exact names from `model_schema_get`.
 
 ## Editing existing footage
 
 All editing is `model_run` on a video-input model; discover each with `search`:
 
-- Prompt-driven edits (restyle, swap objects, characters, backgrounds, or reframe to another aspect ratio): query `"video edit"` or `"reframe"` (Grok Edit Video, Wan 2.7 Video Edit, Lucy Edit, Luma Modify Video, Luma Ray 3.2 Reframe). A reframe outpaints past the frame, unlike a deterministic resize.
+- Prompt-driven edits (restyle, swap objects, characters, backgrounds, or reframe to another aspect ratio): query `"video edit"` or `"reframe"`. A reframe outpaints past the frame, unlike a deterministic resize.
 - Lipsync and dubbing: query `"lipsync"` or `"dubbing"`; see the next section.
-- Upscaling up to 4K: query `"video upscale"` (Topaz, SeedVR2, Magnific, Flash VSR).
+- Upscaling up to 4K: query `"video upscale"`.
 - Deterministic utilities (trim, split, resize, effects, grading, frame extraction, background removal): see `scenario-video-editing`. Assembling a finished cut: see `scenario-video-assembly`.
 - Extending a clip with new footage from its last frame: query `"extend video"`.
 
@@ -51,13 +51,13 @@ Dubbing translates the speech and keeps each speaker's own voice, tone, and timi
 
 1. **Dub.** Takes the clip as `file` and a required `targetLang` from the schema's allowed values. Omit `sourceLang` to auto-detect, since the value that means auto differs between models. When a brand or name must survive translation, pick a hit whose schema carries `keyterms`, as not all do; where it is `array: true`, pass `["Scenario"]` even for one term.
 2. **Extract.** Dubbing a video returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the new speech out with `search` `query="audio extract"`, which surfaces the tool; a generic `query="tool"` buries it.
-3. **Lipsync.** Takes `video` and `audio` separately, plus `syncMode` where the schema exposes it (`cut_off`, `loop`, `bounce`, `silence`, `remap`), which decides what happens when the two durations disagree. The names do not say which one loses, so read the field description and set it rather than inheriting a default.
+3. **Lipsync.** The clip and the track are separate fields, `video`/`audio` on most hits and `videoUrl`/`audioFile` on others. A duration-mismatch control is not universal: where present it is `syncMode` or `lipsyncMode` (`cut_off`, `loop`, `bounce`, `silence`, `remap`) with a per-model default, and there `loop` and `bounce` extend the shorter stream while `cut_off` ends at it; elsewhere a `loop` boolean loops the audio instead. Take names and defaults from `model_schema_get`.
 
-Building a localized talking head from nothing runs audio, video, dub, extract, lipsync. Judge it on a stylized character before promising it on a photoreal one.
+Judge a localized talking head on a stylized character before promising it on a photoreal one.
 
 ## Duration limits
 
-Where a model bounds input length it rejects rather than trims: a 30.08 second reference against a 30.0 second limit fails the whole run, with the error naming both numbers. A ceiling is not a standard field: look for it in the file field's own description; many state none. When one applies, trim first with the deterministic cut or split tools (`search` `query="video cut"`), landing under the limit rather than exactly on it.
+Where a model bounds input length it rejects rather than trims: a 30.08 second reference against a 30.0 second limit fails the whole run, with the error naming both numbers. A ceiling can be a typed `max_duration` on the file field, prose in that field's description, or absent, so check both, on the audio input as readily as the video. When one applies, trim with the deterministic cut or split tools (`search` `query="video cut"`, `public=true`) before the run that enforces it, and before any step whose output must match the trimmed footage, such as a dub. Land inside the stated range, not on its edge.
 
 ## Common mistakes
 

--- a/skills/scenario-video/SKILL.md
+++ b/skills/scenario-video/SKILL.md
@@ -19,7 +19,6 @@ Connection and the core generation loop: see the `scenario` skill. If a sibling 
 | Find a model   | `search`                           | `target="models"`, `public=true`, query `"image to video"`, `"video upscale"`, `"lipsync"`, `"video edit"` |
 | Inspect inputs | `model_schema_get`                 | Always before `model_run`; video schemas differ widely (duration, aspect ratio, frame anchors)             |
 | Upload source  | `upload_asset`                     | A local still or clip becomes an `asset_id`                                                                |
-| Refine prompt  | `prompt_spark`                     | Optional; rewrites a thin motion idea into an on-model prompt                                              |
 | Generate       | `model_run`                        | `wait=false` for video; `dry_run=true` to estimate cost first                                              |
 | Wait           | `jobs_wait`                        | Re-call with the returned `pending_job_ids` until done                                                     |
 | Review         | `asset_display` / `asset_download` | Display inline; `asset_download` returns the file URL, save it with `curl -L`                              |
@@ -50,8 +49,8 @@ All editing is `model_run` on a video-input model; discover each with `search`:
 Dubbing translates the speech and keeps each speaker's own voice, tone, and timing. It does not move the mouth, so a dubbed talking head still has lips forming the original language. Three steps:
 
 1. **Dub.** Takes the clip as `file` and a required `targetLang` from the schema's allowed values. Omit `sourceLang` to auto-detect, since the value that means auto differs between models. When a brand or name must survive translation, pick a hit whose schema carries `keyterms`, as not all do; where it is `array: true`, pass `["Scenario"]` even for one term.
-2. **Extract.** Dubbing a video returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the new speech out with `search` `query="audio extract"`, which surfaces the tool; a generic `query="tool"` buries it.
-3. **Lipsync.** The clip and the track are separate fields, `video`/`audio` on most hits and `videoUrl`/`audioFile` on others. A duration-mismatch control is not universal: where present it is `syncMode` or `lipsyncMode` (`cut_off`, `loop`, `bounce`, `silence`, `remap`) with a per-model default, and there `loop` and `bounce` extend the shorter stream while `cut_off` ends at it; elsewhere a `loop` boolean loops the audio instead. Take names and defaults from `model_schema_get`.
+2. **Extract.** Dubbing returns a dubbed video, not a bare track, and lipsync wants an audio asset. Pull the speech out with `search` `query="audio extract"`; a generic `query="tool"` buries it.
+3. **Lipsync.** Pass the dubbed video together with its extracted track. No schema says whether the input's own audio survives, so listen to the output before shipping. The clip and the track are separate fields, `video`/`audio` on most hits and `videoUrl`/`audioFile` on others. A duration-mismatch control is not universal: where present it is `syncMode` or `lipsyncMode` (`cut_off`, `loop`, `bounce`, `silence`, `remap`) with a per-model default, and there `loop` and `bounce` extend the shorter stream while `cut_off` ends at it; elsewhere a `loop` boolean loops the audio instead. Take names and defaults from `model_schema_get`.
 
 Judge a localized talking head on a stylized character before promising it on a photoreal one.
 


### PR DESCRIPTION
## Why

An audit of the fleet against agent-skill best practices (hub-and-spoke suites in the leading skills on skills.sh, plus this repo's own sibling-install mechanism) found that routing is one-way: every model-family skill points up to its hub, but no hub names a single family skill. `scenario-video` listed the vendors as plain words ("Kling, Veo, Seedance, ...") and `scenario-audio` taught a whole songs section without mentioning that `scenario-ace-step` and `scenario-minimax-music` exist. An agent with only a hub installed never learns the deeper skill exists, and the byte-identical install invitation the hubs already carry can never fire because no sibling is named.

## What changed

- **`scenario-image`**: routes to the 8 image family skills; the worked example now teaches the `jobs_wait` `pending_job_ids` re-call it was missing.
- **`scenario-video`**: routes to the 10 video family skills. The worked example's stale authoring-time ids (`model_kling-v2-6-i2v-pro`, `model_veo3-1-fast`, contradicted by `scenario-kling`'s current V3 teaching) are replaced with unversioned discovery phrasing, so the hub can no longer drift against its family skills. Small compensating trims keep the body under the 900-word cap.
- **`scenario-audio`**: routes to the 4 audio family skills; the songs-with-vocals section is compressed to the cross-family facts, with per-model contracts left to `scenario-ace-step` / `scenario-minimax-music` (they carry them already). Body drops from 898 to 829 words.
- **`scenario-3d`**: routes to the 3 3D family skills and `scenario-3d-worlds`; adds the `dry_run` pricing step the other hubs teach, renames `## Workflow:` to the house `## Worked example:` structure, and drops a hardcoded model id from the search step.

No new facts beyond the tool reference; all model-name mentions stay hedged as discovery examples.

## Validation

- `pnpm validate` green (style, prettier, skill-files, groupings, readme, words, cspell, spec).
- Body budgets after change: image 753, video 888, audio 829, 3d 882 (all under the 900 cap; audio moved toward the target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 11c5aee97e65cc8ba4d5a66b49040e672325ad31. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->