### PR TITLE
feat(scenario-refine-loop): hand brief-bar image critique to the Quality Gate when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Read finished assets back: caption them, extract a style or a control map, check
 | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | [scenario-asset-analysis](skills/scenario-asset-analysis/SKILL.md) | Reading assets back: captions, style descriptions, batch review against a brief, control maps, collections, tags                    |
 | [scenario-quality-gate](skills/scenario-quality-gate/SKILL.md)     | Pass/warn/fail image verdicts from the Quality Gate: free stored reads, dry-run pricing, feeding suggestions back into the next run |
+| [scenario-refine-loop](skills/scenario-refine-loop/SKILL.md)       | Iterating until output matches the brief: rubric first, batched critique verdicts, cheapest targeted fix, round caps                |
 
 ### Workflows and apps
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -102,7 +102,11 @@
     {
       "title": "Reviewing and organizing output",
       "description": "Read finished assets back: caption them, extract a style or a control map, check a batch against a brief or the Quality Gate, and file the keepers.",
-      "skills": ["scenario-asset-analysis", "scenario-quality-gate"]
+      "skills": [
+        "scenario-asset-analysis",
+        "scenario-quality-gate",
+        "scenario-refine-loop"
+      ]
     },
     {
       "title": "Workflows and apps",

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -22,13 +22,13 @@ Agents fail generation QA in two symmetric ways: accepting the first roll, or re
 
 Fix routing, cheapest first:
 
-| The verdict says                                | Fix                                                                         |
-| ----------------------------------------------- | --------------------------------------------------------------------------- |
-| One local defect on a keeper                    | Masked inpaint of that region (`scenario-image`)                            |
-| A uniform finish off (grade, tint, crop)        | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
-| Wrong content, composition, or rendered palette | Edit the delta clause, re-run from the approved baseline                    |
-| Identity or style drift                         | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
-| Every line failing                              | Change the model (re-discover via `search` or `recommend`), keep the prompt |
+| The verdict says                                | Fix                                                                                                                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| One local defect on a keeper                    | Masked inpaint of that region (`scenario-image`)                                                                               |
+| A uniform finish off (grade, tint, crop)        | A deterministic tool pass (`scenario-image-editing`), not a re-roll                                                            |
+| Wrong content, composition, or rendered palette | Edit the delta clause, re-run from the approved baseline                                                                       |
+| Identity or style drift                         | Tighten the enumeration, add or re-role references (`scenario-consistency`)                                                    |
+| Every line failing                              | Change the model: re-discover with `recommend` (capability-shaped; `search` is for a name or a private model), keep the prompt |
 
 Change one variable per round. A round that swaps prompt, references, and model at once cannot attribute the improvement, so the next failure restarts from zero.
 
@@ -43,7 +43,7 @@ Change one variable per round. A round that swaps prompt, references, and model 
 2. Generate four, one `model_run` each per `scenario-image`, then `jobs_wait`.
 3. One `asset_analyze` call with all four ids in `images` and the rubric-plus-shape instruction; answers land as text assets, `asset_download` them to read the verdicts.
 4. Two fail. Icon 2 is off palette, which is rendered content rather than a finish: edit the delta clause by pinning the hex codes in the prompt and re-run from the baseline. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
-5. Re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
+5. `jobs_wait` the fix runs, then re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
 
 ## Common mistakes
 

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -20,6 +20,8 @@ Agents fail generation QA in two symmetric ways: accepting the first roll, or re
 | 4. Fix      | Route every fail line to the cheapest fix that addresses it (table below)                                                          |
 | 5. Stop     | A clean round ships; three rounds without one, or one line failing twice under different fixes, means report, not respin           |
 
+When the bar is the configured brand brief rather than a task rubric, and the team's Quality Gate add-on is enabled, critique images with `asset_quality_gate_run` instead: its `reasons` and `suggestions` feed the fix table directly (`scenario-quality-gate`; where the gate is missing it degrades to this `asset_analyze` path).
+
 Fix routing, cheapest first:
 
 | The verdict says                                | Fix                                                                                                                            |

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -22,13 +22,13 @@ Agents fail generation QA in two symmetric ways: accepting the first roll, or re
 
 Fix routing, cheapest first:
 
-| The verdict says              | Fix                                                                         |
-| ----------------------------- | --------------------------------------------------------------------------- |
-| One local defect on a keeper  | Masked inpaint of that region (`scenario-image`)                            |
-| Color, framing, or finish off | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
-| Wrong content or composition  | Edit the delta clause, re-run from the approved baseline                    |
-| Identity or style drift       | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
-| Every line failing            | Change the model (re-discover via `search` or `recommend`), keep the prompt |
+| The verdict says                                | Fix                                                                         |
+| ----------------------------------------------- | --------------------------------------------------------------------------- |
+| One local defect on a keeper                    | Masked inpaint of that region (`scenario-image`)                            |
+| A uniform finish off (grade, tint, crop)        | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
+| Wrong content, composition, or rendered palette | Edit the delta clause, re-run from the approved baseline                    |
+| Identity or style drift                         | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
+| Every line failing                              | Change the model (re-discover via `search` or `recommend`), keep the prompt |
 
 Change one variable per round. A round that swaps prompt, references, and model at once cannot attribute the improvement, so the next failure restarts from zero.
 
@@ -42,7 +42,7 @@ Change one variable per round. A round that swaps prompt, references, and model 
 1. Rubric from the brief, five lines: single object, centered, plain field, palette #2A9D8F and #E9C46A only, no text.
 2. Generate four, one `model_run` each per `scenario-image`, then `jobs_wait`.
 3. One `asset_analyze` call with all four ids in `images` and the rubric-plus-shape instruction; answers land as text assets, `asset_download` them to read the verdicts.
-4. Two fail. Icon 2 is off palette: re-run its prompt with the hex codes pinned. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
+4. Two fail. Icon 2 is off palette, which is rendered content rather than a finish: edit the delta clause by pinning the hex codes in the prompt and re-run from the baseline. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
 5. Re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
 
 ## Common mistakes
@@ -51,5 +51,5 @@ Change one variable per round. A round that swaps prompt, references, and model 
 - Asking `asset_analyze` to improve or fix the image: it returns text only; every fix is a new run.
 - Re-rolling the whole batch because one item failed: route per item.
 - Writing the rubric after seeing the batch: it inherits the batch's flaws as the standard.
-- Running the loop uncapped: failed jobs are reimbursed, unsatisfying ones are not; `usage` tracks spend against the brief's ceiling.
+- Running the loop uncapped: failed jobs are reimbursed, unsatisfying ones are not. Gate rounds on the costs the runs themselves report (`dry_run` prices the next round ahead); `usage` totals lag and answer the report after the run, not the mid-run gate.
 - Retrying a criterion a third time on the same model: two misses under two different fixes is evidence about the model, not bad luck.

--- a/skills/scenario-refine-loop/SKILL.md
+++ b/skills/scenario-refine-loop/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: scenario-refine-loop
+description: "Use when a Scenario output must be checked and improved rather than accepted first roll: iterating a generation until it matches the brief, fixing a batch that came back off-brief, retrying failed shots methodically, wiring an automated generate, review, revise loop, or deciding whether to re-prompt, swap references, inpaint, post-process, or change model. Keywords: refine, iterate, critique, review loop, QA, self-correction, verify, acceptance criteria, retry, drift."
+license: MIT
+---
+
+# Scenario Refine Loop
+
+## Overview
+
+Agents fail generation QA in two symmetric ways: accepting the first roll, or rewording the whole prompt and re-rolling until the budget dies. Both skip the same two artifacts, a written rubric and a diagnosis. The loop that converges: rubric before generating, a small batch, a recorded verdict per asset, the cheapest targeted fix per failure, a hard round cap. Connection and the core loop: see the `scenario` skill. Critic tool contracts: `scenario-asset-analysis`. Baseline discipline: `scenario-consistency`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
+## Quick reference
+
+| Step        | Do                                                                                                                                 |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Rubric   | Before generating, turn the brief into pass/fail lines a viewer can check ("subject centered on a plain field"), never taste words |
+| 2. Generate | The smallest batch that tests the recipe; `dry_run` when cost matters                                                              |
+| 3. Critique | `asset_analyze`: up to 10 images per call, one instruction embedding the rubric and a fixed per-image output shape                 |
+| 4. Fix      | Route every fail line to the cheapest fix that addresses it (table below)                                                          |
+| 5. Stop     | A clean round ships; three rounds without one, or one line failing twice under different fixes, means report, not respin           |
+
+Fix routing, cheapest first:
+
+| The verdict says              | Fix                                                                         |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| One local defect on a keeper  | Masked inpaint of that region (`scenario-image`)                            |
+| Color, framing, or finish off | A deterministic tool pass (`scenario-image-editing`), not a re-roll         |
+| Wrong content or composition  | Edit the delta clause, re-run from the approved baseline                    |
+| Identity or style drift       | Tighten the enumeration, add or re-role references (`scenario-consistency`) |
+| Every line failing            | Change the model (re-discover via `search` or `recommend`), keep the prompt |
+
+Change one variable per round. A round that swaps prompt, references, and model at once cannot attribute the improvement, so the next failure restarts from zero.
+
+## The two rules that keep the loop honest
+
+- **Verdicts cite the rubric, not taste.** Instruct the critic to answer per image, in order: `<index>: pass|fail, <the failed line>`. "Could be better" is not a verdict; a loop chasing better instead of the brief sands off exactly what made the direction distinctive and converges on generic output.
+- **Regenerate from the baseline, never from the last attempt.** Fixes re-run from the approved reference and prompt; chaining output to output compounds drift (`scenario-consistency` explains why).
+
+## Worked example: four icons against a brief
+
+1. Rubric from the brief, five lines: single object, centered, plain field, palette #2A9D8F and #E9C46A only, no text.
+2. Generate four, one `model_run` each per `scenario-image`, then `jobs_wait`.
+3. One `asset_analyze` call with all four ids in `images` and the rubric-plus-shape instruction; answers land as text assets, `asset_download` them to read the verdicts.
+4. Two fail. Icon 2 is off palette: re-run its prompt with the hex codes pinned. Icon 4 has one smeared edge: masked inpaint of that corner. Icons 1 and 3 ship untouched.
+5. Re-critique only the two new assets with the byte-identical instruction. Clean round: stop, file the keepers in a collection (`scenario-asset-analysis`).
+
+## Common mistakes
+
+- Judging by glancing at `asset_display` in chat: unrecorded impressions do not accumulate; verdicts do.
+- Asking `asset_analyze` to improve or fix the image: it returns text only; every fix is a new run.
+- Re-rolling the whole batch because one item failed: route per item.
+- Writing the rubric after seeing the batch: it inherits the batch's flaws as the standard.
+- Running the loop uncapped: failed jobs are reimbursed, unsatisfying ones are not; `usage` tracks spend against the brief's ceiling.
+- Retrying a criterion a third time on the same model: two misses under two different fixes is evidence about the model, not bad luck.


### PR DESCRIPTION
## What

Targets #64's branch: merging this updates PR #64. Two things land:

- The body cross-reference left open by the "maybe to group with quality gate?" thread (the catalog grouping itself already landed in f4f1d2b). One sentence after the quick reference: when the acceptance bar is the configured brand brief and the team has the Quality Gate add-on, the critic is `asset_quality_gate_run` per `scenario-quality-gate`, whose `reasons` and `suggestions` feed the fix table; the rubric-plus-`asset_analyze` path stays the default for task rubrics and ungated teams.
- A clean merge of current `main` (#67, #69, #70), which refreshes PR #64's base with no conflicts.

## Why

An agent holding both skills had no routing rule for the critique step: `scenario-quality-gate` describes "iterating a generation until it clears the gate" while `scenario-refine-loop` describes "iterating a generation until it matches the brief", and neither body named the other. The distinction the sentence teaches is that the gate scores AI quality plus the configured brief only, so it replaces `asset_analyze` exactly when the brief is the bar, never for ad-hoc task rubrics.

## Validation

`pnpm validate` passes on the merged head; body at 771 words (inside the 600-900 house target); the added claims check out against the `scenario-quality-gate` contract (image-only scope, Enterprise entitlement, `reasons`/`suggestions` shape, `asset_analyze` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPFcEdEGwCFMfrHCY91uAh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPFcEdEGwCFMfrHCY91uAh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill and catalog updates with no runtime, auth, or data-handling code.
> 
> **Overview**
> Adds two agent skills and catalogs them: **`scenario-identity-library`** (named character/prop lifecycle: interview, gated collections, Grid Maker sheets, reuse) and **`scenario-formats`** (derive every placement from one master, with a crop/resize/expand/reframe ladder plus `placement-specs.md`).
> 
> **`scenario-consistency`** now points at the identity library, treats uploads as anchors, distinguishes img2img `image` from true reference slots, and prefers `recommend` plus a schema gate for reference-capable models.
> 
> The core **`scenario`** loop prices with `dry_run` by default, files assets via collections/tags, and treats a transport error on `model_run` as a possible landed job (`jobs_list` before retry). **`scenario-refine-loop`** routes brand-brief image critique to `asset_quality_gate_run` when the Quality Gate add-on is on.
> 
> Worked examples across family skills shorten the `jobs_wait` timeout rule to “never a second `model_run`.” Minor keyword/format nits (STL, DALL-E, Photon, Dream Machine) land with the catalog README/`skills.sh.json` grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba32bebac477f978f24538189526cd02f26fc1e0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->