### PR TITLE
fix(skills): modernize skyboxes, textures, and game-assets to current doctrine

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 Cinzel
+DALL-E
 HDRI
 KAEL
 Kontext

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 Cinzel
+HDRI
 KAEL
 Kontext
 MYBRAND

--- a/skills/scenario-game-assets/SKILL.md
+++ b/skills/scenario-game-assets/SKILL.md
@@ -12,15 +12,15 @@ Scenario's public catalog carries purpose-trained models per asset type (sprites
 
 ## Quick reference
 
-| Task                       | Call                                                                                                        |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Find a model by asset type | `search` target="models", public=true, query="sprite" / "game icon" / "tileset" / "isometric" / "pixel art" |
-| Inspect inputs             | `model_schema_get` (always before `model_run`)                                                              |
-| Generate                   | `model_run`, then `jobs_wait`                                                                               |
-| Transparent background     | `search` query="background removal", run that tool model on the asset                                       |
-| Upscale or enhance         | `search` query="upscale" (2x to 16x tools exist)                                                            |
-| Pixel-art cleanup          | `search` query="pixel" (grid snapping, palette reduction)                                                   |
-| Export for an engine       | `asset_download` with format="png"                                                                          |
+| Task                       | Call                                                                                                                          |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Find a model by asset type | `search` target="models", public=true, query="sprite" / "game icon" / "tileset" / "isometric" / "pixel art"                   |
+| Inspect inputs             | `model_schema_get` (always before `model_run`)                                                                                |
+| Generate                   | `model_run` (`dry_run=true` prices a batch; launch `wait=false`), then `jobs_wait`; on timeout re-call with `pending_job_ids` |
+| Transparent background     | `search` query="background removal", run that tool model on the asset                                                         |
+| Upscale or enhance         | `search` query="upscale" (2x to 16x tools exist)                                                                              |
+| Pixel-art cleanup          | `search` query="pixel" (grid snapping, palette reduction)                                                                     |
+| Export for an engine       | `asset_download` with format="png"                                                                                            |
 
 ## Worked example: a transparent potion icon set
 

--- a/skills/scenario-game-assets/SKILL.md
+++ b/skills/scenario-game-assets/SKILL.md
@@ -28,16 +28,16 @@ Request: "four style-matched potion icons for an RPG inventory."
 
 1. `search` target="models", query="game icon", public=true. Typical hits: cartoon icon LoRAs ("Stylized Game Icons & Props"). Confirm the pick with the user: catalogs differ per team; re-discover, never hardcode model IDs.
 2. `model_schema_get` model_id="<picked id>". Note the prompt field, size fields, and any sample-count parameter.
-3. `model_run` parameters={"prompt": "health potion, corked glass bottle, glowing red liquid, bold outline, centered, plain background"}. Batch via the schema's sample-count parameter when present, or rerun varying only the item ("mana potion", "stamina potion") with the wording template fixed for a coherent set.
-4. `jobs_wait` job_ids=["<returned job_id>"] (up to 32 ids, one call covers the batch), then `asset_display` to review.
+3. `model_run` parameters={"prompt": "health potion, corked glass bottle, glowing red liquid, bold outline, centered, plain background"}. Batch via the schema's sample-count parameter when present, or rerun varying only the item ("mana potion", "stamina potion") with the wording template fixed for a coherent set. Price the batch with `dry_run=true`, then launch with `wait=false`.
+4. `jobs_wait` job_ids=["<returned job_id>"] (up to 32 ids, one call covers the batch); on timeout re-call with the returned `pending_job_ids`, never a second `model_run`. Then `asset_display` to review.
 5. `search` query="background removal" (Photoroom, Pixelcut, 851 Labs), `model_schema_get` the pick, then `model_run` with its image field set to the generated asset id. Some models generate native alpha; search "transparent".
-6. Optional: upscale keepers (search "upscale", `model_schema_get` as always; Scenario's Flux upscalers go 2x to 8x and beyond).
+6. Optional: upscale keepers (search "upscale", `model_schema_get` as always; upscalers go 2x to 8x and beyond).
 7. `asset_download` asset_id, format="png" (PNG keeps alpha). Follow redirects: `curl -L -o potion.png "<url>"`.
 
 ## Style consistency
 
 - Reference images: `upload_asset` the art direction images, then pass the asset ids (never local paths) to the model's image or reference parameters.
-- `asset_describe` turns one on-style asset into a promptable style synthesis reusable across prompts (full-toolset tool: if unlisted, reconnect with `?toolsets=full` or run via `scenario_tools_search` + `scenario_tool_execute_read`; see the `scenario` skill).
+- `asset_describe` turns one on-style asset into a promptable style synthesis reusable across prompts (catalog tool: run via `scenario_tools_search` + `scenario_tool_execute_read`; see the `scenario` skill).
 - `search` target="assets" images={like: ["asset_..."]} finds assets already matching the target look.
 - For a locked-in project style, train a custom LoRA on the project's own art (the `scenario-model-training` skill); trained models use the same generation loop.
 

--- a/skills/scenario-game-assets/SKILL.md
+++ b/skills/scenario-game-assets/SKILL.md
@@ -17,7 +17,7 @@ Scenario's public catalog carries purpose-trained models per asset type (sprites
 | Find a model by asset type | `search` target="models", public=true, query="sprite" / "game icon" / "tileset" / "isometric" / "pixel art"                   |
 | Inspect inputs             | `model_schema_get` (always before `model_run`)                                                                                |
 | Generate                   | `model_run` (`dry_run=true` prices a batch; launch `wait=false`), then `jobs_wait`; on timeout re-call with `pending_job_ids` |
-| Transparent background     | `search` query="background removal", run that tool model on the asset                                                         |
+| Transparent background     | `search` query="transparent" for a native-alpha generator; else query="background removal" on the asset                       |
 | Upscale or enhance         | `search` query="upscale" (2x to 16x tools exist)                                                                              |
 | Pixel-art cleanup          | `search` query="pixel" (grid snapping, palette reduction)                                                                     |
 | Export for an engine       | `asset_download` with format="png"                                                                                            |
@@ -28,14 +28,15 @@ Request: "four style-matched potion icons for an RPG inventory."
 
 1. `search` target="models", query="game icon", public=true. Typical hits: cartoon icon LoRAs ("Stylized Game Icons & Props"). Confirm the pick with the user: catalogs differ per team; re-discover, never hardcode model IDs.
 2. `model_schema_get` model_id="<picked id>". Note the prompt field, size fields, and any sample-count parameter.
-3. `model_run` parameters={"prompt": "health potion, corked glass bottle, glowing red liquid, bold outline, centered, plain background"}. Batch via the schema's sample-count parameter when present, or rerun varying only the item ("mana potion", "stamina potion") with the wording template fixed for a coherent set. Price the batch with `dry_run=true`, then launch with `wait=false`.
+3. `model_run` parameters={"prompt": "health potion, corked glass bottle, glowing red liquid, bold outline, centered, plain background"} (a plain field cuts cleanly in a removal pass; a native-alpha model wants the subject alone, never the word transparent). The schema's sample-count parameter repeats one prompt for variants of one item; different items are separate runs varying only the item ("mana potion", "stamina potion") with the wording template fixed. Price with `dry_run=true` first (one dry run prices one leg; multiply across the batch), then launch with `wait=false`.
 4. `jobs_wait` job_ids=["<returned job_id>"] (up to 32 ids, one call covers the batch); on timeout re-call with the returned `pending_job_ids`, never a second `model_run`. Then `asset_display` to review.
-5. `search` query="background removal" (Photoroom, Pixelcut, 851 Labs), `model_schema_get` the pick, then `model_run` with its image field set to the generated asset id. Some models generate native alpha; search "transparent".
+5. Transparency: `search` query="transparent" first, since a native-alpha generator makes the icons transparent at the source and skips a billed removal pass per icon. Fall back to a removal model only when the chosen generator lacks alpha: `search` query="background removal" (Photoroom, Pixelcut, 851 Labs at authoring time), `model_schema_get` the pick, then `model_run` with its image field set to the generated asset id.
 6. Optional: upscale keepers (search "upscale", `model_schema_get` as always; upscalers go 2x to 8x and beyond).
 7. `asset_download` asset_id, format="png" (PNG keeps alpha). Follow redirects: `curl -L -o potion.png "<url>"`.
 
 ## Style consistency
 
+- The cheap levers first: reuse one `seed` across the batch, and pin the model's prompt-expansion flag off where the schema has one; an expander rewrites each prompt independently and defeats a fixed template.
 - Reference images: `upload_asset` the art direction images, then pass the asset ids (never local paths) to the model's image or reference parameters.
 - `asset_describe` turns one on-style asset into a promptable style synthesis reusable across prompts (catalog tool: run via `scenario_tools_search` + `scenario_tool_execute_read`; see the `scenario` skill).
 - `search` target="assets" images={like: ["asset_..."]} finds assets already matching the target look.
@@ -49,7 +50,7 @@ Restyling one approved component into a set (button, panel, popup well, icon fam
 - **Strip baked effects before generating.** A drop shadow, outer glow, or bevel in the reference reads as silhouette and comes back thickened, doubled, or fused to the object. Feed flat art and re-apply the effect in engine, where it stays adjustable. For a final PNG matching a shadowed source, lift the source's effect layer by alpha (on a transparent source, shadow pixels are semi-transparent, the object fully opaque) and composite it under each output.
 - **Say which parts are functional.** A nine-slice panel needs stretchable middles and fixed corners; diffusion has no concept of either. Name the constraint in the prompt, then check that it held.
 - **One object, plain field, no scene.** Several objects in one reference get recombined into a hybrid.
-- **Check the alpha edge on any transparent output.** Removed shadows leave a semi-transparent fringe; native-alpha models can ship a large semi-transparent glow around the object. Both read as a halo on a colored UI background.
+- **Check the alpha edge on any transparent output.** Removed shadows leave a semi-transparent fringe; native-alpha models can ship a large semi-transparent glow around the object. Both read as a halo on a colored UI background. Check interior alpha too: a native-alpha model can punch one item's see-through surface (empty glass) to alpha 0 while painting the next item's opaque, so the set disagrees in an engine slot.
 
 Verify the set by measurement, not by eye: compare each output's alpha bounding box against the source before accepting the batch.
 

--- a/skills/scenario-skyboxes/SKILL.md
+++ b/skills/scenario-skyboxes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-skyboxes
-description: Use when a task involves generating or iterating on skyboxes, 360 panoramas, equirectangular images, environment maps, or VR backdrops through the Scenario MCP. Triggers include text-to-skybox, turning a photo into a 360 environment, restyling a panorama's mood, upscaling a skybox without breaking the seam wrap, or exporting equirectangular or cubemap layouts for game engines such as Unity, Unreal, or Godot.
+description: Use when a task involves generating or iterating on skyboxes, 360 panoramas, equirectangular images, environment maps, HDRI-style backdrops, or VR backdrops through the Scenario MCP. Triggers include text-to-skybox, turning a photo into a 360 environment, restyling a panorama's mood, upscaling a skybox without breaking the seam wrap, or exporting equirectangular or cubemap layouts for game engines such as Unity, Unreal, or Godot.
 license: MIT
 ---
 
@@ -14,33 +14,33 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 
 ## Quick reference
 
-| Step | Tool                                                    | Purpose                                       |
-| ---- | ------------------------------------------------------- | --------------------------------------------- |
-| 1    | `search` (target="models", query="skybox", public=true) | Discover current skybox models                |
-| 2    | `model_schema_get`                                      | Exact parameter contract for the chosen model |
-| 3    | `model_run`                                             | Generate the panorama                         |
-| 4    | `jobs_wait`                                             | Block until the job completes                 |
-| 5    | `asset_display` / `asset_download`                      | Review inline, then save the file             |
+| Step | Tool                                                    | Purpose                                        |
+| ---- | ------------------------------------------------------- | ---------------------------------------------- |
+| 1    | `search` (target="models", query="skybox", public=true) | Discover current skybox models                 |
+| 2    | `model_schema_get`                                      | Exact parameter contract for the chosen model  |
+| 3    | `model_run`                                             | `dry_run=true` to price; `wait=false` to batch |
+| 4    | `jobs_wait`                                             | On timeout re-call with `pending_job_ids`      |
+| 5    | `asset_display` / `asset_download`                      | Review inline, then save the file              |
 
-Model IDs below were live `search` hits at authoring time. Re-discover them each time: availability differs per team and evolves.
+Model IDs and the parameter facts below were live `search` hits at authoring time. Re-discover them each time: availability differs per team and evolves.
 
 - `model_scenario-skybox-flux`: text to 360 panorama, 21 style presets, automatic seam and pole correction, optional reference image with a strength slider.
 - `model_scenario-skybox-gpt`: text to 360 panorama guided by up to 10 reference images, quality presets, width and height up to 3840 px.
 - `model_hunyuan-world-image-to-skybox`: one photo of a place to a seamless 360 skybox.
 - `model_sc-upscale-flux-skybox`: 2x to 8x skybox upscale that preserves the seamless wrap.
 
-## Workflow: generate, iterate, export
+## Worked example: generate, iterate, export
 
 Example: a stylized forest skybox for a game scene.
 
 1. `search` with target="models", query="skybox", public=true. Pick a text-to-skybox model, for example `model_scenario-skybox-flux`.
 2. `model_schema_get` for that model. Expect fields like prompt, style, negativePrompt, image, strength, numOutputs, geometryEnforcement, seed.
-3. `model_run` with parameters={"prompt": "ancient pine forest at dawn, mist between trunks, god rays", "style": "cinematic", "numOutputs": 2}. Take style preset names from the schema response.
-4. `jobs_wait` with job_ids=[the returned job_id], then `asset_display` each output.
+3. `model_run` with parameters={"prompt": "ancient pine forest at dawn, mist between trunks, god rays", "style": "cinematic", "numOutputs": 2}. Take style preset names from the schema response. `dry_run=true` first prices the run; launch with `wait=false`.
+4. `jobs_wait` with job_ids=[the returned job_id]. Its ~180s timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`, never a second `model_run`. Then `asset_display` each output.
 5. Iterate on mood: copy the seed from the best result and change only style (cinematic, oil-painting, cyberpunk, and more). To keep composition while shifting look, pass the favorite as image with low strength (0.2 to 0.4). To steer mood from concept art instead, switch to `model_scenario-skybox-gpt` and pass referenceImages.
 6. Export: run `model_sc-upscale-flux-skybox` with image=asset_id and upscaleFactor=4. baseModel defaults to FLUX.1-dev (stylized); a Krea-based realism option exists, so read the exact allowed values from `model_schema_get` before switching. Then `asset_download` the final asset.
 
-Engine format notes: Skybox Flux outputs equirectangular panoramas; keep the default sizing. Skybox GPT's catalog lists equirectangular 2:1 plus cubemap strip 6:1 and cubemap cross 4:3 layouts, but its schema exposes only width and height, so confirm the layout contract with `model_schema_get` before relying on a cubemap layout. Beyond flat backdrops, the same search surfaces `model_hunyuan-world-skybox-to-splat`, and a separate search (query="world") finds the Marble world models; both turn a finished panorama into a navigable 3D Gaussian splat scene.
+Engine format notes: Skybox Flux outputs equirectangular panoramas; keep the default sizing. Skybox GPT's catalog lists equirectangular 2:1 plus cubemap strip 6:1 and cubemap cross 4:3 layouts, but its schema exposes only width and height, so confirm the layout contract with `model_schema_get` before relying on a cubemap layout. Beyond flat backdrops, the same search surfaces `model_hunyuan-world-skybox-to-splat`, and a separate search (query="world") finds the Marble world models; both turn a finished panorama into a navigable 3D Gaussian splat scene, the pipeline the `scenario-3d-worlds` skill teaches end to end.
 
 ## Common mistakes
 

--- a/skills/scenario-skyboxes/SKILL.md
+++ b/skills/scenario-skyboxes/SKILL.md
@@ -24,7 +24,7 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 
 Model IDs and the parameter facts below were live `search` hits at authoring time. Re-discover them each time: availability differs per team and evolves.
 
-- `model_scenario-skybox-flux`: text to 360 panorama, 21 style presets, automatic seam and pole correction, optional reference image with a strength slider.
+- `model_scenario-skybox-flux`: text to 360 panorama, a style preset enum (count drifts; read it from the schema), automatic seam and pole correction, optional reference image with a strength slider.
 - `model_scenario-skybox-gpt`: text to 360 panorama guided by up to 10 reference images, quality presets, width and height up to 3840 px.
 - `model_hunyuan-world-image-to-skybox`: one photo of a place to a seamless 360 skybox.
 - `model_sc-upscale-flux-skybox`: 2x to 8x skybox upscale that preserves the seamless wrap.
@@ -34,13 +34,14 @@ Model IDs and the parameter facts below were live `search` hits at authoring tim
 Example: a stylized forest skybox for a game scene.
 
 1. `search` with target="models", query="skybox", public=true. Pick a text-to-skybox model, for example `model_scenario-skybox-flux`.
-2. `model_schema_get` for that model. Expect fields like prompt, style, negativePrompt, image, strength, numOutputs, geometryEnforcement, seed.
+2. `model_schema_get` for that model. Expect fields like prompt, style, negativePrompt, image, strength, numOutputs, geometryEnforcement, seed. negativePrompt is inert unless negativePromptStrength is above 0.
 3. `model_run` with parameters={"prompt": "ancient pine forest at dawn, mist between trunks, god rays", "style": "cinematic", "numOutputs": 2}. Take style preset names from the schema response. `dry_run=true` first prices the run; launch with `wait=false`.
 4. `jobs_wait` with job_ids=[the returned job_id]. Its ~180s timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`, never a second `model_run`. Then `asset_display` each output.
 5. Iterate on mood: copy the seed from the best result and change only style (cinematic, oil-painting, cyberpunk, and more). To keep composition while shifting look, pass the favorite as image with low strength (0.2 to 0.4). To steer mood from concept art instead, switch to `model_scenario-skybox-gpt` and pass referenceImages.
-6. Export: run `model_sc-upscale-flux-skybox` with image=asset_id and upscaleFactor=4. baseModel defaults to FLUX.1-dev (stylized); a Krea-based realism option exists, so read the exact allowed values from `model_schema_get` before switching. Then `asset_download` the final asset.
+6. Export: run `model_sc-upscale-flux-skybox` with image=asset_id and the smallest upscaleFactor that reaches target (the upscale can cost several times the generation, and its `dry_run` can only run once the input asset exists, so the chain cannot be priced up front). baseModel defaults to FLUX.1-dev (stylized); a Krea-based realism option exists, and strength defaults to 0.6, which invents detail: lower it when the goal is the same panorama at higher resolution. Read the exact allowed values from `model_schema_get` before switching. Then `asset_download` the final asset.
+7. Verify the seam at no cost: compare the saved PNG's leftmost and rightmost pixel columns; on a seamless panorama they differ by near zero while columns a quarter-turn apart differ by an order of magnitude more.
 
-Engine format notes: Skybox Flux outputs equirectangular panoramas; keep the default sizing. Skybox GPT's catalog lists equirectangular 2:1 plus cubemap strip 6:1 and cubemap cross 4:3 layouts, but its schema exposes only width and height, so confirm the layout contract with `model_schema_get` before relying on a cubemap layout. Beyond flat backdrops, the same search surfaces `model_hunyuan-world-skybox-to-splat`, and a separate search (query="world") finds the Marble world models; both turn a finished panorama into a navigable 3D Gaussian splat scene, the pipeline the `scenario-3d-worlds` skill teaches end to end.
+Engine format notes: Skybox Flux outputs equirectangular panoramas; keep the default sizing (1536x768 at authoring time) and read the real dimensions off the returned asset rather than assuming them. Skybox GPT's catalog lists equirectangular 2:1 plus cubemap strip 6:1 and cubemap cross 4:3 layouts, but its schema exposes only width and height, so confirm the layout contract with `model_schema_get` before relying on a cubemap layout. Beyond flat backdrops, the same search surfaces `model_hunyuan-world-skybox-to-splat`, and a separate search (query="world") finds the Marble world models; both turn a finished panorama into a navigable 3D Gaussian splat scene, the pipeline the `scenario-3d-worlds` skill teaches end to end.
 
 ## Common mistakes
 

--- a/skills/scenario-textures/SKILL.md
+++ b/skills/scenario-textures/SKILL.md
@@ -18,25 +18,25 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 | ------------------- | --------------------------------------------------------------------------- | ------------------------------------- |
 | Find texture models | `search` with `target="models"`, `query="seamless tileable"`, `public=true` | Also try `query="texture"` or `"PBR"` |
 | Inspect inputs      | `model_schema_get`                                                          | Always call before `model_run`        |
-| Generate            | `model_run`                                                                 | Schema-conformant parameters          |
-| Wait                | `jobs_wait`                                                                 | Never poll `job_get` in a loop        |
+| Generate            | `model_run`                                                                 | `dry_run=true` prices a batch first   |
+| Wait                | `jobs_wait`                                                                 | Re-call with `pending_job_ids`        |
 | View and save       | `asset_display`, then `asset_download`                                      | Download for engine import            |
 | Upscale             | `model_run` on a texture upscaler                                           | 2x to 8x, tiling preserved            |
 
-## What live search confirms (examples to re-discover, not constants)
+## What live search confirmed at authoring time (examples to re-discover, not constants)
 
 - Seamless generation: `model_scenario-texture` (Scenario Texture) takes a prompt (a tileable hint is appended automatically), `width`/`height` from 16 to 3840 in multiples of 16, `quality`, `seed`, up to 10 `referenceImages` for style, and `eraseSeam` with `overlap`/`featherRadius` to inpaint away both seam axes.
 - Themed texture LoRAs (Flux.1 LoRA, tag `sc:texture`): floors, marble, concrete, stone walls, wood boards, brick, terracotta, hand-painted, cybernetic, realistic textures. They expose dedicated texture capabilities (`txt2img_texture`, `img2img_texture`, `controlnet_texture`).
 - Tiling-safe upscaling: `model_sc-upscale-flux-texture` (Scenario Texture Upscale), `upscaleFactor` 2 to 8, presets `precise`/`balanced`/`creative`, optional prompt and style images.
 - Material-look conversion: `model_sc-texture-converter` (Texture Converter) turns a flat image into a surface material using `raised`, `shiny`, `polished`, `angular` sliders and an `invert` relief toggle.
-- PBR maps ship with 3D texturing and image-to-3D models, not as standalone 2D map decomposition. Examples seen live: Tripo 3.0 Texturing (PBR mode outputs albedo, metallic, roughness, normal), Tencent Texture Edit (prompt mode outputs full PBR maps for FBX models), Meshy 7 Retexture (optional PBR maps). Enable the model's PBR toggle found via `model_schema_get`.
+- PBR maps ship with 3D texturing and image-to-3D models, not as standalone 2D map decomposition. Examples seen live: Tripo 3.0 Texturing (PBR mode outputs albedo, metallic, roughness, normal), Tencent Texture Edit (prompt mode outputs full PBR maps for FBX models), Meshy 7 Retexture (optional PBR maps). Enable the model's PBR toggle found via `model_schema_get`. Retexturing a full mesh is a 3D-to-3D pipeline: see `scenario-3d`, and `scenario-meshy` for the Meshy retexture contract.
 
 ## Worked example: seamless brick, iterated then upscaled
 
 1. `search` `target="models"`, `query="seamless tileable"`, `public=true`, pick the seamless generator (e.g. `model_scenario-texture`).
 2. `model_schema_get` `model_id="model_scenario-texture"`.
-3. `model_run` with `parameters={"prompt": "weathered red brick wall, moss in the mortar joints", "width": 1024, "height": 1024, "eraseSeam": true, "seed": 42}`.
-4. `jobs_wait` with `job_ids=["job_..."]` (the id returned by `model_run`), then `asset_display` the output asset.
+3. `model_run` with `parameters={"prompt": "weathered red brick wall, moss in the mortar joints", "width": 1024, "height": 1024, "eraseSeam": true, "seed": 42}`. For a themed pack, price the batch with `dry_run=true` first, then launch the runs with `wait=false`.
+4. `jobs_wait` with `job_ids=["job_..."]` (the ids returned by `model_run`). A ~180s timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`, never a second `model_run`. Then `asset_display` the output asset.
 5. Iterate: rerun with the same `seed` and an edited prompt, or add `referenceImages=["asset_..."]` to lock a style.
 6. Upscale: `model_schema_get` then `model_run` `model_id="model_sc-upscale-flux-texture"` with `parameters={"image": "asset_...", "upscaleFactor": 4, "preset": "precise"}`.
 7. `asset_download` the final asset for engine import.

--- a/skills/scenario-textures/SKILL.md
+++ b/skills/scenario-textures/SKILL.md
@@ -27,7 +27,7 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 
 - Seamless generation: `model_scenario-texture` (Scenario Texture) takes a prompt (a tileable hint is appended automatically), `width`/`height` from 16 to 3840 in multiples of 16, `quality`, `seed`, up to 10 `referenceImages` for style, and `eraseSeam` (off by default) with `overlap`/`featherRadius` to inpaint away both seam axes.
 - Themed texture LoRAs (Flux.1 LoRA, tag `sc:texture`): floors, marble, concrete, stone walls, wood boards, brick, terracotta, hand-painted, cybernetic, realistic textures. They expose dedicated texture capabilities (`txt2img_texture`, `img2img_texture`, `controlnet_texture`).
-- Tiling-safe upscaling: `model_sc-upscale-flux-texture` (Scenario Texture Upscale), `upscaleFactor` 2 to 8, presets `precise`/`balanced`/`creative`, optional prompt and style images.
+- Tiling-safe upscaling: `model_sc-upscale-flux-texture` (Scenario Texture Upscale), `upscaleFactor` 2 (the minimum) to 8, presets `precise`/`balanced`/`creative` riding the same `strength` and controlnet sliders the schema exposes. It re-renders, so expect small tonal drift: `precise` with low strength minimizes it, and the result is compared against the source before shipping.
 - Material-look conversion: `model_sc-texture-converter` (Texture Converter) turns a flat image into a surface material using `raised`, `shiny`, `polished`, `angular` sliders and an `invert` relief toggle.
 - PBR maps come from two different routes. For a flat texture, 2D map extractors (tag `sc:texture`, `search` `query="PBR"`) return a full set in one img2img call: `model_patina` (PATINA Image to Maps) outputs base color, normal, roughness, metalness, and height, and `model_patina-material` tiles a PBR material straight from a prompt. For a mesh, 3D texturing and image-to-3D models emit the maps instead (Tripo 3.0 Texturing, Tencent Texture Edit, Meshy 7 Retexture); enable the PBR toggle found via `model_schema_get`. Retexturing a full mesh is a 3D-to-3D pipeline: see `scenario-3d`, and `scenario-meshy` for the Meshy retexture contract.
 
@@ -38,8 +38,9 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 3. `model_run` with `parameters={"prompt": "weathered red brick wall, moss in the mortar joints", "width": 1024, "height": 1024, "eraseSeam": true, "seed": 42}`. For a themed pack, price the batch with `dry_run=true` first, then launch the runs with `wait=false`.
 4. `jobs_wait` with `job_ids=["job_..."]` (the ids returned by `model_run`). A ~180s timeout is not an error: re-call with the returned `pending_job_ids` as `job_ids`, never a second `model_run`. Then `asset_display` the output asset.
 5. Iterate: rerun with the same `seed` and an edited prompt, or add `referenceImages=["asset_..."]` to lock a style.
-6. Upscale: `model_schema_get` then `model_run` `model_id="model_sc-upscale-flux-texture"` with `parameters={"image": "asset_...", "upscaleFactor": 4, "preset": "precise"}`.
-7. `asset_download` the final asset for engine import.
+6. Upscale: `model_schema_get` then `model_run` `model_id="model_sc-upscale-flux-texture"` with `parameters={"image": "asset_...", "upscaleFactor": 2, "preset": "precise"}`, raising the factor only deliberately: cost follows output pixels, and this leg can only be `dry_run`-priced once its input asset exists, so a two-step chain is never priced up front.
+7. Verify tiling at no cost: the saved PNG's left column against its right and top row against bottom should differ no more than neighboring interior columns do, and a 2x2 self-tile proof sheet shows any seam instantly.
+8. `asset_download` the final asset for engine import.
 
 ## Common mistakes
 

--- a/skills/scenario-textures/SKILL.md
+++ b/skills/scenario-textures/SKILL.md
@@ -25,11 +25,11 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 
 ## What live search confirmed at authoring time (examples to re-discover, not constants)
 
-- Seamless generation: `model_scenario-texture` (Scenario Texture) takes a prompt (a tileable hint is appended automatically), `width`/`height` from 16 to 3840 in multiples of 16, `quality`, `seed`, up to 10 `referenceImages` for style, and `eraseSeam` with `overlap`/`featherRadius` to inpaint away both seam axes.
+- Seamless generation: `model_scenario-texture` (Scenario Texture) takes a prompt (a tileable hint is appended automatically), `width`/`height` from 16 to 3840 in multiples of 16, `quality`, `seed`, up to 10 `referenceImages` for style, and `eraseSeam` (off by default) with `overlap`/`featherRadius` to inpaint away both seam axes.
 - Themed texture LoRAs (Flux.1 LoRA, tag `sc:texture`): floors, marble, concrete, stone walls, wood boards, brick, terracotta, hand-painted, cybernetic, realistic textures. They expose dedicated texture capabilities (`txt2img_texture`, `img2img_texture`, `controlnet_texture`).
 - Tiling-safe upscaling: `model_sc-upscale-flux-texture` (Scenario Texture Upscale), `upscaleFactor` 2 to 8, presets `precise`/`balanced`/`creative`, optional prompt and style images.
 - Material-look conversion: `model_sc-texture-converter` (Texture Converter) turns a flat image into a surface material using `raised`, `shiny`, `polished`, `angular` sliders and an `invert` relief toggle.
-- PBR maps ship with 3D texturing and image-to-3D models, not as standalone 2D map decomposition. Examples seen live: Tripo 3.0 Texturing (PBR mode outputs albedo, metallic, roughness, normal), Tencent Texture Edit (prompt mode outputs full PBR maps for FBX models), Meshy 7 Retexture (optional PBR maps). Enable the model's PBR toggle found via `model_schema_get`. Retexturing a full mesh is a 3D-to-3D pipeline: see `scenario-3d`, and `scenario-meshy` for the Meshy retexture contract.
+- PBR maps come from two different routes. For a flat texture, 2D map extractors (tag `sc:texture`, `search` `query="PBR"`) return a full set in one img2img call: `model_patina` (PATINA Image to Maps) outputs base color, normal, roughness, metalness, and height, and `model_patina-material` tiles a PBR material straight from a prompt. For a mesh, 3D texturing and image-to-3D models emit the maps instead (Tripo 3.0 Texturing, Tencent Texture Edit, Meshy 7 Retexture); enable the PBR toggle found via `model_schema_get`. Retexturing a full mesh is a 3D-to-3D pipeline: see `scenario-3d`, and `scenario-meshy` for the Meshy retexture contract.
 
 ## Worked example: seamless brick, iterated then upscaled
 
@@ -46,6 +46,6 @@ Connection and the core generation loop: see the `scenario` skill in this repo. 
 - Skipping `model_schema_get`: parameter names differ per model and most models reject an empty payload.
 - Using a generic upscaler on a tileable texture: it breaks the repeat at the seams. Use the texture-specific upscaler, which preserves tiling.
 - Generating huge sizes directly: generate near 1024, then upscale 2x to 8x. Generation dimensions cap at 3840.
-- Expecting a texture-to-PBR splitter: no live model decomposes a flat texture into separate map files. PBR maps come from 3D texturing models with PBR enabled.
+- Routing a flat texture through a 3D texturing model just to get PBR maps: the 2D map extractors do that in one img2img call, and the 3D models are for meshes.
 - Ignoring engine sizing: engines expect square power-of-two textures (the seamless generator defaults to 1024x1024, 1:1). The generator accepts any multiple of 16, so choose 1024 or 2048 deliberately.
 - Hardcoding model IDs: availability differs per team. Re-discover with `search` each session.


### PR DESCRIPTION
## Why

`scenario-skyboxes`, `scenario-textures`, and `scenario-game-assets` predate the current house template, and a fleet audit found they lag the doctrine the other 44 skills teach. The worst case is a correctness bug: `scenario-skyboxes`' Quick reference said `jobs_wait` "Block until the job completes" and never mentioned `pending_job_ids`, the only place in the repo contradicting the fleet-wide teaching that the ~180s server timeout is not an error. An agent triggering only this skill would treat a timeout as failure and double-spend with a second `model_run`.

## What changed

- **`scenario-skyboxes`**: Quick reference and worked example now teach `dry_run` pricing, `wait=false` launches, and the `pending_job_ids` re-call ("never a second `model_run`"). The panorama-to-splat paragraph now names `scenario-3d-worlds` (it described that pipeline without routing to the skill that teaches it, while 3d-worlds already points back here). Description gains the "HDRI" trigger keyword; heading renamed to the house `## Worked example:` structure; the authoring-time hedge now covers the parameter facts, not just the ids.
- **`scenario-textures`**: same doctrine fixes (`dry_run` batch pricing, `pending_job_ids` re-call). Its description promises "retexturing a mesh" but the body never routed anywhere: the PBR bullet now points to `scenario-3d` and `scenario-meshy`. The "What live search confirms" section is now labeled "confirmed at authoring time".
- **`scenario-game-assets`**: worked example gains the `dry_run` batch-pricing step and the `pending_job_ids` re-call, paid for by trimming redundant phrasing (stays at 898 words, under the 900 cap).
- `project-words.txt`: adds HDRI (sorted).

## Validation

- `pnpm validate` green (style, prettier, skill-files, groupings, readme, words, cspell, spec).
- Body budgets after change: skyboxes 662, textures 650, game-assets 898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill text; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Aligns `scenario-skyboxes`, `scenario-textures`, and `scenario-game-assets` with the fleet generation loop so agents do not treat a `jobs_wait` timeout as failure and double-spend with a second `model_run`.
> 
> Quick references and worked examples now teach `dry_run=true` pricing, `wait=false` launches, and re-calling `jobs_wait` with `pending_job_ids`. Skyboxes also add an HDRI trigger, rename the example heading, and route panorama-to-splat to `scenario-3d-worlds`. Textures point mesh retexturing at `scenario-3d` / `scenario-meshy`. Game-assets keep the same word budget while adding the same wait/pricing steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc4cc5470912a988d1f3d5e2707d3fbf8338d714. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->