### PR TITLE
feat(scenario-formats): add the multi-placement derivation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ Turn a blank brief into references, options someone can choose between, and a mo
 
 Generate and edit images: model choice, sizing, references, masked edits, post-processing tools, and letter-perfect text overlay cards.
 
-| Skill                                                            | Use it for                                                                                                                   |
-| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| [scenario-image](skills/scenario-image/SKILL.md)                 | Text-to-image and image editing: model choice, sizing fields, prompt limits, reference images, masked inpainting             |
-| [scenario-image-editing](skills/scenario-image-editing/SKILL.md) | Tool-model image edits: 3D LUT grades, effects, expand and reframe, resize, slicing, layers, background removal              |
-| [scenario-formats](skills/scenario-formats/SKILL.md)             | Deriving every placement from one master, image or video: crop vs resize vs expand vs reframe, platform specs and safe areas |
-| [scenario-text-overlay](skills/scenario-text-overlay/SKILL.md)   | Letter-perfect text overlays: templated transparent PNG cards (taglines, CTAs, legal supers, rich cards) to composite        |
-| [scenario-storyboards](skills/scenario-storyboards/SKILL.md)     | Comic pages, storybooks, and pre-viz storyboards: script first, one run per panel, a locked cast, lettering in post          |
+| Skill                                                            | Use it for                                                                                                            |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| [scenario-image](skills/scenario-image/SKILL.md)                 | Text-to-image and image editing: model choice, sizing fields, prompt limits, reference images, masked inpainting      |
+| [scenario-image-editing](skills/scenario-image-editing/SKILL.md) | Tool-model image edits: 3D LUT grades, effects, expand and reframe, resize, slicing, layers, background removal       |
+| [scenario-text-overlay](skills/scenario-text-overlay/SKILL.md)   | Letter-perfect text overlays: templated transparent PNG cards (taglines, CTAs, legal supers, rich cards) to composite |
+| [scenario-storyboards](skills/scenario-storyboards/SKILL.md)     | Comic pages, storybooks, and pre-viz storyboards: script first, one run per panel, a locked cast, lettering in post   |
 
 ### Image model families
 
@@ -160,6 +159,14 @@ Read finished assets back: caption them, extract a style or a control map, check
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | [scenario-asset-analysis](skills/scenario-asset-analysis/SKILL.md) | Reading assets back: captions, style descriptions, batch review against a brief, control maps, collections, tags                    |
 | [scenario-quality-gate](skills/scenario-quality-gate/SKILL.md)     | Pass/warn/fail image verdicts from the Quality Gate: free stored reads, dry-run pricing, feeding suggestions back into the next run |
+
+### Formats and placements
+
+Ship one approved master, image or video, to every placement: ratios, safe zones, and platform specs from social feeds to shops, storefronts, and print.
+
+| Skill                                                | Use it for                                                                                                                   |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [scenario-formats](skills/scenario-formats/SKILL.md) | Deriving every placement from one master, image or video: crop vs resize vs expand vs reframe, platform specs and safe areas |
 
 ### Workflows and apps
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Generate and edit images: model choice, sizing, references, masked edits, post-p
 | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | [scenario-image](skills/scenario-image/SKILL.md)                 | Text-to-image and image editing: model choice, sizing fields, prompt limits, reference images, masked inpainting      |
 | [scenario-image-editing](skills/scenario-image-editing/SKILL.md) | Tool-model image edits: 3D LUT grades, effects, expand and reframe, resize, slicing, layers, background removal       |
+| [scenario-formats](skills/scenario-formats/SKILL.md)             | Deriving every placement from one master: crop vs resize vs expand vs reframe, safe areas, per-format text overlay    |
 | [scenario-text-overlay](skills/scenario-text-overlay/SKILL.md)   | Letter-perfect text overlays: templated transparent PNG cards (taglines, CTAs, legal supers, rich cards) to composite |
 | [scenario-storyboards](skills/scenario-storyboards/SKILL.md)     | Comic pages, storybooks, and pre-viz storyboards: script first, one run per panel, a locked cast, lettering in post   |
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Turn a blank brief into references, options someone can choose between, and a mo
 
 Generate and edit images: model choice, sizing, references, masked edits, post-processing tools, and letter-perfect text overlay cards.
 
-| Skill                                                            | Use it for                                                                                                            |
-| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| [scenario-image](skills/scenario-image/SKILL.md)                 | Text-to-image and image editing: model choice, sizing fields, prompt limits, reference images, masked inpainting      |
-| [scenario-image-editing](skills/scenario-image-editing/SKILL.md) | Tool-model image edits: 3D LUT grades, effects, expand and reframe, resize, slicing, layers, background removal       |
-| [scenario-formats](skills/scenario-formats/SKILL.md)             | Deriving every placement from one master: crop vs resize vs expand vs reframe, safe areas, per-format text overlay    |
-| [scenario-text-overlay](skills/scenario-text-overlay/SKILL.md)   | Letter-perfect text overlays: templated transparent PNG cards (taglines, CTAs, legal supers, rich cards) to composite |
-| [scenario-storyboards](skills/scenario-storyboards/SKILL.md)     | Comic pages, storybooks, and pre-viz storyboards: script first, one run per panel, a locked cast, lettering in post   |
+| Skill                                                            | Use it for                                                                                                                   |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [scenario-image](skills/scenario-image/SKILL.md)                 | Text-to-image and image editing: model choice, sizing fields, prompt limits, reference images, masked inpainting             |
+| [scenario-image-editing](skills/scenario-image-editing/SKILL.md) | Tool-model image edits: 3D LUT grades, effects, expand and reframe, resize, slicing, layers, background removal              |
+| [scenario-formats](skills/scenario-formats/SKILL.md)             | Deriving every placement from one master, image or video: crop vs resize vs expand vs reframe, platform specs and safe areas |
+| [scenario-text-overlay](skills/scenario-text-overlay/SKILL.md)   | Letter-perfect text overlays: templated transparent PNG cards (taglines, CTAs, legal supers, rich cards) to composite        |
+| [scenario-storyboards](skills/scenario-storyboards/SKILL.md)     | Comic pages, storybooks, and pre-viz storyboards: script first, one run per panel, a locked cast, lettering in post          |
 
 ### Image model families
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -18,7 +18,6 @@
       "skills": [
         "scenario-image",
         "scenario-image-editing",
-        "scenario-formats",
         "scenario-text-overlay",
         "scenario-storyboards"
       ]
@@ -108,6 +107,11 @@
       "title": "Reviewing and organizing output",
       "description": "Read finished assets back: caption them, extract a style or a control map, check a batch against a brief or the Quality Gate, and file the keepers.",
       "skills": ["scenario-asset-analysis", "scenario-quality-gate"]
+    },
+    {
+      "title": "Formats and placements",
+      "description": "Ship one approved master, image or video, to every placement: ratios, safe zones, and platform specs from social feeds to shops, storefronts, and print.",
+      "skills": ["scenario-formats"]
     },
     {
       "title": "Workflows and apps",

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -18,6 +18,7 @@
       "skills": [
         "scenario-image",
         "scenario-image-editing",
+        "scenario-formats",
         "scenario-text-overlay",
         "scenario-storyboards"
       ]

--- a/skills/scenario-formats/SKILL.md
+++ b/skills/scenario-formats/SKILL.md
@@ -36,8 +36,8 @@ The last rung applies more often than it looks: 16:9 key art seldom survives to 
 1. Master: 16:9 text-free key art, approved.
 2. 1:1 feed: generative reframe with a prompt naming what must stay ("the knight centered, both banners visible"), then a resize pass to the exact deliverable pixels.
 3. 9:16 story: a far ratio, so recompose natively: one run per `scenario-image` with the master as reference and a 9:16 composition clause; the master holds palette and subject on-look.
-4. Thumbnail: readability rules the crop, so reframe tight on the face or product, then `asset_display` the result and judge it small: thumbnails are seen at a tenth of their size.
-5. Verify dimensions against the deliverable list, overlay the title card per format onto each final canvas, then file the set in a collection.
+4. Thumbnail: readability rules the crop, so reframe tight on the face or product, land exact with a resize, then `asset_display` the result and judge it small: thumbnails are seen at a tenth of their size.
+5. Verify dimensions against the deliverable list and batch-check that subjects survived with one `asset_analyze` pass, then overlay the title card per format onto each final canvas and file the set in a collection.
 
 ## Common mistakes
 

--- a/skills/scenario-formats/SKILL.md
+++ b/skills/scenario-formats/SKILL.md
@@ -25,11 +25,11 @@ The last rung applies more often than it looks: 16:9 key art seldom survives to 
 
 ## Order of operations
 
-1. Approve one master first, at the largest clean size available, on a text-free plate.
+1. Approve one master first, at the largest clean size available, on a text-free plate (unattended, the task's named master or the brief's own description stands in for the approval).
 2. Derive every format from that master, never from another derivative: derivative-of-derivative compounds re-rendering artifacts.
 3. Reframe and expand before grading and grain: generative canvas work re-renders the image, so finishing passes applied first come back partly reinterpreted (`scenario-image-editing` holds the pipeline order).
-4. Re-overlay lettering per format with `scenario-text-overlay`, sized to each canvas: type scaled by a resize turns soft, and each placement has its own safe area. Keep critical content and text away from the edges platform UI covers, and confirm exact current specs per platform with the user rather than assuming them.
-5. Verify by measurement: reframe ratio enums are approximate (a 4:5 request came back 29:36 at authoring time), so check output dimensions and finish with a resize, then batch-check that subjects and lettering survived with `asset_analyze` (`scenario-asset-analysis`).
+4. Verify by measurement before finishing: reframe ratio enums are approximate (a 4:5 request came back 29:36 at authoring time), so check output dimensions, land exact with a resize, and batch-check that subjects survived with `asset_analyze` (`scenario-asset-analysis`).
+5. Letter last: re-overlay lettering per format with `scenario-text-overlay`, sized to each final canvas, since type scaled by a resize turns soft and each placement has its own safe area. Keep critical content and text away from the edges platform UI covers, and confirm current per-platform specs with the user rather than assuming them (unattended, take them from the task instructions, else state the assumption in the delivery report).
 
 ## Worked example: key art to story, feed, and thumbnail
 
@@ -37,7 +37,7 @@ The last rung applies more often than it looks: 16:9 key art seldom survives to 
 2. 1:1 feed: generative reframe with a prompt naming what must stay ("the knight centered, both banners visible"), then a resize pass to the exact deliverable pixels.
 3. 9:16 story: a far ratio, so recompose natively: one run per `scenario-image` with the master as reference and a 9:16 composition clause; the master holds palette and subject on-look.
 4. Thumbnail: readability rules the crop, so reframe tight on the face or product, then `asset_display` the result and judge it small: thumbnails are seen at a tenth of their size.
-5. Overlay the title card per format, verify dimensions against the deliverable list, then file the set in a collection.
+5. Verify dimensions against the deliverable list, overlay the title card per format onto each final canvas, then file the set in a collection.
 
 ## Common mistakes
 

--- a/skills/scenario-formats/SKILL.md
+++ b/skills/scenario-formats/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Format adaptation is derivation, not regeneration: re-prompting the concept per placement makes five cousins, not five formats of one approved master. The failure modes are picking the wrong operation (a resize where canvas needed inventing, a crop that beheads the subject) and deriving in the wrong order. The canvas tools' exact contracts live in `scenario-image-editing`; this skill is the decision ladder and the order of operations around them. Connection and the core loop: see the `scenario` skill. Lettering per format: `scenario-text-overlay`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+Format adaptation is derivation, not regeneration: re-prompting the concept per placement makes five cousins, not five formats of one approved master. The failure modes are picking the wrong operation (a resize where canvas needed inventing, a crop that beheads the subject) and deriving in the wrong order. The canvas tools' exact contracts live in `scenario-image-editing`; this skill is the decision ladder and the order of operations around them, with per-placement ratios, pixel targets, and safe zones in [references/placement-specs.md](references/placement-specs.md). Connection and the core loop: see the `scenario` skill. Lettering per format: `scenario-text-overlay`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
 
 ## The decision ladder
 
@@ -29,7 +29,7 @@ The last rung applies more often than it looks: 16:9 key art seldom survives to 
 2. Derive every format from that master, never from another derivative: derivative-of-derivative compounds re-rendering artifacts.
 3. Reframe and expand before grading and grain: generative canvas work re-renders the image, so finishing passes applied first come back partly reinterpreted (`scenario-image-editing` holds the pipeline order).
 4. Verify by measurement before finishing: reframe ratio enums are approximate (a 4:5 request came back 29:36 at authoring time), so check output dimensions, land exact with a resize, and batch-check that subjects survived with `asset_analyze` (`scenario-asset-analysis`).
-5. Letter last: re-overlay lettering per format with `scenario-text-overlay`, sized to each final canvas, since type scaled by a resize turns soft and each placement has its own safe area. Keep critical content and text away from the edges platform UI covers, and confirm current per-platform specs with the user rather than assuming them (unattended, take them from the task instructions, else state the assumption in the delivery report).
+5. Letter last: re-overlay lettering per format with `scenario-text-overlay`, sized to each final canvas, since type scaled by a resize turns soft and each placement has its own safe area. Keep critical content and text away from the edges platform UI covers: each placement's target and safe zone is in [references/placement-specs.md](references/placement-specs.md) as an authoring-time value, so confirm contractual specs with the user (unattended, task instructions win over the reference, and the delivery report states which was used).
 
 ## Worked example: key art to story, feed, and thumbnail
 

--- a/skills/scenario-formats/SKILL.md
+++ b/skills/scenario-formats/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-formats
-description: "Use when one approved visual must ship at many sizes or placements through Scenario: adapting a master to 1:1, 4:5, 9:16, or 16:9, social formats for feeds and stories, YouTube thumbnails, storefront capsules and app store graphics, display banners, a website hero, or choosing between crop, resize, expand, and generative reframe. Keywords: aspect ratio, resize, reframe, outpaint, expand, derivative, adaptation, safe zone, thumbnail, banner."
+description: "Use when one approved visual, image or video, must ship at many sizes or placements through Scenario: adapting a master to 1:1, 4:5, 9:16, or 16:9, social formats for feeds and stories, YouTube thumbnails, storefront capsules and app store graphics, marketplace product images, link previews, display banners, a website hero, or choosing between crop, resize, expand, and generative reframe. Keywords: aspect ratio, resize, reframe, outpaint, expand, derivative, safe zone, thumbnail, banner."
 license: MIT
 ---
 
@@ -8,7 +8,7 @@ license: MIT
 
 ## Overview
 
-Format adaptation is derivation, not regeneration: re-prompting the concept per placement makes five cousins, not five formats of one approved master. The failure modes are picking the wrong operation (a resize where canvas needed inventing, a crop that beheads the subject) and deriving in the wrong order. The canvas tools' exact contracts live in `scenario-image-editing`; this skill is the decision ladder and the order of operations around them, with per-placement ratios, pixel targets, and safe zones in [references/placement-specs.md](references/placement-specs.md). Connection and the core loop: see the `scenario` skill. Lettering per format: `scenario-text-overlay`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+Format adaptation is derivation, not regeneration: re-prompting the concept per placement makes five cousins, not five formats of one approved master. The failure modes are picking the wrong operation (a resize where canvas needed inventing, a crop that beheads the subject) and deriving in the wrong order. The canvas tools' exact contracts live in `scenario-image-editing`; this skill is the decision ladder and the order of operations around them, with per-placement ratios, pixel targets, and safe zones in [references/placement-specs.md](references/placement-specs.md). A video master climbs the same ladder: video resize versus generative reframe lives in `scenario-video-editing`, and far ratios recompose per `scenario-video`. Connection and the core loop: see the `scenario` skill. Lettering per format: `scenario-text-overlay`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
 
 ## The decision ladder
 

--- a/skills/scenario-formats/SKILL.md
+++ b/skills/scenario-formats/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: scenario-formats
+description: "Use when one approved visual must ship at many sizes or placements through Scenario: adapting a master to 1:1, 4:5, 9:16, or 16:9, social formats for feeds and stories, YouTube thumbnails, storefront capsules and app store graphics, display banners, a website hero, or choosing between crop, resize, expand, and generative reframe. Keywords: aspect ratio, resize, reframe, outpaint, expand, derivative, adaptation, safe zone, thumbnail, banner."
+license: MIT
+---
+
+# Scenario Formats
+
+## Overview
+
+Format adaptation is derivation, not regeneration: re-prompting the concept per placement makes five cousins, not five formats of one approved master. The failure modes are picking the wrong operation (a resize where canvas needed inventing, a crop that beheads the subject) and deriving in the wrong order. The canvas tools' exact contracts live in `scenario-image-editing`; this skill is the decision ladder and the order of operations around them. Connection and the core loop: see the `scenario` skill. Lettering per format: `scenario-text-overlay`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
+## The decision ladder
+
+Per target format, take the first rung that fits:
+
+| The target needs                             | Operation                                                                                                                           |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Same ratio, other pixels                     | Resize: exact, scales pixels, invents nothing                                                                                       |
+| More canvas, composition intact              | Expand or uncrop: exact pixels, fills outward                                                                                       |
+| Another ratio, recomposed around the subject | Generative reframe; the text-protecting variant when lettering or marks are on the plate                                            |
+| A far ratio or a new visual hierarchy        | Recompose natively: a fresh run per `scenario-image` with the master as reference (`scenario-consistency`), composed for that ratio |
+
+The last rung applies more often than it looks: 16:9 key art seldom survives to 9:16 by any amount of outpainting, which is why the director siblings (`scenario-video-ads`) design each delivery ratio as its own composition.
+
+## Order of operations
+
+1. Approve one master first, at the largest clean size available, on a text-free plate.
+2. Derive every format from that master, never from another derivative: derivative-of-derivative compounds re-rendering artifacts.
+3. Reframe and expand before grading and grain: generative canvas work re-renders the image, so finishing passes applied first come back partly reinterpreted (`scenario-image-editing` holds the pipeline order).
+4. Re-overlay lettering per format with `scenario-text-overlay`, sized to each canvas: type scaled by a resize turns soft, and each placement has its own safe area. Keep critical content and text away from the edges platform UI covers, and confirm exact current specs per platform with the user rather than assuming them.
+5. Verify by measurement: reframe ratio enums are approximate (a 4:5 request came back 29:36 at authoring time), so check output dimensions and finish with a resize, then batch-check that subjects and lettering survived with `asset_analyze` (`scenario-asset-analysis`).
+
+## Worked example: key art to story, feed, and thumbnail
+
+1. Master: 16:9 text-free key art, approved.
+2. 1:1 feed: generative reframe with a prompt naming what must stay ("the knight centered, both banners visible"), then a resize pass to the exact deliverable pixels.
+3. 9:16 story: a far ratio, so recompose natively: one run per `scenario-image` with the master as reference and a 9:16 composition clause; the master holds palette and subject on-look.
+4. Thumbnail: readability rules the crop, so reframe tight on the face or product, then `asset_display` the result and judge it small: thumbnails are seen at a tenth of their size.
+5. Overlay the title card per format, verify dimensions against the deliverable list, then file the set in a collection.
+
+## Common mistakes
+
+- Re-prompting per format: five generations of one prompt are five different images; derive from the master.
+- Stretching into a new ratio with a resize: it scales pixels; ratio changes take reframe, expand, or recomposition.
+- Grading and grain before reframing: the order is reshape, then grade, then texture.
+- Deriving from the lettered master: generative operations re-render type; keep a text-free plate and re-overlay per format.
+- Trusting a ratio enum: measure the output and resize to exact.
+- Center-cropping toward 9:16 because it is cheap: it is also how subjects lose their heads; the ladder exists to be climbed.
+- Skipping `dry_run` on reframes: generative canvas work is the expensive step in the chain, tens of times an effect's price (`scenario-image-editing`).

--- a/skills/scenario-formats/references/placement-specs.md
+++ b/skills/scenario-formats/references/placement-specs.md
@@ -1,0 +1,84 @@
+# Placement specs
+
+Authoring-time values (2026). Platform UI and store requirements churn: treat every row as the default, confirm contractual deliverables against the platform's current published spec, and read safe zones as approximate. The workflow around these numbers is SKILL.md's ladder and order of operations: aim generative work at the row's ratio, land exact pixels with a resize, then verify by measurement.
+
+## Social
+
+| Placement                 | Ratio  | Pixels          | Notes                                                                    |
+| ------------------------- | ------ | --------------- | ------------------------------------------------------------------------ |
+| Instagram feed, square    | 1:1    | 1080x1080       | Portrait 4:5 earns more feed screen                                      |
+| Instagram feed, portrait  | 4:5    | 1080x1350       | Grid preview crops toward square: keep the subject centered              |
+| Instagram story or reel   | 9:16   | 1080x1920       | 9:16 safe zone below                                                     |
+| TikTok                    | 9:16   | 1080x1920       | 9:16 safe zone below; the right rail holds action buttons                |
+| YouTube thumbnail         | 16:9   | 1280x720        | Judge it at a tenth of its size; bottom right carries the duration badge |
+| YouTube channel banner    | 16:9   | 2560x1440       | Only a centered band near 1546x423 is visible on every device            |
+| X (Twitter) in-feed       | 16:9   | 1200x675        | 1:1 also renders clean in feed                                           |
+| X (Twitter) header        | 3:1    | 1500x500        | The avatar overlaps the lower left                                       |
+| LinkedIn feed / link card | 1.91:1 | 1200x627        |                                                                          |
+| Facebook feed             | 4:5    | 1080x1350       | Link cards render 1.91:1 at 1200x630                                     |
+| Facebook page cover       | ~2.6:1 | 820x312         | Mobile crops the sides: keep content central                             |
+| Pinterest pin             | 2:3    | 1000x1500       | Taller pins get cut in feed                                              |
+| Profile picture / avatar  | 1:1    | 400x400 or more | Displayed as a circle: keep the mark inside the inscribed circle         |
+
+## The 9:16 safe zone
+
+Platform UI eats the edges of stories, reels, and TikTok. Keep the subject, all text, and any mark inside the central band: clear roughly the top 14 percent, the bottom 35 percent, and 6 to 13 percent per side (as of 2026, the same band `scenario-video-ads` composes video masters to). One composition inside that band passes every 9:16 placement.
+
+## Screen, cinema, and hero
+
+| Placement          | Ratio         | Pixels                              | Notes                                                                                 |
+| ------------------ | ------------- | ----------------------------------- | ------------------------------------------------------------------------------------- |
+| HD frame / cover   | 16:9          | 1920x1080                           |                                                                                       |
+| UHD frame          | 16:9          | 3840x2160                           |                                                                                       |
+| Cinema flat still  | 1.85:1        | 1998x1080 (DCI 2K), 3996x2160 (4K)  |                                                                                       |
+| Cinema scope still | 2.39:1        | 2048x858 (DCI 2K), 4096x1716 (4K)   |                                                                                       |
+| Ultrawide monitor  | 21:9          | 3440x1440                           | Also 2560x1080                                                                        |
+| Website hero       | site-specific | commonly 1920 wide, 500 to 800 tall | Measure the live slot; heroes crop responsively, keep the subject in the center third |
+
+## Phone, tablet, desktop
+
+| Placement         | Ratio   | Pixels          | Notes                                                                                                  |
+| ----------------- | ------- | --------------- | ------------------------------------------------------------------------------------------------------ |
+| Phone wallpaper   | ~9:19.5 | 1290x2796 class | Devices vary and parallax crops: subject centered, clock up top, dock at the bottom                    |
+| Tablet wallpaper  | ~3:4    | 2048x2732 class |                                                                                                        |
+| Desktop wallpaper | 16:9    | 3840x2160       |                                                                                                        |
+| App icon          | 1:1     | 1024x1024       | The OS applies the rounded mask: keep the mark inside the central 80 percent; iOS forbids transparency |
+
+## Storefront and app stores
+
+| Placement                   | Ratio   | Pixels          | Notes                                                                          |
+| --------------------------- | ------- | --------------- | ------------------------------------------------------------------------------ |
+| Steam header capsule        | ~2.14:1 | 920x430         | The logo must read at half size                                                |
+| Steam main capsule          | ~1.75:1 | 1232x706        |                                                                                |
+| Steam small capsule         | ~2.65:1 | 462x174         | Displayed as small as 231x87: logo nearly full-frame                           |
+| Steam vertical capsule      | ~5:6    | 748x896         |                                                                                |
+| Steam library capsule       | 2:3     | 600x900         |                                                                                |
+| Steam library hero          | ~3.1:1  | 3840x1240       | The logo ships as a separate transparent PNG layer                             |
+| iOS App Store screenshot    | ~9:19.5 | 1290x2796 class | Exact sizes track current device classes: take them from the store's spec page |
+| Google Play feature graphic | ~2:1    | 1024x500        |                                                                                |
+
+## Display banners and email
+
+| Placement        | Pixels         | Notes                                                            |
+| ---------------- | -------------- | ---------------------------------------------------------------- |
+| Medium rectangle | 300x250        | The workhorse IAB size                                           |
+| Leaderboard      | 728x90         |                                                                  |
+| Half page        | 300x600        |                                                                  |
+| Wide skyscraper  | 160x600        |                                                                  |
+| Mobile banner    | 320x50         | Also 320x100                                                     |
+| Billboard        | 970x250        |                                                                  |
+| Email header     | 1200x400 class | Emails render near 600 wide; deliver 2x for high-density screens |
+
+Banners are far ratios on tiny canvases: recompose natively (the ladder's last rung) rather than reframing, and letter at final size with `scenario-text-overlay`.
+
+## Print
+
+| Placement              | Trim       | Pixels at 300 dpi | Notes |
+| ---------------------- | ---------- | ----------------- | ----- |
+| A4                     | 210x297 mm | 2480x3508         |       |
+| A3                     | 297x420 mm | 3508x4961         |       |
+| A2                     | 420x594 mm | 4961x7016         |       |
+| US letter              | 8.5x11 in  | 2550x3300         |       |
+| Movie one-sheet poster | 27x40 in   | 8100x12000        |       |
+
+Add 3 mm of bleed per edge (0.125 in on US trims) and keep text 5 mm inside the trim. 300 dpi targets exceed native generation sizes: generate the master at the largest clean size, upscale to the print target (`search` query `"upscale"`), and only then letter.

--- a/skills/scenario-formats/references/placement-specs.md
+++ b/skills/scenario-formats/references/placement-specs.md
@@ -15,10 +15,11 @@ Authoring-time values (2026). Platform UI and store requirements churn: treat ev
 | X (Twitter) in-feed       | 16:9   | 1200x675        | 1:1 also renders clean in feed                                           |
 | X (Twitter) header        | 3:1    | 1500x500        | The avatar overlaps the lower left                                       |
 | LinkedIn feed / link card | 1.91:1 | 1200x627        |                                                                          |
-| Facebook feed             | 4:5    | 1080x1350       | Link cards render 1.91:1 at 1200x630                                     |
+| Facebook feed             | 4:5    | 1080x1350       | Link cards follow the Open Graph row                                     |
 | Facebook page cover       | ~2.6:1 | 820x312         | Mobile crops the sides: keep content central                             |
 | Pinterest pin             | 2:3    | 1000x1500       | Taller pins get cut in feed                                              |
 | Profile picture / avatar  | 1:1    | 400x400 or more | Displayed as a circle: keep the mark inside the inscribed circle         |
+| Link preview (Open Graph) | 1.91:1 | 1200x630        | One og:image serves most share targets; keep text large, feeds downscale |
 
 ## The 9:16 safe zone
 
@@ -56,6 +57,39 @@ Platform UI eats the edges of stories, reels, and TikTok. Keep the subject, all 
 | Steam library hero          | ~3.1:1  | 3840x1240       | The logo ships as a separate transparent PNG layer                             |
 | iOS App Store screenshot    | ~9:19.5 | 1290x2796 class | Exact sizes track current device classes: take them from the store's spec page |
 | Google Play feature graphic | ~2:1    | 1024x500        |                                                                                |
+| Epic Games Store offer      | 3:4     | 1200x1600       | Landscape variant 2560x1440                                                    |
+| itch.io cover               | ~5:4    | 630x500         |                                                                                |
+
+## Shops and marketplaces
+
+| Placement            | Ratio | Pixels          | Notes                                                               |
+| -------------------- | ----- | --------------- | ------------------------------------------------------------------- |
+| Amazon listing       | 1:1   | 1600x1600 class | Zoom needs 1000 or more on the longest side                         |
+| eBay listing         | 1:1   | 1600x1600 class | Minimum 500 on the longest side                                     |
+| Etsy listing         | 4:3   | 2700x2025       | Feed thumbnail crops to 4:3; keep 2000 or more on the shortest side |
+| Shopify product      | 1:1   | 2048x2048       |                                                                     |
+| Google Shopping feed | 1:1   | 800x800 or more | Apparel minimum 250x250                                             |
+
+Marketplace main images are policy surfaces, not creative ones: Amazon wants the product on pure white (RGB 255, 255, 255) filling about 85 percent of the frame with no text, logos, or watermarks, and the other marketplaces run close variants. The text-free master doctrine pays off here: the master is the main image, and lettered or lifestyle derivatives fill the secondary slots and social placements.
+
+## Streaming and community
+
+| Placement             | Ratio    | Pixels    | Notes                                     |
+| --------------------- | -------- | --------- | ----------------------------------------- |
+| Twitch profile banner | 2.5:1    | 1200x480  |                                           |
+| Twitch offline screen | 16:9     | 1920x1080 |                                           |
+| Twitch panel          | flexible | 320 wide  |                                           |
+| Twitch emote          | 1:1      | 112x112   | Auto-scaled to 56 and 28: must read at 28 |
+| Discord server icon   | 1:1      | 512x512   | Displayed as a circle                     |
+| Discord server banner | 16:9     | 960x540   |                                           |
+
+## Covers
+
+| Placement          | Ratio | Pixels    | Notes                                       |
+| ------------------ | ----- | --------- | ------------------------------------------- |
+| Podcast cover      | 1:1   | 3000x3000 | Minimum 1400x1400                           |
+| Music cover art    | 1:1   | 3000x3000 | Distributors commonly require the full 3000 |
+| Kindle ebook cover | 5:8   | 1600x2560 | The title must survive thumbnail size       |
 
 ## Display banners and email
 


### PR DESCRIPTION
## Summary

- New skill `scenario-formats`: derive one approved master, image or video, into every size and placement instead of re-prompting the concept per format, which makes five cousins rather than five formats of one visual.
- A decision ladder per target: resize (same ratio), expand/uncrop (more canvas, composition intact), generative reframe (new ratio, text-protecting variant when lettering is on the plate), and native recomposition with the master as reference for far ratios. Image canvas contracts stay delegated to `scenario-image-editing`; a video master climbs the same ladder with its resize-versus-reframe decision routed to `scenario-video-editing` and far ratios to `scenario-video`.
- An order of operations: approve one text-free master; derive every format from it, never from a derivative; reshape before grade and grain; verify by measurement (reframe ratio enums are approximate) and land exact with a resize; letter last per placement with `scenario-text-overlay`.
- A placement-spec reference (`references/placement-specs.md`, 118 lines): per-placement ratios, pixel targets, and safe zones for social feeds and link previews, cinema stills, phone/tablet/desktop, storefronts and app stores (Steam, Epic, itch.io, iOS, Google Play), marketplaces (Amazon, eBay, Etsy, Shopify, Google Shopping, with the main-image policy rules the text-free master serves), streaming and community (Twitch, Discord), covers (podcast, music, ebook), display banners, and print. All hedged as authoring-time values with a churn warning; the 9:16 safe-zone band matches `scenario-video-ads`.
- A new "Formats and placements" grouping in `skills.sh.json` and the README (the skill spans image and video, so neither Images nor Video described it), placed after "Reviewing and organizing output" as the pipeline's delivery stage.

## Validation

- [x] `pnpm validate` passes: house style, prettier, supporting-file checks, groupings, README table, spelling, `skills-ref` spec validation
- [x] `description` starts "Use when", 492 chars; body 750 words, inside the house target
- [x] Supporting file reviewed twice (justified vs body content, linked one level deep, public facts spot-checked against platform specs, MCP-first, sibling consistency)

## Stats

4 files changed, 181 insertions: one skill (`scenario-formats`, SKILL.md + `references/placement-specs.md`) plus its README section and `skills.sh.json` grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6viVJSUnTAWP569sB6afF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill and catalog listing; no runtime, auth, or data-handling code.
> 
> **Overview**
> Adds the `scenario-formats` agent skill so one approved master can be derived into many placements (feeds, stories, thumbnails, banners) instead of re-prompting a new image per size.
> 
> The skill is a **decision ladder** (resize vs expand vs generative reframe vs native recompose) plus an **order of operations**: text-free master first, never derivative-of-derivative, reshape before grade, measure then resize to exact pixels, letter last. Tool contracts stay in `scenario-image-editing`.
> 
> Also lists the skill in the Images group in `README.md` and `skills.sh.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc73fb31ac64cf58ca471918e692345e4609cca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
