### PR TITLE
feat(scenario-refine-loop): add the generate, critique, revise loop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Read finished assets back: caption them, extract a style or a control map, check
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | [scenario-asset-analysis](skills/scenario-asset-analysis/SKILL.md) | Reading assets back: captions, style descriptions, batch review against a brief, control maps, collections, tags                    |
 | [scenario-quality-gate](skills/scenario-quality-gate/SKILL.md)     | Pass/warn/fail image verdicts from the Quality Gate: free stored reads, dry-run pricing, feeding suggestions back into the next run |
+| [scenario-refine-loop](skills/scenario-refine-loop/SKILL.md)       | Iterating until output matches the brief: rubric first, batched critique verdicts, cheapest targeted fix, round caps                |
 
 ### Formats and placements
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -106,7 +106,11 @@
     {
       "title": "Reviewing and organizing output",
       "description": "Read finished assets back: caption them, extract a style or a control map, check a batch against a brief or the Quality Gate, and file the keepers.",
-      "skills": ["scenario-asset-analysis", "scenario-quality-gate"]
+      "skills": [
+        "scenario-asset-analysis",
+        "scenario-quality-gate",
+        "scenario-refine-loop"
+      ]
     },
     {
       "title": "Formats and placements",

--- a/skills/scenario-quality-gate/SKILL.md
+++ b/skills/scenario-quality-gate/SKILL.md
@@ -37,6 +37,8 @@ A verdict alone only sorts assets. The gate earns its cost when the feedback dri
 - When a round repeats the same flaw classes at an unmoved score, rewording will not fix them: switch models (`recommend` again) or repair the flaw with a masked edit before spending another round.
 - Fix the exit bar and a round cap up front: `verdict: "pass"` by default, or a score target the user names (`overallScore` at or above 90, say; the named bar then outranks a bare `pass`), and three rounds unless told otherwise, since every round bills a generation plus an analysis. At the cap, or when a round stops moving the scores, stop: report the best asset with its remaining flaws and ask before spending more rounds; unattended, deliver that best asset and flag the miss.
 
+`scenario-refine-loop` carries the loop discipline beyond the gate: one variable per round, regeneration from the approved baseline, and fix routing when the criteria go past the brief.
+
 ## Worked example: iterate a hero prop to pass
 
 1. Generate per `scenario-image`: `model_run`, `jobs_wait`, collect the asset id.

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -22,13 +22,13 @@ Agents fail generation QA in two symmetric ways: accepting the first roll, or re
 
 Fix routing, cheapest first:
 
-| The verdict says                                | Fix                                                                         |
-| ----------------------------------------------- | --------------------------------------------------------------------------- |
-| One local defect on a keeper                    | Masked inpaint of that region (`scenario-image`)                            |
-| A uniform finish off (grade, tint, crop)        | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
-| Wrong content, composition, or rendered palette | Edit the delta clause, re-run from the approved baseline                    |
-| Identity or style drift                         | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
-| Every line failing                              | Change the model (re-discover via `search` or `recommend`), keep the prompt |
+| The verdict says                                | Fix                                                                                                                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| One local defect on a keeper                    | Masked inpaint of that region (`scenario-image`)                                                                               |
+| A uniform finish off (grade, tint, crop)        | A deterministic tool pass (`scenario-image-editing`), not a re-roll                                                            |
+| Wrong content, composition, or rendered palette | Edit the delta clause, re-run from the approved baseline                                                                       |
+| Identity or style drift                         | Tighten the enumeration, add or re-role references (`scenario-consistency`)                                                    |
+| Every line failing                              | Change the model: re-discover with `recommend` (capability-shaped; `search` is for a name or a private model), keep the prompt |
 
 Change one variable per round. A round that swaps prompt, references, and model at once cannot attribute the improvement, so the next failure restarts from zero.
 
@@ -43,7 +43,7 @@ Change one variable per round. A round that swaps prompt, references, and model 
 2. Generate four, one `model_run` each per `scenario-image`, then `jobs_wait`.
 3. One `asset_analyze` call with all four ids in `images` and the rubric-plus-shape instruction; answers land as text assets, `asset_download` them to read the verdicts.
 4. Two fail. Icon 2 is off palette, which is rendered content rather than a finish: edit the delta clause by pinning the hex codes in the prompt and re-run from the baseline. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
-5. Re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
+5. `jobs_wait` the fix runs, then re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
 
 ## Common mistakes
 

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -20,6 +20,8 @@ Agents fail generation QA in two symmetric ways: accepting the first roll, or re
 | 4. Fix      | Route every fail line to the cheapest fix that addresses it (table below)                                                          |
 | 5. Stop     | A clean round ships; three rounds without one, or one line failing twice under different fixes, means report, not respin           |
 
+When the bar is the configured brand brief rather than a task rubric, and the team's Quality Gate add-on is enabled, critique images with `asset_quality_gate_run` instead: its `reasons` and `suggestions` feed the fix table directly (`scenario-quality-gate`; where the gate is missing it degrades to this `asset_analyze` path).
+
 Fix routing, cheapest first:
 
 | The verdict says                                | Fix                                                                                                                            |

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -22,13 +22,13 @@ Agents fail generation QA in two symmetric ways: accepting the first roll, or re
 
 Fix routing, cheapest first:
 
-| The verdict says              | Fix                                                                         |
-| ----------------------------- | --------------------------------------------------------------------------- |
-| One local defect on a keeper  | Masked inpaint of that region (`scenario-image`)                            |
-| Color, framing, or finish off | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
-| Wrong content or composition  | Edit the delta clause, re-run from the approved baseline                    |
-| Identity or style drift       | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
-| Every line failing            | Change the model (re-discover via `search` or `recommend`), keep the prompt |
+| The verdict says                                | Fix                                                                         |
+| ----------------------------------------------- | --------------------------------------------------------------------------- |
+| One local defect on a keeper                    | Masked inpaint of that region (`scenario-image`)                            |
+| A uniform finish off (grade, tint, crop)        | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
+| Wrong content, composition, or rendered palette | Edit the delta clause, re-run from the approved baseline                    |
+| Identity or style drift                         | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
+| Every line failing                              | Change the model (re-discover via `search` or `recommend`), keep the prompt |
 
 Change one variable per round. A round that swaps prompt, references, and model at once cannot attribute the improvement, so the next failure restarts from zero.
 
@@ -42,7 +42,7 @@ Change one variable per round. A round that swaps prompt, references, and model 
 1. Rubric from the brief, five lines: single object, centered, plain field, palette #2A9D8F and #E9C46A only, no text.
 2. Generate four, one `model_run` each per `scenario-image`, then `jobs_wait`.
 3. One `asset_analyze` call with all four ids in `images` and the rubric-plus-shape instruction; answers land as text assets, `asset_download` them to read the verdicts.
-4. Two fail. Icon 2 is off palette: re-run its prompt with the hex codes pinned. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
+4. Two fail. Icon 2 is off palette, which is rendered content rather than a finish: edit the delta clause by pinning the hex codes in the prompt and re-run from the baseline. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
 5. Re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
 
 ## Common mistakes
@@ -51,5 +51,5 @@ Change one variable per round. A round that swaps prompt, references, and model 
 - Asking `asset_analyze` to improve or fix the image: it returns text only; every fix is a new run.
 - Re-rolling the whole batch because one item failed: route per item.
 - Writing the rubric after seeing the batch: it inherits the batch's flaws as the standard.
-- Running the loop uncapped: failed jobs are reimbursed, unsatisfying ones are not; `usage` tracks spend against the brief's ceiling.
+- Running the loop uncapped: failed jobs are reimbursed, unsatisfying ones are not. Gate rounds on the costs the runs themselves report (`dry_run` prices the next round ahead); `usage` totals lag and answer the report after the run, not the mid-run gate.
 - Retrying a criterion a third time on the same model: two misses under two different fixes is evidence about the model, not bad luck.

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: scenario-refine-loop
+description: "Use when a Scenario output must be checked and improved rather than accepted first roll: iterating a generation until it matches the brief, fixing a batch that came back off-brief, retrying failed shots methodically, wiring an automated generate, review, revise loop, or deciding whether to re-prompt, swap references, inpaint, post-process, or change model. Keywords: refine, iterate, critique, review loop, QA, self-correction, verify, acceptance criteria, retry, drift."
+license: MIT
+---
+
+# Scenario Refine Loop
+
+## Overview
+
+Agents fail generation QA in two symmetric ways: accepting the first roll, or rewording the whole prompt and re-rolling until the budget dies. Both skip the same two artifacts, a written rubric and a diagnosis. The loop that converges: rubric before generating, a small batch, a recorded verdict per asset, the cheapest targeted fix per failure, a hard round cap. Connection and the core loop: see the `scenario` skill. Critic tool contracts: `scenario-asset-analysis`. Baseline discipline: `scenario-consistency`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
+## Quick reference
+
+| Step        | Do                                                                                                                                 |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Rubric   | Before generating, turn the brief into pass/fail lines a viewer can check ("subject centered on a plain field"), never taste words |
+| 2. Generate | The smallest batch that tests the recipe; `dry_run` when cost matters                                                              |
+| 3. Critique | `asset_analyze`: up to 10 images per call, one instruction embedding the rubric and a fixed per-image output shape                 |
+| 4. Fix      | Route every fail line to the cheapest fix that addresses it (table below)                                                          |
+| 5. Stop     | A clean round ships; three rounds without one, or one line failing twice under different fixes, means report, not respin           |
+
+Fix routing, cheapest first:
+
+| The verdict says              | Fix                                                                         |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| One local defect on a keeper  | Masked inpaint of that region (`scenario-image`)                            |
+| Color, framing, or finish off | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
+| Wrong content or composition  | Edit the delta clause, re-run from the approved baseline                    |
+| Identity or style drift       | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
+| Every line failing            | Change the model (re-discover via `search` or `recommend`), keep the prompt |
+
+Change one variable per round. A round that swaps prompt, references, and model at once cannot attribute the improvement, so the next failure restarts from zero.
+
+## The two rules that keep the loop honest
+
+- **Verdicts cite the rubric, not taste.** Instruct the critic to answer per image, in order: `<index>: pass|fail, <the failed line>`. "Could be better" is not a verdict; a loop chasing better instead of the brief sands off exactly what made the direction distinctive and converges on generic output.
+- **Regenerate from the baseline, never from the last attempt.** Fixes re-run from the approved reference and prompt; chaining output to output compounds drift (`scenario-consistency` explains why).
+
+## Worked example: four icons against a brief
+
+1. Rubric from the brief, five lines: single object, centered, plain field, palette #2A9D8F and #E9C46A only, no text.
+2. Generate four, one `model_run` each per `scenario-image`, then `jobs_wait`.
+3. One `asset_analyze` call with all four ids in `images` and the rubric-plus-shape instruction; answers land as text assets, `asset_download` them to read the verdicts.
+4. Two fail. Icon 2 is off palette: re-run its prompt with the hex codes pinned. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
+5. Re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
+
+## Common mistakes
+
+- Judging by glancing at `asset_display` in chat: unrecorded impressions do not accumulate; verdicts do.
+- Asking `asset_analyze` to improve or fix the image: it returns text only; every fix is a new run.
+- Re-rolling the whole batch because one item failed: route per item.
+- Writing the rubric after seeing the batch: it inherits the batch's flaws as the standard.
+- Running the loop uncapped: failed jobs are reimbursed, unsatisfying ones are not; `usage` tracks spend against the brief's ceiling.
+- Retrying a criterion a third time on the same model: two misses under two different fixes is evidence about the model, not bad luck.


### PR DESCRIPTION
## Summary

- New skill `scenario-refine-loop`: the closed generate, critique, revise loop that takes a Scenario generation from first roll to on-brief. Rubric before generating (pass/fail lines a viewer can check, never taste words), the smallest batch that tests the recipe, batched `asset_analyze` verdicts (up to 10 images per call, fixed per-image verdict shape), and hard stop rules: a clean round ships; three rounds without one, or one criterion failing twice under different fixes, means report rather than respin.
- Cheapest-fix routing table: masked inpaint for a local defect, deterministic tool pass for a uniform finish, delta re-run from the approved baseline for content, reference changes for drift, model change (via `recommend`) when every line fails. One variable per round; regenerate from the baseline, never from the last attempt.
- Grouped with the Quality Gate: listed under "Reviewing and organizing output" beside `scenario-asset-analysis` and `scenario-quality-gate` in both `README.md` and `skills.sh.json`.
- Bidirectional cross-references: the loop's critique step hands image critique to `asset_quality_gate_run` (per `scenario-quality-gate`) when the bar is the configured brand brief and the team has the add-on, keeping the rubric-plus-`asset_analyze` path as the default; the gate skill points back at the loop for the round discipline (one variable per round, baseline regeneration, fix routing past the brief).
- Review feedback folded in: `jobs_wait` on fix runs before re-critique, `recommend` (capability-shaped) split from `search` (name or private model), palette failures routed consistently in table and worked example, and round spend gated on run-reported costs with `dry_run` pricing (with the `usage`-lag caveat).

## Validation

- [x] `pnpm run validate` passes end to end: house style, prettier formatting, supporting-file checks, `skills.sh.json` groupings, README rows, sorted word list, cspell, and `skills-ref` spec validation
- [x] `scenario-refine-loop` description 472 chars, third person, starts "Use when"
- [x] Bodies in budget: `scenario-refine-loop` at 771 words (inside the 600-900 target); `scenario-quality-gate` gains two lines and stays under the hard cap
- [x] Tool and parameter claims grounded in the public tool reference and the existing `scenario` / `scenario-asset-analysis` / `scenario-quality-gate` contracts (no new tool surface asserted)
- [x] Rebased onto current `main`: linear five-commit history, no conflicts

## Stats

- 4 files changed, 65 insertions(+), 1 deletion(-)
- Skills touched: `scenario-refine-loop` (new), `scenario-quality-gate` (two-line back-reference), plus the `README.md` row and `skills.sh.json` grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPFcEdEGwCFMfrHCY91uAh