### PR TITLE
docs: add code of conduct, contributing guide, security policy, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+The PR title becomes the squash commit header on main, so write it as a
+Conventional Commit: type(scope): summary. Valid scopes are the skill
+directory names plus skills, agents, ci, deps, docs, and tooling.
+Example: feat(scenario-luma-video): teach the keyframe reframe workflow
+
+One concern per PR. A new skill, a fix to another skill, and a tooling
+change are three PRs. See CONTRIBUTING.md and AGENTS.md.
+-->
+
+## What and why
+
+<!-- One or two sentences: what changes, and the problem it solves. -->
+
+## Validation
+
+- [ ] `pnpm format` ran, then `pnpm validate` passes locally
+- [ ] `pnpm test` passes (required only when a shipped script changed)
+- [ ] For a new or changed skill: the application test from AGENTS.md ran (`/skills:validate <name>`), and the result is summarized below
+
+<!-- Application test result: the task used, pass or fail, what was fixed.
+     For docs or tooling changes, write "not applicable" instead. -->
+
+## Public content
+
+- [ ] No internal repositories, hostnames, team or project identifiers, customer names, or unreleased features
+- [ ] No credentials: no API keys, tokens, or signed asset URLs
+- [ ] Every tool and parameter claim is verifiable from public surfaces (the [tool reference](https://mcp.scenario.com/docs/tools), the public model catalog)
+
+## Authorship
+
+- [ ] A human reviewed the complete diff before this PR was submitted
+
+<!-- If an agent authored this PR, name the harness (Claude Code, Cursor,
+     Codex, ...) so reviewers know how the change was produced. -->

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@ skills-lock.json
 # Vendored dev skills, kept byte-identical to their published source
 .claude/skills/
 .agents/skills/
+
+# Contributor Covenant 2.1, kept byte-identical to its published source
+CODE_OF_CONDUCT.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at support@scenario.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for helping improve the Scenario Agent Skills. This guide covers the mechanics of a good contribution; [AGENTS.md](AGENTS.md) is the full authoring contract and wins wherever the two overlap.
+
+## Before you start
+
+- Found a bug or unclear guidance? [Open an issue](https://github.com/scenario-labs/skills/issues/new/choose) first: the templates capture exactly what a fix needs.
+- This repository is public. Everything in it, including commit messages, PR text, and issue text, must be publicly shareable: no internal repositories or hostnames, no credentials or signed asset URLs, no team or project ids you would not publish, and no facts that cannot be verified from public surfaces such as the [tool reference](https://mcp.scenario.com/docs/tools). When in doubt, leave it out.
+- Anything tied to your account (billing, credits, a security report) goes to support@scenario.com or in-app support at [app.scenario.com](https://app.scenario.com), never into a public issue. See the [security policy](SECURITY.md).
+
+## Setup
+
+```bash
+git clone https://github.com/scenario-labs/skills.git
+cd skills
+pnpm install
+```
+
+`pnpm install` sets up commitlint, cspell, prettier, and the husky git hooks, so every commit runs the same checks CI runs.
+
+## Authoring a skill
+
+Read [AGENTS.md](AGENTS.md) before writing. It defines the frontmatter contract, the description format ("Use when..."), the 600-900 word body target, the MCP-first rule, and the house style: no em dashes, no marketing language, and model ids discovered via `search` rather than asserted as constants. The `skill-creator` dev skill vendored in `.claude/skills/` helps with drafting; where its generic guidance and AGENTS.md disagree, AGENTS.md wins.
+
+## Validating
+
+```bash
+pnpm format   # prettier reflows markdown, so run it before validate
+pnpm validate # house style, formatting, supporting files, groupings, README table, spelling, spec
+pnpm test     # only needed when a shipped script changed; suites live in tests/<name>/
+```
+
+A new or changed skill also needs the application test from AGENTS.md ("Validation and testing"): a clean-room agent runs a realistic task with only the skill installed, and its plan is graded against the public tool reference. `/skills:validate <name>` drives it end to end. Mechanical validation checks the format; the application test checks whether the skill actually teaches.
+
+## Commits and pull requests
+
+- Commit messages and PR titles follow [Conventional Commits](https://www.conventionalcommits.org), enforced by commitlint. Valid scopes are the skill directory names plus `skills`, `agents`, `ci`, `deps`, `docs`, and `tooling`.
+- PRs target `main` and are squash-merged: the PR title becomes the commit header, so write it as one.
+- Keep a PR to one concern. A new skill, a fix to another skill, and a tooling change are three PRs.
+- Fill in the pull request template; it mirrors the checks above.
+
+## AI-agent contributors
+
+Agents are first-class authors here (AGENTS.md is written for them), with one expectation: a human reviews the complete diff before the PR is submitted, and the PR says so.
+
+## Code of conduct and license
+
+Participation is governed by the [code of conduct](CODE_OF_CONDUCT.md). Contributions are licensed under the [MIT License](LICENSE), the same license every skill carries in its frontmatter.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ A skill is a `SKILL.md` file with procedural knowledge an agent loads on demand,
 
 ## Contributing
 
-See [AGENTS.md](AGENTS.md) for the authoring contract, the public-content policy, validation, and the application-testing bar. One-time setup after cloning: `pnpm install` (installs commitlint, cspell, prettier, and the husky git hooks). `pnpm run validate` runs the same content checks CI runs; commit messages and the PR title are linted separately with commitlint. PRs welcome; PR titles follow Conventional Commits since they become the squash commit header on `main`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow, and [AGENTS.md](AGENTS.md) for the authoring contract, the public-content policy, validation, and the application-testing bar. One-time setup after cloning: `pnpm install` (installs commitlint, cspell, prettier, and the husky git hooks). `pnpm run validate` runs the same content checks CI runs; commit messages and the PR title are linted separately with commitlint. PRs welcome; PR titles follow Conventional Commits since they become the squash commit header on `main`.
 
 Every script shipped with a skill has a test suite in `tests/<name>/`; `pnpm test` runs them all (CI does too). Suites need Python 3.11+ with any `tests/<name>/requirements.txt` dependencies installed, plus ffmpeg on PATH where a suite uses it. Python suites use stdlib `unittest`, TypeScript suites use vitest.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Do not report security vulnerabilities through public GitHub issues, discussions, or pull requests: everything posted here is public and permanent.
+
+Report privately instead, through either channel:
+
+- Email support@scenario.com and put "security" in the subject line.
+- Use in-app support at [app.scenario.com](https://app.scenario.com).
+
+Include what an investigation needs: the affected surface (a skill or script in this repository, the Scenario MCP server, or the Scenario platform), reproduction steps, and the impact you see. Scenario support routes security reports to the right team and follows up through the same channel.
+
+## Scope
+
+This repository contains skill documents (markdown) and a small number of helper scripts; it runs no service of its own. Reports that belong here include:
+
+- a script shipped with a skill that does something unsafe,
+- skill guidance that would lead an agent to expose credentials or other secrets,
+- a supply-chain concern with the repository's tooling or CI.
+
+Vulnerabilities in the Scenario platform itself (app.scenario.com, the MCP server at mcp.scenario.com, the public API) go through the same private channels above, not through this repository's issue tracker.
+
+## Secrets in issues and pull requests
+
+Signed asset URLs are credentials: never commit them and never paste them into issues or PRs. The same goes for API keys, tokens, and anything else the issue templates flag. If you spot a secret already exposed in this repository, report it privately rather than pointing to it in a public issue.

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -8,5 +8,9 @@ pnpm exec cspell --no-progress --relative --no-must-find-files \
   'skills/**/*.md' \
   'README.md' \
   'AGENTS.md' \
+  'CODE_OF_CONDUCT.md' \
+  'CONTRIBUTING.md' \
+  'SECURITY.md' \
+  '.github/**/*.md' \
   '.claude/commands/*.md' \
   '.claude/agents/*.md'

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -59,7 +59,9 @@ annotate_em_dashes() {
 # found, so treat 0 as "violations found" and >=2 as a loud config failure
 # instead of letting either case pass silently.
 grep_status=0
-em_dash_hits=$(grep -rn --include='*.md' -e '—' skills README.md AGENTS.md .claude/commands .claude/agents) || grep_status=$?
+# CODE_OF_CONDUCT.md is excluded on purpose: it is the published Contributor
+# Covenant text kept byte-identical to its source, like the vendored dev skills.
+em_dash_hits=$(grep -rn --include='*.md' -e '—' skills README.md AGENTS.md CONTRIBUTING.md SECURITY.md .github .claude/commands .claude/agents) || grep_status=$?
 if [ "$grep_status" -eq 0 ]; then
   echo 'Em dashes are forbidden (house style). Each hit below is path:line:column (column counts from 1) with the offending em dash (U+2014) wrapped in >>> <<<; a leading "- " list bullet is an ASCII hyphen, never the match.'
   annotate_em_dashes "$em_dash_hits"


### PR DESCRIPTION
## What and why

Completes the GitHub community-standards checklist ([repo community profile](https://github.com/scenario-labs/skills/community)), which was missing four items: code of conduct, contributing guidelines, security policy, and a pull request template. The additions follow what the best-performing skills.sh repositories ship (obra/superpowers is the only top repo carrying community health files: a Contributor Covenant code of conduct and an agent-aware PR template), adapted to this repo's existing rules.

- **CODE_OF_CONDUCT.md**: the published Contributor Covenant 2.1, byte-identical to its source apart from the contact method (support@scenario.com, the private channel the issue templates already name). Excluded from prettier like other vendored text so GitHub's template detection keeps matching it.
- **CONTRIBUTING.md**: distills the contribution workflow already spread across README.md and AGENTS.md: public-content policy, setup, `pnpm format` / `pnpm validate` / `pnpm test`, the application test, Conventional Commits with the valid scopes, and an AI-agent contributors section. AGENTS.md remains the authoritative contract.
- **SECURITY.md**: routes vulnerability reports privately (support@scenario.com or in-app support), scopes what belongs to a content repo (unsafe shipped scripts, guidance that would expose secrets, supply-chain concerns in tooling or CI), and repeats the signed-asset-URLs-are-credentials rule. GitHub private vulnerability reporting is currently disabled on this repo, so the policy does not point to it; if an admin enables it, it can be added as a channel.
- **.github/pull_request_template.md**: mirrors the repo's real gates: Conventional-Commit title reminder (squash-merge makes it the commit header), validation checklist including the application test, public-content checklist, and a human-reviewed-diff checkbox with optional harness disclosure.

Supporting changes: README's Contributing section links CONTRIBUTING.md; `scripts/check-style.sh` extends the em-dash check to CONTRIBUTING.md, SECURITY.md, and `.github` markdown (verified it fires), keeping CODE_OF_CONDUCT.md excluded as vendored text.

Note: the community-profile checkmarks update only once this lands on `main`, since GitHub reads community health files from the default branch.

## Validation

- [x] `pnpm format` ran, then `pnpm validate` passes locally (ran on both commits via the pre-commit hook)
- [x] `pnpm test`: not applicable, no shipped skill script changed
- [x] Application test: not applicable, docs and tooling only (no SKILL.md touched)

## Public content

- [x] No internal repositories, hostnames, team or project identifiers, customer names, or unreleased features
- [x] No credentials: no API keys, tokens, or signed asset URLs
- [x] Every tool and parameter claim is verifiable from public surfaces (the [tool reference](https://mcp.scenario.com/docs/tools), the public model catalog)

## Authorship

- [ ] A human reviewed the complete diff before this PR was submitted

Authored with Claude Code in a remote session at the maintainer's request; leaving this box for the reviewing human to tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BmNBaZw4Egv5TS5fPWrxb

---
_Generated by [Claude Code](https://claude.ai/code/session_019BmNBaZw4Egv5TS5fPWrxb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and community-standards files only; the style-check path expansion is a small, non-runtime lint change.
> 
> **Overview**
> Fills the GitHub community-standards gaps with a Contributor Covenant 2.1 `CODE_OF_CONDUCT.md` (kept byte-identical and prettier-ignored), a `CONTRIBUTING.md` that points at `AGENTS.md` as the authoring contract, a `SECURITY.md` that routes reports privately to support, and a PR template that encodes Conventional Commits, validation, public-content, and human-review checklists.
> 
> README now links `CONTRIBUTING.md`. The em-dash house-style grep also covers `CONTRIBUTING.md`, `SECURITY.md`, and `.github`, while still excluding the vendored CoC text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b2b74c015aea9097d14cdb8a2c6bdddbc11be2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->