### PR TITLE
feat(scenario-brand-kit): add brand kit skill for visual identities

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,6 +34,7 @@
       "skills": [
         "./skills/scenario-image",
         "./skills/scenario-product-shots",
+        "./skills/scenario-brand-kit",
         "./skills/scenario-image-editing",
         "./skills/scenario-text-overlay",
         "./skills/scenario-storyboards"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Generate and edit images: model choice, sizing, references, masked edits, post-p
 | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | [scenario-image](skills/scenario-image/SKILL.md)                 | Text-to-image and image editing: model choice, sizing fields, prompt limits, reference images, masked inpainting      |
 | [scenario-product-shots](skills/scenario-product-shots/SKILL.md) | Product photography from a real photo: packshots, lifestyle scenes, relighting, label-fidelity gates                  |
+| [scenario-brand-kit](skills/scenario-brand-kit/SKILL.md)         | Visual identities: SVG logos and wordmarks, palette and type specs, gated variants and applications, the filed kit    |
 | [scenario-image-editing](skills/scenario-image-editing/SKILL.md) | Tool-model image edits: 3D LUT grades, effects, expand and reframe, resize, slicing, layers, background removal       |
 | [scenario-text-overlay](skills/scenario-text-overlay/SKILL.md)   | Letter-perfect text overlays: templated transparent PNG cards (taglines, CTAs, legal supers, rich cards) to composite |
 | [scenario-storyboards](skills/scenario-storyboards/SKILL.md)     | Comic pages, storybooks, and pre-viz storyboards: script first, one run per panel, a locked cast, lettering in post   |

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -18,6 +18,7 @@
       "skills": [
         "scenario-image",
         "scenario-product-shots",
+        "scenario-brand-kit",
         "scenario-image-editing",
         "scenario-text-overlay",
         "scenario-storyboards"

--- a/skills/scenario-brand-kit/SKILL.md
+++ b/skills/scenario-brand-kit/SKILL.md
@@ -12,28 +12,28 @@ An identity is decided, then rendered. Palette and typography are choices writte
 
 ## Quick reference
 
-| Need         | Route                                                                                                                                                       |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| The spec     | Written first, by you with the user: palette as hex values with roles, two type families with weights, voice line, clear-space and don't rules              |
-| Logo, native | `search` `"svg"`: prompt-to-SVG generators (logos, icons, badges) were the authoring-time hits; the output is a real editable vector                        |
-| Logo, traced | An existing raster mark goes through `search` `"vectorize"` (raster-to-SVG tracers) rather than being regenerated                                           |
-| Gate         | `asset_analyze` the mark: spelling letter by letter, geometry, palette compliance; a drifted wordmark is re-run, never patched                              |
-| Variants     | `asset_download` the SVG (omit `format`, a raster conversion), edit fills and strokes to the spec's hex values locally, `upload_asset` each variant back    |
-| Applications | `recommend` with `capability="img2img"`, approved mark as reference, spec hex values named in the prompt, one placement per run                             |
-| Fix a mark   | `search` `"logo"`: an authoring-time hit repairs a drifted logo in a scene from the reference as ground truth                                               |
-| File the kit | `collection_create` plus `collection_add_assets` (tool catalog: `scenario` skill); `asset_update` gives each asset a description carrying its role and rule |
+| Need         | Route                                                                                                                                                                                          |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The spec     | Written first, by you with the user: palette as hex values with roles, two type families with weights, voice line, clear-space and don't rules                                                 |
+| Logo, native | `search` `"svg"`: prompt-to-SVG generators (logos, icons, badges) were the authoring-time hits; the output is a real editable vector                                                           |
+| Logo, traced | An existing raster mark goes through `search` `"vectorize"` (raster-to-SVG tracers) rather than being regenerated                                                                              |
+| Gate         | `asset_analyze` the mark, the spec passed via `text_inputs`: spelling letter by letter, geometry, palette; a drifted wordmark is re-run, never patched                                         |
+| Variants     | `asset_get` the mark and save its `url` (`curl -L`): it serves the stored SVG verbatim, where `asset_download` converts to `png` by default; recolor locally, `upload_asset` each variant back |
+| Applications | `recommend` with `capability="img2img"`, approved mark as reference, spec hex values named in the prompt, one placement per run                                                                |
+| Fix a mark   | `search` `"logo"`: an authoring-time hit repairs a drifted logo in a scene from the reference as ground truth                                                                                  |
+| File the kit | `collection_create` plus `collection_add_assets` (tool catalog: `scenario` skill); `asset_update` gives each asset a description carrying its role and rule                                    |
 
 ## The spec sheet
 
-One short document anchors every run and every gate: four to six hex values, each with a role (primary, ink, paper, accent); two type families with weights and their jobs (display, body); the logo's clear space and minimum size; three "never" rules (never stretch, never recolor outside the palette, never set the wordmark in another face). Prompts name hex values from it verbatim, `asset_analyze` gates against it, and it ships with the kit as its usage page. Type comes from families the destination can load (widely available or licensed): a generated "font" is a picture of one, so real text is set by `scenario-text-overlay` in the spec's family.
+One short document anchors every run and every gate: four to six hex values, each with a role (primary, ink, paper, accent); two type families with weights and their jobs (display, body); the logo's clear space and minimum size; three "never" rules (never stretch, never recolor outside the palette, never set the wordmark in another face). Prompts name hex values from it verbatim, every gate hands its full text to `asset_analyze` through `text_inputs` (a paraphrase drops exact spelling and hex roles), and it ships with the kit as its usage page. Type comes from families the destination can load (widely available or licensed): a generated "font" is a picture of one, so real text is set by `scenario-text-overlay` in the spec's family.
 
 ## Worked example: an identity for a new game studio
 
 1. Spec first. The brief names a mood; `scenario-inspiration` turns it into a chosen direction when it names nothing. Write palette, type, and rules down before any generation and confirm with the user (unattended: take the brief's constraints, decide the rest, mark it provisional).
 2. Mark: `search` with `target="models"`, `query="svg"`, `public=true`; `model_schema_get` the generator pick. One run per candidate mark, prompting flat geometry, few colors, the spec's hex values, and the studio name for the wordmark. `jobs_wait`, `asset_display`, and let the user pick (unattended: gate all, keep the best pass).
-3. Gate the pick with `asset_analyze` (write lane, contract in `scenario-asset-analysis`): name read letter by letter, geometry closed and centered, colors on palette. Fail means re-run with the prompt tightened, never an edit of the drifted output.
-4. Variants: `asset_download` the winning SVG and open it, since it is XML. Recolor fills to make mono, reversed, and paper-background variants; `upload_asset` each (`kind` `image`). One mark, colorways as data.
-5. Applications: `recommend` with `capability="img2img"`; wire the approved mark as reference exactly as the schema says (an array only under `array: true`). One run per placement (avatar, banner, wallpaper), each prompt subordinating the scene to the mark: "the exact logo from the reference, unaltered, centered on...". Gate each against the spec; a scene that mangled the mark can go through the logo-repair route in the table.
+3. Gate the pick with `asset_analyze` (write lane, contract in `scenario-asset-analysis`), the spec via `text_inputs`: name read letter by letter, geometry closed and centered, colors on palette. Fail means re-run with the prompt tightened, never an edit of the drifted output.
+4. Variants: `asset_get` the winning mark and save its `url` with `curl -L`, which serves the stored SVG verbatim (`asset_download` converts to raster, `format` defaulting to `png`). Recolor fills to make mono, reversed, and paper-background variants; `upload_asset` each (`kind` `image`). One mark, colorways as data.
+5. Applications: `recommend` with `capability="img2img"`; wire the approved mark as reference exactly as the schema says (an array only under `array: true`; a pick whose schema has no image field cannot hold the mark, so take the next option). One run per placement (avatar, banner, wallpaper), each prompt subordinating the scene to the mark: "the exact logo from the reference, unaltered, centered on...". Gate each against the spec; text the gate cannot resolve at output size is unverified, not passed (upscale and re-gate, or flag it), and a scene that mangled the mark can go through the logo-repair route in the table.
 6. Exact text (tagline, handle, URL) is composited by `scenario-text-overlay` in the spec's type, never prompted into the plate. Placement sizes derive per `scenario-formats`.
 7. File everything with `collection_create` and `collection_add_assets`, write each asset's role and rule into its `asset_update` description, and deliver the spec sheet as the kit's usage page.
 

--- a/skills/scenario-brand-kit/SKILL.md
+++ b/skills/scenario-brand-kit/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: scenario-brand-kit
+description: "Use when building a visual identity or brand kit with Scenario: a logo, wordmark, or icon as editable SVG, a color palette and typography spec, logo variants (mono, reversed, favicon), brand applications like social templates, avatars, banners, or merchandise mockups, and the assembled kit filed with usage rules. Also for a rebrand or refreshing an existing mark. Keywords: brand kit, visual identity, logo, wordmark, SVG, vectorize, color palette, typography, brand guidelines, launch kit."
+license: MIT
+---
+
+# Scenario Brand Kit
+
+## Overview
+
+An identity is decided, then rendered. Palette and typography are choices written into a spec before any run; the logo is generated once as a real vector and reused everywhere; every application references the approved mark instead of re-imagining it. Skipping the spec yields ten assets that each look fine and do not look related. Connection and the core loop: see the `scenario` skill. Finding the direction when nothing is decided: `scenario-inspiration`. Image runs and reference wiring: `scenario-image`. Exact taglines and CTAs on applications: `scenario-text-overlay`. Per-placement sizes: `scenario-formats`. Gating contract: `scenario-asset-analysis`. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
+## Quick reference
+
+| Need         | Route                                                                                                                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The spec     | Written first, by you with the user: palette as hex values with roles, two type families with weights, voice line, clear-space and don't rules              |
+| Logo, native | `search` `"svg"`: prompt-to-SVG generators (logos, icons, badges) were the authoring-time hits; the output is a real editable vector                        |
+| Logo, traced | An existing raster mark goes through `search` `"vectorize"` (raster-to-SVG tracers) rather than being regenerated                                           |
+| Gate         | `asset_analyze` the mark: spelling letter by letter, geometry, palette compliance; a drifted wordmark is re-run, never patched                              |
+| Variants     | `asset_download` the SVG (omit `format`, a raster conversion), edit fills and strokes to the spec's hex values locally, `upload_asset` each variant back    |
+| Applications | `recommend` with `capability="img2img"`, approved mark as reference, spec hex values named in the prompt, one placement per run                             |
+| Fix a mark   | `search` `"logo"`: an authoring-time hit repairs a drifted logo in a scene from the reference as ground truth                                               |
+| File the kit | `collection_create` plus `collection_add_assets` (tool catalog: `scenario` skill); `asset_update` gives each asset a description carrying its role and rule |
+
+## The spec sheet
+
+One short document anchors every run and every gate: four to six hex values, each with a role (primary, ink, paper, accent); two type families with weights and their jobs (display, body); the logo's clear space and minimum size; three "never" rules (never stretch, never recolor outside the palette, never set the wordmark in another face). Prompts name hex values from it verbatim, `asset_analyze` gates against it, and it ships with the kit as its usage page. Type comes from families the destination can load (widely available or licensed): a generated "font" is a picture of one, so real text is set by `scenario-text-overlay` in the spec's family.
+
+## Worked example: an identity for a new game studio
+
+1. Spec first. The brief names a mood; `scenario-inspiration` turns it into a chosen direction when it names nothing. Write palette, type, and rules down before any generation and confirm with the user (unattended: take the brief's constraints, decide the rest, mark it provisional).
+2. Mark: `search` with `target="models"`, `query="svg"`, `public=true`; `model_schema_get` the generator pick. One run per candidate mark, prompting flat geometry, few colors, the spec's hex values, and the studio name for the wordmark. `jobs_wait`, `asset_display`, and let the user pick (unattended: gate all, keep the best pass).
+3. Gate the pick with `asset_analyze` (write lane, contract in `scenario-asset-analysis`): name read letter by letter, geometry closed and centered, colors on palette. Fail means re-run with the prompt tightened, never an edit of the drifted output.
+4. Variants: `asset_download` the winning SVG and open it, since it is XML. Recolor fills to make mono, reversed, and paper-background variants; `upload_asset` each (`kind` `image`). One mark, colorways as data.
+5. Applications: `recommend` with `capability="img2img"`; wire the approved mark as reference exactly as the schema says (an array only under `array: true`). One run per placement (avatar, banner, wallpaper), each prompt subordinating the scene to the mark: "the exact logo from the reference, unaltered, centered on...". Gate each against the spec; a scene that mangled the mark can go through the logo-repair route in the table.
+6. Exact text (tagline, handle, URL) is composited by `scenario-text-overlay` in the spec's type, never prompted into the plate. Placement sizes derive per `scenario-formats`.
+7. File everything with `collection_create` and `collection_add_assets`, write each asset's role and rule into its `asset_update` description, and deliver the spec sheet as the kit's usage page.
+
+## Common mistakes
+
+- Generating applications before a spec exists: without written hex values and rules there is nothing to gate against, and the kit drifts apart asset by asset.
+- Prompting the brand name into every application: generated type drifts; the name rides the approved mark or a `scenario-text-overlay` card.
+- Re-imagining the logo per application instead of referencing it: ten cousins, no identity. The mark is generated once, then reused.
+- Upscaling a raster of the logo: the vector already scales; the SVG stays the master.
+- Recoloring by regenerating: fills and strokes in an SVG are text edits; a regeneration changes the geometry too.
+- Passing a wordmark that looks right at thumbnail size: letterform drift hides there; the gate reads it back letter by letter.
+- Treating palette hex values as a vibe: unnamed colors drift warm or cool per run; every prompt names them from the spec.
+- Deriving a variant from a mockup instead of the master: derivative-of-derivative compounds artifacts (`scenario-formats` has the order of operations).


### PR DESCRIPTION
## What and why

Adds `scenario-brand-kit`, a pipeline skill for building a visual identity through the Scenario MCP: a written spec first (palette hex values with roles, type families, usage rules), an SVG-native logo discovered via `search`, a letter-by-letter `asset_analyze` gate fed the spec through `text_inputs`, local recolor of the vector for mono and reversed variants, reference-driven applications with exact text composited via `scenario-text-overlay`, and the kit filed in a collection. No existing skill covers identity work: `scenario-product-shots` starts from a real product photo and `scenario-image` teaches runs, not the system that keeps ten brand assets looking related. The skill joins the Images grouping (`skills.sh.json`, README row, regenerated marketplace manifest).

## Validation

- [x] `pnpm format` ran, then `pnpm validate` passes locally
- [ ] `pnpm test` passes (required only when a shipped script changed) — not applicable, no script shipped
- [x] For a new or changed skill: the application test from AGENTS.md ran (plan-only variant), and the result is summarized below

Application test (plan-only): a fresh clean-room agent, given only this SKILL.md plus the `scenario` SKILL.md, planned an unattended brand kit for a fictional studio (SVG icon-plus-wordmark, mono and reversed variants, avatar and tagline banner, filed on the platform). Graded against the tool reference fetched fresh: every tool and parameter named exists, model ids came from `search`/`recommend`, the flow was discovery, `model_schema_get`, `dry_run`, `model_run`, `jobs_wait` re-called with `pending_job_ids`, and the trap steps landed (variants recolored locally instead of regenerated, wordmark gated letter by letter through the write-lane executor, tagline kept out of the generation prompt, references wired as arrays only under `array: true`). Baseline probe without the skill: the agent regenerated variants by prompt, prompted the tagline into the plate, gated with a single "looks garbled" check, and was unsure vector output existed, confirming the skill earns its context cost.

Review round: four bot findings were each verified before fixing. The largest was real and is now corrected in the skill text: `asset_download` converts image assets to raster (`format` defaults to `png`), reproduced live on a public SVG asset, so the vector master is retrieved via `asset_get`'s `url`, which was confirmed to serve the stored SVG verbatim. The other fixes: the spec now rides every gate via `text_inputs`, unresolved text is unverified rather than passed, and a `recommend` pick whose schema has no image field is skipped for the next option.

## Public content

- [x] No internal repositories, hostnames, team or project identifiers, customer names, or unreleased features
- [x] No credentials: no API keys, tokens, or signed asset URLs
- [x] Every tool and parameter claim is verifiable from public surfaces (the [tool reference](https://mcp.scenario.com/docs/tools), the public model catalog): the SVG generators, vectorizers, and the logo-repair tool referenced as authoring-time hits were all confirmed live in the public catalog, and the `asset_get`/`asset_download` behavior was verified against the live platform

## Authorship

- [ ] A human reviewed the complete diff before this PR was submitted

Agent-authored (Claude Code); a human review of the diff is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGh1n4aNDu4cxoNDj3FcBy