### PR TITLE
fix(skills): compress the duplicated wait-discipline sentence across 21 family skills

### DIFF
--- a/skills/scenario-ace-step/SKILL.md
+++ b/skills/scenario-ace-step/SKILL.md
@@ -44,7 +44,7 @@ Keep `prompt` to a one-line style caption (genre, mood, instruments, production)
 1. `search` with `target="models"`, `query="ace-step"`, `public=true`. Pick members by mode name, e.g. `model_ace-step-1-5-turbo-text-to-music` and `model_ace-step-1-5-turbo-repaint` (live hits at authoring time: re-discover each session).
 2. `model_schema_get` on each id before running it.
 3. `model_run` the Text to Music member with `dry_run=true` and `parameters={"prompt": "indie folk, warm, fingerpicked guitar, soft female vocals", "lyrics": "[Verse]\n...\n[Chorus]\n...", "duration": 90, "vocalLanguage": "en"}`; re-estimate after changing `duration` or `numOutputs`.
-4. Repeat with `wait=false`, then `jobs_wait` with the job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+4. Repeat with `wait=false`, then `jobs_wait` with the job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 5. `asset_display` to listen; note the chorus window, say 24 to 52 seconds.
 6. `model_run` the Repaint member with `parameters={"srcAudio": "<asset id>", "repaintingStart": 24, "repaintingEnd": 52, "thinking": false, "prompt": "Repaint the selected section with new sung lyrics:", "lyrics": "<full sheet with the new chorus in place>"}`.
 7. Listen again, then `asset_download` the keeper (omit `format` for audio).

--- a/skills/scenario-elevenlabs/SKILL.md
+++ b/skills/scenario-elevenlabs/SKILL.md
@@ -47,7 +47,7 @@ Both Dubbing members take an audio or video `file` with a required `targetLang`,
 2. `model_schema_get` with that id: fields and defaults before anything else.
 3. `upload_asset` the trailer video (see the `scenario` skill) to get an asset id.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"file": "asset_x", "targetLang": "es", "keyterms": ["Aetherfall", "Kestrel Squad"]}`. The file drives the price: re-estimate per input.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the result (a video, because the input was) and confirm the keyterms survived; `asset_download` with no `format` to save it.
 
 ## Common mistakes

--- a/skills/scenario-gemini-image/SKILL.md
+++ b/skills/scenario-gemini-image/SKILL.md
@@ -38,7 +38,7 @@ The cost cliff sits between members more than between resolutions: at authoring 
 2. `model_schema_get` with that id: fields, caps, and defaults.
 3. `upload_asset` the product photo and the style reference (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"prompt": "Image 1 is the product: keep its shape, label, and colors exactly. Image 2 sets the mood: warm sunset palette, soft shadows. Place the product on a marble counter in natural window light.", "referenceImages": ["asset_a", "asset_b"], "aspectRatio": "4:5", "resolution": "2K", "numOutputs": 2}` for the cost estimate.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` to review both variations, `asset_download` to save the pick.
 
 ## Common mistakes

--- a/skills/scenario-gemini-omni/SKILL.md
+++ b/skills/scenario-gemini-omni/SKILL.md
@@ -40,7 +40,7 @@ Edit is the inverse: motion, camera path, and timing are locked from the source 
 2. `model_schema_get` with that id: required fields, caps, and defaults before anything else.
 3. `upload_asset` two or three angles of the mascot (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"prompt": "The character skips across a rain-slick plaza, catches a falling leaf, and holds it up in triumph. Overcast soft light, low tracking shot. Audio: light rain, footsteps on wet stone, one bright chirp.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "aspectRatio": "16:9"}`; references and duration move the cost, so re-estimate after changing either.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the output and review it with sound: the audio is part of the deliverable.
 
 ## Common mistakes

--- a/skills/scenario-gpt-image/SKILL.md
+++ b/skills/scenario-gpt-image/SKILL.md
@@ -38,7 +38,7 @@ Text inside the image: quote the exact copy, spell out typography (weight, case,
 2. `model_schema_get` with that id: sizing bounds, mask presence, and defaults first.
 3. `upload_asset` the product photo (see the `scenario` skill) for its asset id.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"prompt": "Editorial product photography, soft daylight. The exact bottle from the reference image on brushed concrete, label, shape, and color preserved. Headline \"DRINK GREEN\" in bold sans-serif, centered, no extra words, no duplicate text.", "referenceImages": ["asset_x"], "width": 1536, "height": 1024, "quality": "high"}` for the cost estimate.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the result and proofread the rendered text before batching; `asset_download` to save.
 
 ## Common mistakes

--- a/skills/scenario-grok-imagine-image/SKILL.md
+++ b/skills/scenario-grok-imagine-image/SKILL.md
@@ -38,7 +38,7 @@ Editing is prompt-driven: pass up to three `referenceImages` and describe the ch
 2. `model_schema_get` with that id: the reference cap, `quality` and `resolution` values, and the ratio list before anything else.
 3. `upload_asset` the product photo (see the `scenario` skill) to get its asset id.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "Add a minimalist front label to the bottle where the title reads \"LUMEN\" in a clean white serif and a smaller line beneath reads \"Sparkling Citrus Soda\". Keep the bottle shape, glass tint, background, shadows, and lighting unchanged, no other text.", "referenceImages": ["asset_abc"], "quality": "medium", "resolution": "2k"}`; re-estimate after any change to `quality`, `resolution`, `numOutputs`, or references.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` and proofread the label at full size, then `asset_download` the keeper.
 
 ## Common mistakes

--- a/skills/scenario-grok-imagine-video/SKILL.md
+++ b/skills/scenario-grok-imagine-video/SKILL.md
@@ -40,7 +40,7 @@ Generation members produce native audio and no parameter controls it: the prompt
 2. `model_schema_get` with that id: fields, caps, and defaults before anything else.
 3. `upload_asset` the hero still (see the `scenario` skill) to get its asset id.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "The frame shows a knight on a cliff at dusk. She lowers her sword, turns to the camera, and says quietly: 'It ends tonight.' Slow dolly-in, wind lifting her cloak. Audio: wind, distant thunder, her line clear. No music.", "image": "asset_abc", "duration": 8, "resolution": "1080p"}` for the cost estimate; re-estimate after any change to duration, resolution, or `numOutputs`.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the output and watch it with sound: the audio direction is judged by ear.
 
 ## Common mistakes

--- a/skills/scenario-ideogram/SKILL.md
+++ b/skills/scenario-ideogram/SKILL.md
@@ -39,7 +39,7 @@ Native: V3 Generate Transparent writes the alpha channel directly, so icons, sti
 1. `search` with `target="models"`, `query="ideogram"`, `public=true`. Members return as separate hits; match by name, e.g. `model_ideogram-v4` for typography (a live hit at authoring time: re-discover each session).
 2. `model_schema_get` with that id: field names, allowed values, and defaults before anything else.
 3. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"prompt": "Retro travel poster, warm dusk palette. The headline reads \"KYOTO IN BLOOM\" in bold serif across the top; caption \"April 2027\" bottom right.", "imageSize": "portrait_16_9", "renderingSpeed": "QUALITY", "enablePromptExpansion": false, "numOutputs": 2}` for the cost estimate.
-4. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+4. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 5. `asset_display` the outputs and pick one.
 6. To make the copy editable, discover the Layerize member the same way (`model_ideogram-v3-layerize-text` at authoring time), read its schema, and `model_run` with `parameters={"image": "<poster asset id>"}`: a generated asset's id feeds a file input directly, no re-upload. The output is a text-erased base plus text blocks with role, position, and content.
 7. `jobs_wait`, then `asset_display` and `asset_download`.

--- a/skills/scenario-kling/SKILL.md
+++ b/skills/scenario-kling/SKILL.md
@@ -48,7 +48,7 @@ Motion members require a character `image` and a driving `video`; `characterOrie
 2. `model_schema_get` with that id: multiPrompt shape, duration values, element caps.
 3. `upload_asset` the start frame and the character's frontal photo (see the `scenario` skill).
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"startImage": "asset_s", "multiPrompt": [{"prompt": "Wide shot, @Element1 crosses the plaza, slow dolly-in", "duration": "5"}, {"prompt": "Close-up, @Element1 smiles and says: 'we made it'", "duration": "4"}], "generateAudio": true, "elements": [{"frontalImage": "asset_f"}]}` for the cost estimate; re-estimate after changing durations, tier, or audio.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the output and review both shots with sound.
 
 ## Common mistakes

--- a/skills/scenario-luma-video/SKILL.md
+++ b/skills/scenario-luma-video/SKILL.md
@@ -39,7 +39,7 @@ Ray rewards natural-language prompts of roughly 50 to 300 words built around mot
 2. `model_schema_get` with the generator id: options and their vetoes before anything else.
 3. `upload_asset` the product still (see the `scenario` skill) to get an asset id.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "A crystal perfume bottle catches soft window light as a single drop arcs off the stopper, slow push-in, product commercial style.", "startFrame": "asset_a", "duration": "5s", "resolution": "1080p", "aspectRatio": "16:9"}`; re-estimate after any option change.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `model_schema_get` the Reframe sibling, then `model_run` with `parameters={"video": "<generated asset id>", "aspectRatio": "9:16", "prompt": "continue the marble counter downward and the softly lit wall upward", "resolution": "1080p"}`, same wait discipline.
 7. `asset_display` both and inspect the outpainted edges before delivery.
 

--- a/skills/scenario-mai-image/SKILL.md
+++ b/skills/scenario-mai-image/SKILL.md
@@ -38,7 +38,7 @@ Both editors take one source image and a plain instruction, under different fiel
 1. `search` with `target="models"`, `query="mai image"`, `public=true`. Note the generation and edit hits, e.g. `model_microsoft-mai-image-2-5-pro` and `model_microsoft-mai-image-2-5-edit` (live hits at authoring time: re-discover each session).
 2. `model_schema_get` on the generation pick: ratio list, prompt cap, defaults.
 3. `model_run` with `dry_run=true` and `parameters={"prompt": "A photorealistic poster of a climber on a granite wall at dawn, warm rim light, the headline 'ASCEND' in tall condensed sans-serif across the top, a small tagline 'Hold your line' lower left, editorial sports aesthetic.", "aspectRatio": "2:3", "numOutputs": 4}`. `numOutputs` moves cost, so re-estimate after changing it.
-4. Repeat with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+4. Repeat with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 5. `asset_display` the four outputs and keep one asset id.
 6. `model_schema_get` on the edit pick, then `model_run` with `parameters={"referenceImages": ["asset_x"], "prompt": "Keep the climber, lighting, and layout unchanged. Change only the headline to 'ASCEND HIGHER', same font, color, and placement."}`; `jobs_wait`, then `asset_display`.
 

--- a/skills/scenario-meshy/SKILL.md
+++ b/skills/scenario-meshy/SKILL.md
@@ -42,7 +42,7 @@ Rigging and Animation are alternatives, not stages. Animation auto-rigs internal
 
 1. `search` with `target="models"`, `query="meshy"`, `public=true`. Single-image route: `model_meshy-7-img23d` (a live hit at authoring time: re-discover each session).
 2. `model_schema_get` with that id, then `upload_asset` the character photo (see the `scenario` skill).
-3. `model_run` with `dry_run=true` and `parameters={"image": ["asset_photo"], "poseMode": "t-pose", "texturePrompt": "worn leather armor, muted palette", "enablePbr": true}` for the estimate; then re-run with `wait=false` and `jobs_wait` with the job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+3. `model_run` with `dry_run=true` and `parameters={"image": ["asset_photo"], "poseMode": "t-pose", "texturePrompt": "worn leather armor, muted palette", "enablePbr": true}` for the estimate; then re-run with `wait=false` and `jobs_wait` with the job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 4. `asset_display` the GLB; check silhouette and texture before spending further.
 5. `search` for the animation member, `model_schema_get`, then `model_run` with `parameters={"model": "<GLB asset id from step 4>", "heightMeters": 1.8, "actionId": <id from the library>}`.
 6. `jobs_wait`, `asset_display`, then `asset_download` for engine import.

--- a/skills/scenario-minimax-music/SKILL.md
+++ b/skills/scenario-minimax-music/SKILL.md
@@ -40,7 +40,7 @@ Music Cover takes its source through `audioUrl`: `upload_asset` the MP3 or WAV f
 1. `search` with `target="models"`, `query="minimax music"`, `public=true`. Prefer the newest non-deprecated hit, e.g. `model_minimax-music-3-0` (a live hit at authoring time: re-discover each session); the cover member lists `audio2audio` in capabilities.
 2. `model_schema_get` with that id: fields, caps, and defaults before anything else.
 3. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "epic orchestral trailer, 140 BPM, D minor, female vocals, taiko and strings", "lyrics": "[Intro]\n(Low strings)\n\n[Verse]\nWe were born below the thunder\n...\n\n[Outro]\n(Choir fades)"}`. Re-estimate after lyric edits: character count moves the price.
-4. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+4. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 5. `asset_display` the output and listen before laying it under a cut.
 
 ## Common mistakes

--- a/skills/scenario-minimax-video/SKILL.md
+++ b/skills/scenario-minimax-video/SKILL.md
@@ -43,7 +43,7 @@ Write the rest as natural prose, ordered camera, subject, action, scene, lightin
 2. `model_schema_get` with that id: modes, caps, and allowed values before anything else.
 3. `upload_asset` two clean, evenly lit character stills (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "[Tracking shot] The scout from the reference images sprints across a rooftop at dusk, coat snapping in the wind, warm rim light, footsteps and distant traffic in the audio, cinematic realism.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "2K", "aspectRatio": "16:9"}` for the cost estimate; re-estimate after changing duration, resolution, or the reference count.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`; H3 at 2K commonly runs several minutes.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`; H3 at 2K commonly runs several minutes.
 6. `asset_display` the output and review it with sound on: dialogue and SFX sync are part of what you paid for.
 
 ## Common mistakes

--- a/skills/scenario-reve/SKILL.md
+++ b/skills/scenario-reve/SKILL.md
@@ -39,7 +39,7 @@ Neither member takes a mask, so the prompt carries the whole edit: state what ch
 2. `model_schema_get` on the pick: field names, caps, and the ratio list before anything else.
 3. `upload_asset` the poster (see the `scenario` skill) to get an asset id.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"prompt": "Replace the headline on the poster in <frame>0</frame> with 'SUMMER SALE', matching the original font, perspective, and lighting. Change nothing else.", "references": ["asset_x"], "aspectRatio": "auto"}` for the cost estimate.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` to check the swap, then `asset_download` to save.
 
 ## Common mistakes

--- a/skills/scenario-seedance/SKILL.md
+++ b/skills/scenario-seedance/SKILL.md
@@ -47,7 +47,7 @@ The prompt is the only lever, so listen to what comes back: when music leaks in 
 2. `model_schema_get` with that id: fields, caps, and defaults before anything else.
 3. `upload_asset` the product stills (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and the exact `parameters={"prompt": "@image1 defines the bottle and label. Slow dolly-in as condensation beads. Diegetic sound only, no music. No text, no captions.", "referenceImages": ["asset_a", "asset_b"], "duration": 8, "resolution": "720p", "generateAudio": true}` for the cost estimate; re-estimate after any change to duration, resolution, or references.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the output and watch it with sound before the music goes on.
 
 ## Common mistakes

--- a/skills/scenario-seedream/SKILL.md
+++ b/skills/scenario-seedream/SKILL.md
@@ -38,7 +38,7 @@ Layerize returns a base layer plus up to 16 transparent PNG cutouts, rebuilding 
 1. `search` with `target="models"`, `query="seedream"`, `public=true`. Prefer the newest non-deprecated hit for the job, e.g. `model_bytedance-seedream-5-0-pro` (a live hit at authoring time: re-discover each session).
 2. `model_schema_get` with that id: sizing fields, caps, defaults.
 3. `model_run` with that id, `dry_run=true`, and `parameters={"prompt": "Concert poster, teal and cream, screen-print grain. Headline reads \"MIDNIGHT ORBIT\", date line \"Nov 14, Union Hall\".", "width": 1600, "height": 2368}`; both sizing fields move price.
-4. Rerun `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+4. Rerun `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 5. `asset_display` and proofread the rendered text.
 6. `model_schema_get` on the Layerize hit, then `model_run` with that id and `parameters={"image": "<poster asset id>", "prompt": "Separate this poster into transparent layers: the headline text, the date line, and the background. Clean edges, complete transparency.", "size": "2K"}`.
 7. `jobs_wait`, then `asset_display` each layer and `asset_download` the keepers.

--- a/skills/scenario-sonilo/SKILL.md
+++ b/skills/scenario-sonilo/SKILL.md
@@ -41,7 +41,7 @@ The music mux members replace the whole original track by default. `keepSpeechVo
 2. `model_schema_get` with that id: fields and caps before anything else.
 3. `upload_asset` the clip (see the `scenario` skill) to get its asset id.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"video": "asset_x", "segments": [{"start": 0, "end": 4, "prompt": "footsteps on wet metal, close and sharp"}, {"start": 4, "end": 12, "prompt": "plasma rifle shots, hollow hangar reverb"}]}`: cost scales with clip length.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the muxed video, then `asset_download` it and the separate track.
 
 ## Common mistakes

--- a/skills/scenario-veo/SKILL.md
+++ b/skills/scenario-veo/SKILL.md
@@ -40,7 +40,7 @@ Write present-tense prose ordered as cinematography, subject, action, context, s
 2. `model_schema_get` on the chosen id: confirm which reference inputs exist before writing the payload.
 3. `upload_asset` two character stills (see the `scenario` skill) to get asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"prompt": "Medium shot, the knight lowers her visor and says, \"Hold the line.\" Torchlight flickers on wet stone. Ambient noise: distant thunder. SFX: metal visor clank.", "referenceImages": ["asset_a", "asset_b"], "referenceImagesType": "ASSET", "duration": 8, "resolution": "1080p", "aspectRatio": "16:9", "generateAudio": true}`. Estimate the same job on the Fast id (drop `referenceImagesType`, absent there) and compare.
-5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the output and review with sound. To iterate on wording alone, hold an explicit `seed` fixed across reruns.
 
 ## Common mistakes

--- a/skills/scenario-vidu/SKILL.md
+++ b/skills/scenario-vidu/SKILL.md
@@ -41,7 +41,7 @@ T2V and I2V want a 120 to 180 word single-shot paragraph in present tense: scene
 2. `model_schema_get` with that id: duration bounds, resolutions, defaults.
 3. `upload_asset` the start and end stills (see the `scenario` skill) for two asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"generationType": "start_end_to_video", "images": ["asset_start", "asset_end"], "prompt": "The knight slowly lowers his sword as dusk settles over the courtyard. The camera dollies in on his face.", "duration": 8, "resolution": "1080p"}`; expand the prompt to the full paragraph shape above in real runs, and re-estimate after any change to duration or resolution.
-5. Re-run `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Re-run `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the output and check both anchor frames landed.
 
 ## Common mistakes

--- a/skills/scenario-wan/SKILL.md
+++ b/skills/scenario-wan/SKILL.md
@@ -47,7 +47,7 @@ The 2.7 generators always deliver audio: upload an `audio` file to drive it, or 
 2. `model_schema_get` with that id: exclusivity notes, caps, defaults.
 3. `upload_asset` the opening and closing stills (see the `scenario` skill) for asset ids.
 4. `model_run` with that `model_id`, `dry_run=true`, and `parameters={"prompt": "She turns from the window and walks toward the door, coat swaying; slow push-in. Room tone and distant traffic, no music.", "image": "asset_open", "endImage": "asset_close", "duration": 5, "resolution": "1080p"}` for the cost estimate; re-estimate after changing duration or resolution.
-5. Re-run with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. A timeout is not a failure and never justifies a second `model_run`.
+5. Re-run with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
 6. `asset_display` the output and review motion and audio together.
 
 ## Common mistakes


### PR DESCRIPTION
## Why

A fleet audit found the highest-impact systemic issue is that most model-family skills sit within a few percent of the 900-word hard cap while carrying byte-identical boilerplate. The worst offender: the two-sentence wait-discipline block

> "Repeat `model_run` with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout. **A timeout is not a failure and never justifies a second `model_run`.**"

appears verbatim in 21 skills. The authoring contract's own rationale is that every body word competes with the user's task on every trigger, and the repeated rationale sentence is content the `scenario` skill (which every family skill cross-references and every real install ships) already teaches twice: in its worked example and in its errors section.

## What changed

One mechanical replacement, identical in all 21 files:

- Before: `...re-called with \`pending_job_ids\` on timeout. A timeout is not a failure and never justifies a second \`model_run\`.`
- After: `...re-called with \`pending_job_ids\` on timeout, never a second \`model_run\`.`

Every actionable fact stays in each family skill: the `wait=false` launch, the `pending_job_ids` re-call, and the never-relaunch guard. Only the rationale clause is deduplicated. This frees ~10 words in exactly the skills pressed against the cap (e.g. kling 890→882, elevenlabs 894→886, grok-imagine-video 892→884), creating headroom for future per-model facts without splitting files.

Touched: ace-step, elevenlabs, gemini-image, gemini-omni, gpt-image, grok-imagine-image, grok-imagine-video, ideogram, kling, luma-video, mai-image, meshy, minimax-music, minimax-video, reve, seedance, seedream, sonilo, veo, vidu, wan.

## Validation

- `pnpm validate` green.
- `git diff` is 21 single-line replacements of the same string; no other content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change in skill markdown; no runtime, API, or security behavior is affected.
> 
> **Overview**
> Frees a few words in 21 model-family skills that sit near the 900-word cap by collapsing the duplicated wait-discipline line.
> 
> Worked examples still tell agents to launch with `wait=false`, re-call `jobs_wait` with `pending_job_ids` on timeout, and never fire a second `model_run`. Only the extra “timeout is not a failure” rationale is dropped; that explanation already lives in the shared `scenario` skill. No other content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81436a55ecaa93c94b0f6afc07507739eb79a0d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->