### PR TITLE
docs(scenario): teach keeping generated assets organized with collections and tags

### DIFF
--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -52,7 +52,7 @@ Generating a stylized game prop image:
 
 Local inputs go up with `upload_asset`: always `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Prefer multipart: add `file_size`, follow the returned `instructions` to PUT every part URL, then `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both; they take no other fields: no parts list, no etags.
 
-Filing outputs into collections for later retrieval (the collection tools live in the tool catalog above) is taught by the `scenario-asset-analysis` skill. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+A working session piles up assets across types, and keeping them organized is part of the job: collections and tags are the mechanisms, via the tool catalog above (`collection_create`, `collection_add_assets`, `asset_add_tags`), and the `scenario-asset-analysis` skill teaches filing and retrieval in depth. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
 
 ## Errors and recovery
 

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -52,7 +52,7 @@ Generating a stylized game prop image:
 
 Local inputs go up with `upload_asset`: always `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Prefer multipart: add `file_size`, follow the returned `instructions` to PUT every part URL, then `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both; they take no other fields: no parts list, no etags.
 
-A working session piles up assets across types, and keeping them organized is part of the job: collections and tags are the mechanisms, via the tool catalog above (`collection_create`, `collection_add_assets`, `asset_add_tags`), and the `scenario-asset-analysis` skill teaches filing and retrieval in depth. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+A working session piles up assets across types, and keeping them organized is part of the job: collections and tags are the mechanisms, via the tool catalog above (`collection_create`, `collection_add_assets`, `asset_add_tags`), and sibling Scenario skills go deeper on filing and retrieval where their workflows call for it.
 
 ## Errors and recovery
 

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -52,6 +52,8 @@ Generating a stylized game prop image:
 
 Local inputs go up with `upload_asset`: always `file_name`, `content_type`, and `kind` (`image`, `audio`, `video`, `3d`). Prefer multipart: add `file_size`, follow the returned `instructions` to PUT every part URL, then `upload_asset_complete` with the `upload_id`. Inline `data` only under ~100KB. Scope rides on both; they take no other fields: no parts list, no etags.
 
+Filing outputs into collections for later retrieval (the collection tools live in the tool catalog above) is taught by the `scenario-asset-analysis` skill. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
 ## Errors and recovery
 
 | Error                                            | Recovery                                                                                                                                                                                                                  |


### PR DESCRIPTION
## Summary

- The core `scenario` skill now frames organization as part of the job: a working session piles up assets across types, and collections and tags are the mechanisms for keeping them organized.
- Names the concrete catalog tools (`collection_create`, `collection_add_assets`, `asset_add_tags`), reachable through the discovery path the Setup section already teaches (`scenario_tools_search`, then the matching `scenario_tool_execute_*` lane).
- Defers depth to sibling Scenario skills generically rather than naming one, so the core skill stays stable as the sibling set evolves; with no sibling named, the install-invitation sentence is not required.
- Kept to one short paragraph: the body already runs above the house word target, and the filing and retrieval mechanics stay in the sibling skills (one skill, one concern).

## Validation

- [x] `pnpm style` (house style)
- [x] `pnpm format:check` (prettier)
- [x] `pnpm skill-files` (supporting files linked and runnable)
- [x] `pnpm groupings` and `pnpm readme` (skills.sh.json and README coverage, all 50 skills)
- [x] `pnpm words:check` and `pnpm spell` (cspell, 0 issues)
- [x] `pnpm spec` (skills-ref spec validation, all 50 skills valid)

## Stats

- 1 file changed, 2 insertions(+) net vs main
- Skills touched: `scenario`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPs2FRoBmZePf4h3JHaZU8