### PR TITLE
fix(skills): name the direct tools and the resize surface agents kept missing

### DIFF
--- a/skills/scenario-formats/SKILL.md
+++ b/skills/scenario-formats/SKILL.md
@@ -12,7 +12,7 @@ Format adaptation is derivation, not regeneration: re-prompting the concept per 
 
 ## The decision ladder
 
-Per target format, take the first rung that fits:
+Per target format, take the first rung that fits. Each rung is a `model_run` on a model found with `search` (`target="models"`, `public=true`), never a dedicated MCP tool of its own:
 
 | The target needs                             | Operation                                                                                                                           |
 | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -14,7 +14,7 @@ Scenario (scenario.com) generates AI images, video, 3D, and audio across 500+ mo
 
 Endpoint: `https://mcp.scenario.com/mcp` (Streamable HTTP). Prefer OAuth: no credentials pass through the conversation. Client config and API-key setup for headless use: [references/setup.md](references/setup.md). Never ask an agent to collect, encode, or echo a secret.
 
-The default toolset is the core loop below; `?toolsets=full` exposes everything. Any other tool: `scenario_tools_search` with the verb as `query` returns its schema and lane; the matching `scenario_tool_execute_read` / `write` / `delete` runs it with `{name, parameters}`, scope ids inside `parameters` (unlike the core tools' top-level `team_id`/`project_id`). The lane is the result's own `permission`, not what the verb sounds like: `asset_download` and `asset_analyze` are both write-class.
+The default toolset is wider than the core loop below: `asset_get`, `job_get`, `jobs_list` and `models_list` are in it too and are called directly, so treat the table as the loop rather than the whole list. `?toolsets=full` exposes everything. The catalog tools are the ones outside it (collections, tagging, analysis, training, members, keys): `scenario_tools_search` with the verb as `query` returns the schema and lane, and the matching `scenario_tool_execute_read` / `write` / `delete` runs it with `{name, parameters}`, scope ids inside `parameters` (unlike a direct tool's top-level `team_id`/`project_id`). The lane is the result's own `permission`, not what the verb sounds like: `asset_download` and `asset_analyze` are both write-class.
 
 ## Scope first
 
@@ -32,6 +32,7 @@ The server fills scope in only for read-only tools with one candidate remaining;
 | Generate          | `model_run`                              | Schema-conformant `parameters`; `dry_run` for cost              |
 | Wait              | `jobs_wait`                              | Only if `model_run` returns `in_progress`; never loop `job_get` |
 | View / save       | `asset_display` / `asset_download`       | Never paste raw asset URLs                                      |
+| Inspect an asset  | `asset_get`                              | Free; dimensions, duration, `firstFrame` / `lastFrame` ids      |
 | Upload inputs     | `upload_asset` + `upload_asset_complete` | Local files become asset_ids                                    |
 | Refine a prompt   | `prompt_spark`                           | Advisory rewrite; needs `model_id`                              |
 | Quota / debugging | `usage`, `diagnostics_run`               | CU consumption; `diagnose` MCP prompt                           |


### PR DESCRIPTION
## What and why

Two mis-routings that clean-room planning runs hit repeatedly while validating #85. Both are pre-existing on `main` and independent of that PR (they touch different lines; a test merge against its head is clean).

**`asset_get` looked catalog-only.** It is in the default toolset and is called directly, but Setup read "The default toolset is the core loop below" and the quick reference table omits it. Three of four agents concluded it needed the catalog route and planned `scenario_tools_search` then `scenario_tool_execute_read` for it, with scope ids moved inside `parameters`. One called the detour "an awkward dependency for a tool whose whole value is being free". Two others flagged it as their top friction, and one hedged every `asset_get` step with both call shapes.

- `scenario`: Setup now says the default toolset is wider than the table and names `asset_get`, `job_get`, `jobs_list` and `models_list` as direct calls, and scopes "any other tool" to the catalog families it actually means. The quick reference gains an `asset_get` row.

**The formats ladder never says its rungs are model runs.** An agent holding only `scenario-formats` planned the resize as `scenario_tool_execute_write` against the tool catalog: the ladder names operations ("Resize", "Expand or uncrop", "Generative reframe") and defers contracts to `scenario-image-editing`, which a real install need not ship.

- `scenario-formats`: the ladder now says each rung is a `model_run` on a model found with `search`, which also heads off the "reach for an MCP tool named resize" failure the sibling skills warn about.

Verified against the live surface: `asset_get` is exposed directly on `https://mcp.scenario.com/mcp` with no `?toolsets=full`, and the tool reference does not mark it catalog-only (unlike `asset_analyze`, `assets_list`, and the collection tools).

## Validation

- [x] `pnpm format` ran, then `pnpm validate` passes locally
- [x] `pnpm test` passes (required only when a shipped script changed): not applicable, no script changed
- [x] For a new or changed skill: the application test from AGENTS.md ran, summarized below

Application test: two fresh clean-room agents, `--plan-only` (zero credits), one per changed skill, same tasks that produced the original mis-routings. Both now call `asset_get` directly with top-level `team_id`/`project_id`, and the formats agent routes the ladder through `search`, `model_schema_get`, `model_run`. Neither reaches for `scenario_tool_execute_*` on a direct tool any more.

Bodies stay well inside the budget: `scenario` 1255 words, `scenario-formats` 771.

## Public content

- [x] No internal repositories, hostnames, team or project identifiers, customer names, or unreleased features
- [x] No credentials: no API keys, tokens, or signed asset URLs
- [x] Every tool and parameter claim is verifiable from public surfaces (the [tool reference](https://mcp.scenario.com/docs/tools), the live default toolset)

## Authorship

- [ ] A human reviewed the complete diff before this PR was submitted

Authored with Claude Code; the diff is two changed lines plus one table row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to skill markdown; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Clarifies two agent routing mistakes in Scenario MCP skill docs discovered during planning validation.
> 
> **`scenario`:** Setup no longer implies the quick-reference table is the full default toolset—it names **`asset_get`**, **`job_get`**, **`jobs_list`**, and **`models_list`** as direct calls and limits the catalog path (`scenario_tools_search` + `scenario_tool_execute_*`) to tools outside that set. The quick reference adds an **Inspect an asset** row for **`asset_get`** (free metadata, frame ids).
> 
> **`scenario-formats`:** The decision ladder now states each rung (resize, expand, reframe, recompose) is executed via **`model_run`** on a model from **`search`**, not a standalone resize/reframe MCP tool or catalog write.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48b154c306c499b092aceb8b4cb2bddaa8f72cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->