### PR TITLE
feat(skills): widen description trigger nets with the aliases users actually type

### DIFF
--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-3d
-description: Use when generating or handling 3D assets through the Scenario MCP server, including text-to-3D or image-to-3D meshes, GLB, FBX, OBJ, or VOX files, PBR-textured or game-ready models, voxel models, multi-view reconstruction, retexture, remesh, UV unwrap, auto-rigging a biped or quadruped character, skin weights, or retargeting an animation, previewing a mesh in the inline 3D viewer, capturing a viewer screenshot, or downloading a model for import into Unity, Unreal, Godot, or Blender.
+description: Use when generating or handling 3D assets through the Scenario MCP server, including text-to-3D or image-to-3D meshes, GLB, FBX, OBJ, STL, or VOX files, PBR-textured or game-ready models, voxel models, multi-view reconstruction, retexture, remesh, UV unwrap, auto-rigging a biped or quadruped character, skin weights, or retargeting an animation, previewing a mesh in the inline 3D viewer, capturing a viewer screenshot, or downloading a model for import into Unity, Unreal, Godot, or Blender.
 license: MIT
 ---
 

--- a/skills/scenario-gpt-image/SKILL.md
+++ b/skills/scenario-gpt-image/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-gpt-image
-description: "Use when generating or editing images with OpenAI's GPT Image models on Scenario via MCP: text-to-image, instruction-driven editing from reference images, inpainting with an alpha-channel mask, in-image text rendering for logos and infographics, transparent background cutouts, exact pixel sizing, preserving product or face detail with input fidelity, or choosing between family members. Keywords: GPT Image 2, GPT Image 1.5, OpenAI, gpt-image, txt2img, img2img, mask, quality, background."
+description: "Use when generating or editing images with OpenAI's GPT Image models on Scenario via MCP: text-to-image, instruction-driven editing from reference images, inpainting with an alpha-channel mask, in-image text rendering for logos and infographics, transparent background cutouts, exact pixel sizing, preserving product or face detail with input fidelity, or choosing between family members. Keywords: GPT Image 2, GPT Image 1.5, OpenAI, DALL-E, gpt-image, txt2img, img2img, mask, quality, background."
 license: MIT
 ---
 

--- a/skills/scenario-luma-image/SKILL.md
+++ b/skills/scenario-luma-image/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-luma-image
-description: "Use when generating or editing images with Luma Uni-1 models on Scenario via MCP: text-to-image, prompt-based editing of an existing image, style or character reference images with named roles, web search grounding for real-world subjects, rendering exact title text into posters, aspect ratio control, or choosing between Uni-1 Max and Uni-1. Keywords: Luma Labs, Uni-1, txt2img, img2img, image edit, reference images, webSearch, reasoning image model."
+description: "Use when generating or editing images with Luma Uni-1 models on Scenario via MCP: text-to-image, prompt-based editing of an existing image, style or character reference images with named roles, web search grounding for real-world subjects, rendering exact title text into posters, aspect ratio control, or choosing between Uni-1 Max and Uni-1. Keywords: Luma Labs, Uni-1, Photon, txt2img, img2img, image edit, reference images, webSearch, reasoning image model."
 license: MIT
 ---
 

--- a/skills/scenario-luma-video/SKILL.md
+++ b/skills/scenario-luma-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scenario-luma-video
-description: "Use when generating or editing video with Luma Ray models on Scenario via MCP: cinematic text-to-video, image-to-video from a start frame, start plus end frame anchors, seamless looping clips, HDR output, restyling footage while preserving motion with edit strengths and face, pose, depth, or trajectory controls, reframing to another aspect ratio by outpainting, or budget prompt edits on real footage. Keywords: Luma Labs, Ray 3.2, Ray 3, Modify Video, Reframe, T2V, I2V, V2V, loop, HDR."
+description: "Use when generating or editing video with Luma Ray models on Scenario via MCP: cinematic text-to-video, image-to-video from a start frame, start plus end frame anchors, seamless looping clips, HDR output, restyling footage while preserving motion with edit strengths and face, pose, depth, or trajectory controls, reframing to another aspect ratio by outpainting, or budget prompt edits on real footage. Keywords: Luma, Dream Machine, Ray 3.2, Ray 3, Modify Video, Reframe, T2V, I2V, V2V, loop, HDR."
 license: MIT
 ---
 


### PR DESCRIPTION
## Why

Agents load only `name` and `description` at startup, so the description carries the entire triggering burden. The leading genmedia skills on skills.sh treat it as a trigger net: it enumerates the exact brand names and aliases a user would type, including names that are no longer the current product name. A description audit of all 48 skills found the fleet already strong here (Nano Banana, Hailuo, ByteDance, Kuaishou, Alibaba are all covered) with four remaining gaps.

## What changed (description lines only)

- **`scenario-gpt-image`**: adds **DALL-E** — the word users most often type when they mean OpenAI image generation; the description never contained it (498/500 chars).
- **`scenario-luma-image`**: adds **Photon** — the name Luma's image family shipped under and still a live search term (461/500).
- **`scenario-luma-video`**: adds **Dream Machine** — Luma's video product name; "Luma Labs" becomes "Luma" to stay inside the 500-char budget (499/500).
- **`scenario-3d`**: adds **STL** to the format list; the body already teaches STL as a rigging input format (493/500).
- `project-words.txt`: adds DALL-E (sorted).

`scenario-kling` was also checked for "Kuaishou" and already carries it, so it is untouched.

## Validation

- `pnpm validate` green (style, prettier, skill-files, groupings, readme, words, cspell, spec).
- All four descriptions still start with "Use when", stay third person, and stay under 500 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhfcuHBohQT9KZDbekjHiQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only frontmatter keyword tweaks plus a spellcheck word list; no runtime or security impact.
> 
> **Overview**
> Agents only see skill `name` and `description` at load time, so this PR fills remaining trigger gaps with names people actually type.
> 
> Adds **DALL-E** to `scenario-gpt-image`, **Photon** to `scenario-luma-image`, **Dream Machine** to `scenario-luma-video` (shortening "Luma Labs" to "Luma" for the 500-char cap), and **STL** to `scenario-3d`. `project-words.txt` gets `DALL-E` for cspell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4d230dd8c03f0da381d63ebca3940aceab0dc9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->