### PR TITLE
feat(skills): add the scenario-ugc and scenario-fan-cam skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,6 +63,8 @@
         "./skills/scenario-seedance-music-video",
         "./skills/scenario-seedance-storyboard",
         "./skills/scenario-video-ads",
+        "./skills/scenario-ugc",
+        "./skills/scenario-fan-cam",
         "./skills/scenario-audio",
         "./skills/scenario-video-assembly"
       ]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Video generation and editing, music, sound effects, voice, and speech.
 | [scenario-seedance-music-video](skills/scenario-seedance-music-video/SKILL.md) | Turning a song into a music video: beat-aligned shots, lyric transcription, shot sound under the master, assembly                     |
 | [scenario-seedance-storyboard](skills/scenario-seedance-storyboard/SKILL.md)   | Movement that holds across cuts: timecoded shot scripts, character sheets and boards, pose-chained shots that play as one performance |
 | [scenario-video-ads](skills/scenario-video-ads/SKILL.md)                       | Producing a video ad from a product shot: brief, storyboard, cinematic grammar, fidelity gates, budget, delivery                      |
+| [scenario-ugc](skills/scenario-ugc/SKILL.md)                                   | UGC-style creator video: talking-head and avatar ads, demos, faceless voiceover, spoken-register scripts, claim safety                |
+| [scenario-fan-cam](skills/scenario-fan-cam/SKILL.md)                           | Personalized fan-cam clips: identity edit into a broadcast still, reaction beats to video, graphics composited in post                |
 | [scenario-audio](skills/scenario-audio/SKILL.md)                               | Music, sound effects, voice and speech generation, video scoring, audio utilities                                                     |
 | [scenario-video-assembly](skills/scenario-video-assembly/SKILL.md)             | Assembling clips into a finished video: timeline composition, concat with transitions, overlays, music, captions                      |
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -12,6 +12,7 @@ artic
 binet
 bisociation
 captioner
+defocused
 desaturate
 diegetic
 equirectangular

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -43,6 +43,8 @@
         "scenario-seedance-music-video",
         "scenario-seedance-storyboard",
         "scenario-video-ads",
+        "scenario-ugc",
+        "scenario-fan-cam",
         "scenario-audio",
         "scenario-video-assembly"
       ]

--- a/skills/scenario-fan-cam/SKILL.md
+++ b/skills/scenario-fan-cam/SKILL.md
@@ -37,7 +37,7 @@ Give the reaction an arc rather than a state: oblivious, then noticing the camer
 4. Gate the still: `asset_display` it for approval, and inventory the likeness (face geometry, hair, wardrobe) with the analysis lane from `scenario-asset-analysis`; unattended, that inventory stands in for the user's sign-off.
 5. `search` `query="image to video"`, pick per `scenario-kling` or `scenario-video`, `model_schema_get`, then `model_run` with `dry_run=true` for the quote.
 6. Run with the approved still as the start image and two beats: "she chats, unaware" then "she spots herself on the stadium screen, stands, and cheers", one slow reframing move, `wait=false`, then `jobs_wait` re-called with `pending_job_ids` on timeout, never a second `model_run`.
-7. Extract frames from the clip and compare against the approved still; likeness drift fails the clip, and the retry starts from the same still, never from the drifted output.
+7. Extract frames from the clip on-platform with a frame-extract tool model (`search` `query="extract frames"`, a tool-model lane per `scenario-video-editing`) and compare against the approved still; likeness drift fails the clip, and the retry starts from the same still, never from the drifted output.
 8. Assemble per `scenario-video-assembly`: score strip and channel bug rendered by `scenario-text-overlay` as image layers in the safe corners. `asset_display` the master, then cut 9:16 per `scenario-formats`.
 
 ## Common mistakes

--- a/skills/scenario-fan-cam/SKILL.md
+++ b/skills/scenario-fan-cam/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: scenario-fan-cam
+description: "Use when putting a person from a photo into live-broadcast crowd footage with Scenario: a stadium or arena fan-cam reaction, a jumbotron or kiss-cam moment, a spectator cutaway at a match or concert, a courtside or front-row sighting, or a personalized sports-TV still that then animates into video. Keywords: fan cam, crowd reaction, jumbotron, stadium screen, kiss cam, broadcast cutaway, spectator, crowd shot, sports TV, courtside, arena."
+license: MIT
+---
+
+# Scenario Fan Cam
+
+## Overview
+
+A fan cam is a two-stage build: an identity-preserving image edit places the person into a 16:9 broadcast still, and image-to-video animates the approved still into a reaction. The uploaded photo is an identity reference, never a start frame: feeding it straight to a video model animates a portrait, not a broadcast. Stage one is cheap and stage two is not, so the still carries every decision worth approving.
+
+Use only photos of the user or of people who gave them permission; refuse celebrity or stranger insertions. Real faces also trip provider filters more than most subjects: on a block, see `scenario-moderation`. Connection and the core loop: see the `scenario` skill in this repo. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
+## Quick reference
+
+Discover ids with `search` (`target="models"`, `public=true`); never assert one as a constant.
+
+| Stage             | What happens                                                                           | Detail                                             |
+| ----------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| 1. Identity still | Image-edit member (query `"image edit"`) composites the person into a 16:9 crowd frame | `scenario-image-editing`, `scenario-consistency`   |
+| 2. Still gate     | Likeness checked against the photo before any video money is spent                     | `scenario-asset-analysis`                          |
+| 3. Animate        | Image-to-video from the approved still, reaction beats, one camera move                | `scenario-kling`, `scenario-video`                 |
+| 4. Identity gate  | Frames extracted from the clip, compared to the approved still                         | `scenario-asset-analysis`                          |
+| 5. Overlays       | Score strip, channel bug, lower third composited as post layers, never generated       | `scenario-text-overlay`, `scenario-video-assembly` |
+| 6. Derivatives    | 9:16 and 1:1 social cuts off the 16:9 master                                           | `scenario-formats`                                 |
+
+Broadcast grammar is what sells the shot, so prompt it explicitly at both stages: long-lens compression with the crowd defocused in front and behind, harsh stadium floodlight or arena strobe, slight motion blur, the camera hunting and reframing as it finds the subject. Keep the person mid-ground among other fans, off-center, at broadcast camera height. A centered, well-lit, eye-level subject reads as a photoshoot in a stadium, not a cutaway.
+
+Give the reaction an arc rather than a state: oblivious, then noticing the camera or the screen, then the reaction the user asked for (cheering, laughing, disbelief, heartbreak). Multi-beat prompting per the video family's contract keeps the turn inside one clip.
+
+## Worked example: caught on the stadium screen, 8 seconds
+
+1. Collect the photo, the sport or event, venue mood, wardrobe, and the wanted reaction. `upload_asset` the photo once and reuse the returned asset id.
+2. `search` `target="models"`, `query="image edit"`, `public=true`; pick a current identity-capable editor and read `model_schema_get` for its reference-image inputs (`scenario-image-editing` for the lane, `scenario-consistency` for reference discipline).
+3. Edit prompt: "the person from the reference image seated mid-crowd at a floodlit football stadium, 16:9 television cutaway, long-lens crowd compression, no text, logos, or graphics in frame". Keep the plate text-free: overlays come later.
+4. Gate the still: `asset_display` it for approval, and inventory the likeness (face geometry, hair, wardrobe) with the analysis lane from `scenario-asset-analysis`; unattended, that inventory stands in for the user's sign-off.
+5. `search` `query="image to video"`, pick per `scenario-kling` or `scenario-video`, `model_schema_get`, then `model_run` with `dry_run=true` for the quote.
+6. Run with the approved still as the start image and two beats: "she chats, unaware" then "she spots herself on the stadium screen, stands, and cheers", one slow reframing move, `wait=false`, then `jobs_wait` re-called with `pending_job_ids` on timeout, never a second `model_run`.
+7. Extract frames from the clip and compare against the approved still; likeness drift fails the clip, and the retry starts from the same still, never from the drifted output.
+8. Assemble per `scenario-video-assembly`: score strip and channel bug rendered by `scenario-text-overlay` as image layers in the safe corners. `asset_display` the master, then cut 9:16 per `scenario-formats`.
+
+## Common mistakes
+
+- Animating the uploaded photo directly: the mandatory stage is the broadcast still; skip it only when the user hands over an already approved 16:9 frame.
+- Letting the image or video model render the scoreboard, channel bug, or jersey sponsor text: generated type drifts frame to frame; composite graphics in post on a text-free plate.
+- Portrait staging: centered subject, flattering light, and empty seats around them break the documentary read; bury them in a reacting crowd.
+- Judging likeness from one glance at the moving clip: drift hides between glances; run the frame-extract gate.
+- Retrying from a drifted clip instead of the approved still: errors compound.
+- Composing the master at 9:16: broadcast is 16:9; verticals are derivatives.
+- A flat emotional state for the whole clip: without the notice-then-react turn, the result is a looping portrait, not a fan cam.
+- Compound camera moves: one reframing drift; the crowd and the reaction supply the motion.

--- a/skills/scenario-ugc/SKILL.md
+++ b/skills/scenario-ugc/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: scenario-ugc
+description: "Use when producing UGC-style creator video with Scenario: a talking-head ad or testimonial from a portrait and a script, a founder clip, a product demo or unboxing, a reaction or before-after cut, a faceless voiceover over b-roll, or vertical social video for TikTok, Reels, or Shorts that must feel filmed on a phone rather than produced. Keywords: UGC, creator ad, talking head, testimonial, avatar, lipsync, founder video, social proof, faceless voiceover, organic, vertical video."
+license: MIT
+---
+
+# Scenario UGC Creator Video
+
+## Overview
+
+UGC is a register, not a length: content that reads as a person talking into their own phone, not a brand talking through a camera crew. Everything in this skill serves that register, and most failures come from importing ad craft into it. This skill routes the production; mechanics live in the sibling skills named per lane. Connection and the core loop: see the `scenario` skill in this repo. If a sibling skill named here is missing from your available skills, ask the user to install it (`npx skills add scenario-labs/skills --skill <name>`); unattended, proceed from tool schemas and flag the gap.
+
+Two rules are non-negotiable. The product is never generated: demo shots start from an uploaded photo or footage of the real product (`scenario-product-shots` for stills). And the words are never invented: no fabricated testimonials, review counts, metrics, medical or financial claims, or legal copy; speak only lines the user supplied or approved, and prefer observable statements ("the texture looks lighter") over claims ("this cures acne").
+
+## Quick reference: route by speaker lane
+
+Discover ids with `search` (`target="models"`, `public=true`); never assert one as a constant.
+
+| Lane                                | Route                                                            | Contract                                              |
+| ----------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
+| Portrait plus speech audio          | Talking-avatar members (query `"avatar"`)                        | `scenario-kling`                                      |
+| Existing footage, new words         | Lipsync members (query `"lipsync"`), audio or `text`, never both | `scenario-kling`                                      |
+| Generated creator speaking natively | Native-audio video families, dialogue in quotes                  | `scenario-veo`, `scenario-seedance`, `scenario-kling` |
+| Faceless voiceover                  | B-roll clips plus TTS narration                                  | `scenario-video`, `scenario-elevenlabs`               |
+| Product demo inserts                | Image-to-video off the uploaded product still                    | `scenario-product-shots`, `scenario-video`            |
+| Captions, cut, 9:16 master          | Assembly tool models; text cards as image layers                 | `scenario-video-assembly`, `scenario-text-overlay`    |
+
+Script in six spoken beats: hook (one concrete tension or result), context (why this speaker cares), product moment, proof (visible demo or a user-supplied fact), turn (objection answered or before-after), close (soft CTA). Write for the mouth, not the page: contractions, false starts allowed, no taglines. Spoken pace runs near 2.5 words a second, so a 25-second ad is roughly 60 words.
+
+Keep the register in every visual prompt: phone-height framing, available light, a real location with clutter, one handheld drift at most. Cinematic grammar (dolly moves, golden-hour rim light, shallow anamorphic looks, graded color) reads as an ad and kills belief. Compose 9:16 natively; a cropped 16:9 master frames like television.
+
+## Worked example: 25-second founder ad from a portrait
+
+1. Brief once: offer, platform, runtime, the facts the founder may claim, tone. Collect the portrait and the real product photo, then run without stopping.
+2. Draft the six beats at about 60 words and confirm the wording with the user; the script is a claims surface, not just copy.
+3. Voice: `upload_asset` the founder's recorded narration, or generate TTS per `scenario-elevenlabs` when they want a stand-in voice they approved.
+4. `search` `target="models"`, `query="avatar"`, `public=true`; pick the newest non-deprecated talking-avatar member and read its `model_schema_get`: input names and caps change per member.
+5. `upload_asset` the portrait. `model_run` with `dry_run=true` first: avatar members sit far apart on price, so quote before spending.
+6. Run for real with `wait=false`, then `jobs_wait` with the returned job id, re-called with `pending_job_ids` on timeout, never a second `model_run`.
+7. Demo insert: animate the uploaded product photo with an image-to-video member (`scenario-video`), 3 to 5 seconds, one micro-move.
+8. Assemble per `scenario-video-assembly`: talking head as the spine, insert cut over beats three and four, captions burned into the platform's safe zone, product-name card from `scenario-text-overlay` as an image layer.
+9. `asset_display` the master, verify the product frames against the uploaded photo (`scenario-asset-analysis`), and report spend from `usage`.
+
+## Common mistakes
+
+- Writing ad copy and handing it to a mouth: alliterative taglines collapse on a talking head; read the script aloud before generating.
+- Fabricating social proof: an invented "10,000 five-star reviews" is a claim the user never made; keep numbers and testimonials to supplied wording.
+- Prompting the creator like a commercial: tripod framing, perfect light, and a spotless studio kitchen read as an ad; imperfection is the format.
+- Passing both audio and `text` to a lipsync member: exclusive inputs; pick one.
+- Skipping `dry_run` on avatar and lipsync runs: per-member pricing varies too widely to guess.
+- Generating the product or any on-screen text: the product comes from the uploaded photo, type is overlaid in assembly.
+- One 40-second clip: generate per-beat clips and cut on the beat turns; single long takes drift and cost more to retry.
+- Cropping a landscape master to 9:16: heads and captions land outside the safe zone; compose vertical from the start.


### PR DESCRIPTION
## What and why

Adds two creator-video verticals with no current coverage: `scenario-ugc` (UGC-register creator ads: talking-head, lipsync, native-audio, and faceless lanes, spoken-beat scripts, claim safety) and `scenario-fan-cam` (personalized broadcast crowd reactions built still-first: identity edit into a 16:9 plate, reaction-arc animation, graphics composited in post). Both route mechanics to sibling family skills and are wired into `skills.sh.json`, the README, and the regenerated plugin manifest.

## Validation

- [x] `pnpm format` ran, then `pnpm validate` passes locally
- [ ] `pnpm test` passes (required only when a shipped script changed)
- [x] For a new or changed skill: the application test from AGENTS.md ran (`/skills:validate <name>`), and the result is summarized below

Application test (plan-only variant, clean-room agent given only the skill under test plus the `scenario` skill):

- `scenario-ugc`: task was a 20-second TikTok testimonial from a portrait, a recorded voice memo, and a product photo, with captions and an on-screen product name. Pass. The plan used only real tools, discovered models via `search`, quoted with `dry_run` before the avatar run, ran `wait=false` then `jobs_wait` re-called with `pending_job_ids`, animated the product from the uploaded photo, kept the product name and captions out of generation, and flagged uncertainty instead of guessing where siblings weren't installed.
- `scenario-fan-cam`: task was an 8-second jumbotron reaction clip from a user photo, vertical for Reels, with a broadcast score graphic. First run failed one step: the agent fell back to local frame extraction at the identity gate. Fixed by naming the on-platform frame-extract tool-model lane in the skill; the re-run with a fresh agent passed, including the still-first pipeline, the 16:9 master with a 9:16 derivative, and the graphic composited in post.
- Baseline probes (same tasks, no skill installed) fed the raw photo straight to image-to-video, had the video model generate the score graphic, composed 9:16 directly, and assembled locally with ffmpeg, confirming both skills earn their context cost.

## Public content

- [x] No internal repositories, hostnames, team or project identifiers, customer names, or unreleased features
- [x] No credentials: no API keys, tokens, or signed asset URLs
- [x] Every tool and parameter claim is verifiable from public surfaces (the [tool reference](https://mcp.scenario.com/docs/tools), the public model catalog)

## Authorship

- [ ] A human reviewed the complete diff before this PR was submitted

Agent-authored with Claude Code; a human review of the diff is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DANPfcMr5VzfERJ9bePbYV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DANPfcMr5VzfERJ9bePbYV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill metadata only; no application code, auth, or data-handling changes.
> 
> **Overview**
> Adds two **Video and audio** director skills and registers them in the Claude plugin manifest, `skills.sh.json`, and the README.
> 
> **`scenario-ugc`** guides agents through phone-native creator ads: routing by lane (talking avatar, lipsync, native-audio video, faceless VO + b-roll), six-beat spoken scripts, mandatory real product uploads, and claim-safe copy (no invented testimonials or metrics). **`scenario-fan-cam`** defines a still-first broadcast pipeline—identity image edit into a text-free 16:9 crowd plate, likeness gates, reaction-arc image-to-video, graphics via overlay/assembly, then vertical derivatives.
> 
> Spellcheck adds `defocused` for fan-cam prompt language. No shipped scripts or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ad6cb12ab947194373750a9ed717d1c9ab928a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->