### PR TITLE
feat(scenario-quality-gate): add the brief-compliance and AI-quality verdict skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,12 @@ Hold one character, product, or style across a whole set, and train custom model
 
 ### Reviewing and organizing output
 
-Read finished assets back: caption them, extract a style or a control map, check a batch against a brief, and file the keepers.
+Read finished assets back: caption them, extract a style or a control map, check a batch against a brief or the Quality Gate, and file the keepers.
 
-| Skill                                                              | Use it for                                                                                                       |
-| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| [scenario-asset-analysis](skills/scenario-asset-analysis/SKILL.md) | Reading assets back: captions, style descriptions, batch review against a brief, control maps, collections, tags |
+| Skill                                                              | Use it for                                                                                                                          |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [scenario-asset-analysis](skills/scenario-asset-analysis/SKILL.md) | Reading assets back: captions, style descriptions, batch review against a brief, control maps, collections, tags                    |
+| [scenario-quality-gate](skills/scenario-quality-gate/SKILL.md)     | Pass/warn/fail image verdicts from the Quality Gate: free stored reads, dry-run pricing, feeding suggestions back into the next run |
 
 ### Workflows and apps
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -101,8 +101,8 @@
     },
     {
       "title": "Reviewing and organizing output",
-      "description": "Read finished assets back: caption them, extract a style or a control map, check a batch against a brief, and file the keepers.",
-      "skills": ["scenario-asset-analysis"]
+      "description": "Read finished assets back: caption them, extract a style or a control map, check a batch against a brief or the Quality Gate, and file the keepers.",
+      "skills": ["scenario-asset-analysis", "scenario-quality-gate"]
     },
     {
       "title": "Workflows and apps",

--- a/skills/scenario-asset-analysis/SKILL.md
+++ b/skills/scenario-asset-analysis/SKILL.md
@@ -27,7 +27,7 @@ All four bill credits and all four take `dry_run: true` for an estimate first. R
 
 - **`asset_analyze` batches.** One call carries up to 10 images against one `instruction`, so reviewing 200 assets is 20 calls, not 200. `num_outputs` (1 to 5) is unrelated: it returns several distinct answers to the same instruction, not one answer per image. Ask for a fixed per-image output shape in the `instruction` so the answers stay parseable.
 - **`asset_detect` strips the background by default.** `remove_background` defaults to true, so a depth or pose map comes back with the frame's context already gone. Set it false whenever the map has to cover the whole image.
-- **Fixed beats flexible when it fits.** `asset_caption` and `asset_describe` are purpose-built and faster than instructing an LLM to do the same job. Reach for `asset_analyze` for classification, extraction, comparison, translation, or a verdict against a brief.
+- **Fixed beats flexible when it fits.** `asset_caption` and `asset_describe` are purpose-built and faster than instructing an LLM to do the same job. Reach for `asset_analyze` for classification, extraction, comparison, translation, or a verdict against a brief. One carve-out: for a structured pass/warn/fail verdict against a configured brand brief, teams with the Quality Gate add-on have a dedicated tool that stores its verdict and re-reads it free (see `scenario-quality-gate`); `asset_analyze` stays the route when the add-on is missing or the brief exists only as prose.
 
 `asset_analyze` and `asset_detect` wait up to 180s and then hand back a `job_id`; carry on with `jobs_wait` as anywhere else.
 

--- a/skills/scenario-quality-gate/SKILL.md
+++ b/skills/scenario-quality-gate/SKILL.md
@@ -16,7 +16,7 @@ The tool is catalog-only and write-class: get the schema with `scenario_tools_se
 
 | Call                              | What happens                                                             | Cost                                                                       |
 | --------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| Plain call, usable verdict stored | Returns the stored verdict, `source: "stored"`                           | Free                                                                       |
+| Plain call, usable verdict stored | Returns the stored verdict, `source: "stored"`                           | Free (the response carries no `creativeUnitsCost`)                         |
 | Plain call, no usable verdict     | Runs a new analysis and stores the verdict, `source: "new_analysis"`     | Billed; the response carries `creativeUnitsCost` (1 CU as of this writing) |
 | `rerun: true`                     | New analysis that replaces the stored verdict                            | Billed                                                                     |
 | `dry_run: true`                   | Nothing runs; returns the price of a new analysis as `creativeUnitsCost` | Free                                                                       |
@@ -32,24 +32,25 @@ The response is `source` plus `quality_gate`: `verdict`, `overallScore`, `aiQual
 A verdict alone only sorts assets. The gate earns its cost when the feedback drives the next attempt:
 
 - `reasons` name concrete flaws ("elongated finger anatomy on the left hand", "background gradient off the brief's palette"). Use them to pick the fix path per flaw: a local defect on an otherwise approved image is a masked inpainting pass (`scenario-image`); a global one is a regeneration.
-- `suggestions` are written as actionable edits. Apply all that fit, not just the first: fold them into the next `model_run` prompt or parameters, or into the edit instruction.
-- A regenerated image is a new asset, so a plain call scores it. `rerun` is never part of the loop. It may even come back pre-scored for free: teams with auto-detect enabled score new generations automatically.
-- Fix the exit bar and a round cap up front: `verdict: "pass"` by default, or a score target the user names (`overallScore` at or above 90, say), and three rounds unless told otherwise, since every round bills a generation plus an analysis. At the cap, or when a round stops moving the scores, stop: report the best asset with its remaining flaws and ask before spending more rounds.
+- `suggestions` are written as edit instructions, often worded for manual retouching. Apply all that fit, not just the first: translate them into the next `model_run` prompt or parameters, or into the edit instruction.
+- A regenerated image is a new asset, so a plain call scores it. `rerun` is never part of the loop. It may even come back pre-scored for free: teams with auto-detect enabled (`qualityGateAutoDetect: true` on their `teams_list` row) score new generations automatically.
+- When a round repeats the same flaw classes at an unmoved score, rewording will not fix them: switch models (`recommend` again) or repair the flaw with a masked edit before spending another round.
+- Fix the exit bar and a round cap up front: `verdict: "pass"` by default, or a score target the user names (`overallScore` at or above 90, say; the named bar then outranks a bare `pass`), and three rounds unless told otherwise, since every round bills a generation plus an analysis. At the cap, or when a round stops moving the scores, stop: report the best asset with its remaining flaws and ask before spending more rounds; unattended, deliver that best asset and flag the miss.
 
 ## Worked example: iterate a hero prop to pass
 
 1. Generate per `scenario-image`: `model_run`, `jobs_wait`, collect the asset id.
 2. `scenario_tools_search` with `query="quality gate"` once for the schema, then `dry_run: true` on the first asset to surface the per-analysis price.
-3. Score: `scenario_tool_execute_write` with `{name: "asset_quality_gate_run", parameters: {asset_id, team_id, project_id}}`. It returns `source: "new_analysis"`, `verdict: "warn"`, `briefComplianceScore: 58`, and `details.briefCompliance.suggestions` asking for the logo at the top left and a flatter background.
+3. Score: `scenario_tool_execute_write` with `{name: "asset_quality_gate_run", parameters: {asset_id, team_id, project_id}}`. It returns `source: "new_analysis"` and a `quality_gate` carrying `verdict: "warn"`, `briefComplianceScore: 58`, and `details.briefCompliance.suggestions` asking for the logo at the top left and a flatter background.
 4. Fold both suggestions into the prompt, regenerate, and score the new asset with a plain call (no `rerun`).
 5. `verdict: "pass"`: deliver, and file it (collections and tags per `scenario-asset-analysis`). Later reads of any scored asset are free stored reads.
-6. The brief changes next sprint: only then `rerun: true` on assets that must be re-judged, since it replaces each stored verdict and bills again.
+6. The brief changes next sprint: only then `rerun: true` on the assets that must be re-judged.
 
 ## Common mistakes
 
 - Treating a plain call as a free read: without a usable stored verdict it silently runs and bills the analysis. Probe with `dry_run` or `asset_get` first when the spend matters.
 - Passing `rerun: true` out of habit: it re-bills verdicts that were free to read. Its one job is refreshing after the brief or sensitivity changed.
-- Expecting `briefComplianceScore` with no brief configured: the field and `details.briefCompliance` exist only when `appliedBriefIds` is non-empty.
+- Expecting `briefComplianceScore` with no brief configured: `quality_gate` carries it and `details.briefCompliance` only when `appliedBriefIds` is non-empty.
 - Applying one suggestion and rescoring each time: the lists usually carry several fixes, and one regeneration can absorb them all.
 - Running it through `scenario_tool_execute_read`: write-class, rejected by lane.
 - Scoring a video, 3D, or audio asset: image assets only.

--- a/skills/scenario-quality-gate/SKILL.md
+++ b/skills/scenario-quality-gate/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: scenario-quality-gate
+description: "Use when a generated Scenario image needs a quality check or a brand-brief compliance verdict before it ships: pass/warn/fail scoring, on-brand review against a configured brief, QA gating a batch, pricing or refreshing a stored verdict, or iterating a generation until it clears the gate. Keywords: quality gate, quality check, QA, verdict, brief compliance, on-brand, brand brief, pass fail, score, review, asset_quality_gate_run."
+license: MIT
+---
+
+# Scenario Quality Gate
+
+## Overview
+
+One tool, `asset_quality_gate_run`, scores a finished image asset and returns a `pass`/`warn`/`fail` verdict with 0 to 100 scores and per-dimension lists of `reasons` and `suggestions`: an AI-quality check always, plus brand-brief compliance when the team or project has a brief configured. Image assets only. Quality Gate is an Enterprise add-on: when it is not enabled for the team the call fails cleanly, so detect that, fall back to an `asset_analyze` review (see `scenario-asset-analysis`), and say so. Retrying never clears it.
+
+The tool is catalog-only and write-class: get the schema with `scenario_tools_search`, then run it through `scenario_tool_execute_write` with `{name: "asset_quality_gate_run", parameters: {...}}`, scope ids inside `parameters` (the read executor rejects it by lane and names the right one). Or reconnect with `?toolsets=full`. Connection and scope: see the `scenario` skill. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
+## Quick reference: what a call costs
+
+| Call                              | What happens                                                             | Cost                                                                       |
+| --------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Plain call, usable verdict stored | Returns the stored verdict, `source: "stored"`                           | Free                                                                       |
+| Plain call, no usable verdict     | Runs a new analysis and stores the verdict, `source: "new_analysis"`     | Billed; the response carries `creativeUnitsCost` (1 CU as of this writing) |
+| `rerun: true`                     | New analysis that replaces the stored verdict                            | Billed                                                                     |
+| `dry_run: true`                   | Nothing runs; returns the price of a new analysis as `creativeUnitsCost` | Free                                                                       |
+
+A plain call is a read only when a usable verdict already exists; otherwise the same call silently escalates to the billed analysis. "No usable verdict" covers both never-scored and a stored `error` result. When spend needs approval first, probe free: `dry_run: true`, or `asset_get`, whose `qualityGate` field carries the verdict and scores when one is stored (summary only; the stored `reasons` and `suggestions` come back through the tool, still free). `sensitivity` (`low`, `medium`, `high`; default is the team or project setting) shapes new analyses only and is ignored on stored reads. `rerun: true` is for after the brief or the sensitivity changed, nothing else: it re-bills and overwrites.
+
+## Reading the verdict
+
+The response is `source` plus `quality_gate`: `verdict`, `overallScore`, `aiQualityScore`, `briefComplianceScore`, `sensitivity`, `appliedBriefIds`, and `details`. With no brief configured the compliance dimension is absent entirely (`appliedBriefIds: []`, `overallScore` equals `aiQualityScore`); with one, `details.briefCompliance` sits beside `details.aiQuality`, each carrying a `score` and lists of `reasons` and `suggestions`, usually several of each.
+
+## Turning the verdict into a better image
+
+A verdict alone only sorts assets. The gate earns its cost when the feedback drives the next attempt:
+
+- `reasons` name concrete flaws ("elongated finger anatomy on the left hand", "background gradient off the brief's palette"). Use them to pick the fix path per flaw: a local defect on an otherwise approved image is a masked inpainting pass (`scenario-image`); a global one is a regeneration.
+- `suggestions` are written as actionable edits. Apply all that fit, not just the first: fold them into the next `model_run` prompt or parameters, or into the edit instruction.
+- A regenerated image is a new asset, so a plain call scores it. `rerun` is never part of the loop. It may even come back pre-scored for free: teams with auto-detect enabled score new generations automatically.
+- Fix the exit bar and a round cap up front: `verdict: "pass"` by default, or a score target the user names (`overallScore` at or above 90, say), and three rounds unless told otherwise, since every round bills a generation plus an analysis. At the cap, or when a round stops moving the scores, stop: report the best asset with its remaining flaws and ask before spending more rounds.
+
+## Worked example: iterate a hero prop to pass
+
+1. Generate per `scenario-image`: `model_run`, `jobs_wait`, collect the asset id.
+2. `scenario_tools_search` with `query="quality gate"` once for the schema, then `dry_run: true` on the first asset to surface the per-analysis price.
+3. Score: `scenario_tool_execute_write` with `{name: "asset_quality_gate_run", parameters: {asset_id, team_id, project_id}}`. It returns `source: "new_analysis"`, `verdict: "warn"`, `briefComplianceScore: 58`, and `details.briefCompliance.suggestions` asking for the logo at the top left and a flatter background.
+4. Fold both suggestions into the prompt, regenerate, and score the new asset with a plain call (no `rerun`).
+5. `verdict: "pass"`: deliver, and file it (collections and tags per `scenario-asset-analysis`). Later reads of any scored asset are free stored reads.
+6. The brief changes next sprint: only then `rerun: true` on assets that must be re-judged, since it replaces each stored verdict and bills again.
+
+## Common mistakes
+
+- Treating a plain call as a free read: without a usable stored verdict it silently runs and bills the analysis. Probe with `dry_run` or `asset_get` first when the spend matters.
+- Passing `rerun: true` out of habit: it re-bills verdicts that were free to read. Its one job is refreshing after the brief or sensitivity changed.
+- Expecting `briefComplianceScore` with no brief configured: the field and `details.briefCompliance` exist only when `appliedBriefIds` is non-empty.
+- Applying one suggestion and rescoring each time: the lists usually carry several fixes, and one regeneration can absorb them all.
+- Running it through `scenario_tool_execute_read`: write-class, rejected by lane.
+- Scoring a video, 3D, or audio asset: image assets only.
+- Assuming a fresh upload has no verdict: uploads deduplicate by content, so identical bytes return the same long-lived asset id whatever the filename, and a re-upload of a file the team scored before carries its stored verdict.
+- Setting `sensitivity` on a call that returns a stored verdict: it applies to new analyses only; stricter scoring of an already-scored asset requires `rerun: true`.
+- Retrying the entitlement failure: Quality Gate is an Enterprise add-on. Degrade to the `asset_analyze` review in `scenario-asset-analysis` and tell the user why.


### PR DESCRIPTION
## Summary

- New `skills/scenario-quality-gate/SKILL.md` teaching `asset_quality_gate_run`: catalog-only write-lane dispatch, the get-before-analyze cost model (free stored reads marked by the absent `creativeUnitsCost`, silent escalation to a billed analysis, `dry_run` pricing, `rerun` reserved for brief or sensitivity changes), and the verdict shape, including that `briefComplianceScore` and `details.briefCompliance` exist only when a brief is configured.
- The improvement loop is the centerpiece: fold all fitting `suggestions` into one regeneration (they are often worded for manual retouching, so translate them into prompt or parameter changes), score the new asset with a plain call (never `rerun`), fix an exit bar (a user-named score target outranks a bare `pass`) and a round cap up front, switch models or repair with a masked edit when a round repeats the same flaws at an unmoved score, and stop-and-ask past the cap, with an unattended fallback.
- Entitlement and edge cases: Enterprise add-on failure degrades to the `asset_analyze` review in `scenario-asset-analysis`; upload content-dedup means a re-uploaded file can already carry a stored verdict; auto-detect teams (`qualityGateAutoDetect: true` on their `teams_list` row) pre-score new generations.
- `scenario-asset-analysis` now routes structured brand-brief verdicts to the new skill, keeping `asset_analyze` as the fallback when the add-on is missing or the brief exists only as prose.
- README row and `skills.sh.json` grouping entry added under "Reviewing and organizing output".

## Validation

- [x] `pnpm run validate` passes (house style, prettier, supporting files, groupings, README, spelling, `skills-ref` spec validation for all 50 skills)
- [x] Two clean-room application-test runs against the live MCP server (separate process, no repository context): every taught behavior executed correctly, including dry-run pricing before each billed call, the free stored re-read, the plateau model switch, and the round-cap fallback; full report in the PR comments
- [x] Every tool and response-field claim grounded in the live catalog schema, the public tool reference, and live probes (dry-run cost field, stored-read pricing, `asset_get` summary shape, read-executor lane rejection, upload content-dedup)
- [x] Review comments addressed: both Bugbot findings fixed (verdict nesting in the worked example, unattended round-cap fallback); Claude code review reports no issues

## Stats

- 4 files changed, 67 insertions(+), 7 deletions(-)
- Skills touched: `scenario-quality-gate` (new), `scenario-asset-analysis` (routing cross-reference)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SDa7MfaUjE2s4BD9seyNg
