### PR TITLE
fix(skills): route every wait=false launch to jobs_wait regardless of the status word

### DIFF
--- a/skills/scenario-3d/SKILL.md
+++ b/skills/scenario-3d/SKILL.md
@@ -12,14 +12,14 @@ Scenario runs text-to-3D, image-to-3D, and 3D-to-3D models behind the same MCP g
 
 ## Quick reference
 
-| Step           | Tool                                                                           | Notes                                                                                                |
-| -------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Find 3D models | `recommend` with the capability and the user's own words (`search` for a name) | Capabilities: `txt23d`, `img23d`, `3d23d`                                                            |
-| Inspect inputs | `model_schema_get`                                                             | Always call before `model_run`                                                                       |
-| Generate       | `model_run`                                                                    | Pass reference images as asset IDs                                                                   |
-| Wait           | `jobs_wait`                                                                    | Long jobs return `in_progress` with a `job_id`; pass it in `job_ids`; never poll `job_get` in a loop |
-| Preview        | `asset_display`                                                                | Interactive GLB/FBX/VOX/OBJ viewer on MCP App hosts                                                  |
-| Download       | `asset_download`                                                               | Returns a URL; save with `curl -L`                                                                   |
+| Step           | Tool                                                                           | Notes                                                                                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Find 3D models | `recommend` with the capability and the user's own words (`search` for a name) | Capabilities: `txt23d`, `img23d`, `3d23d`                                                                                                                                   |
+| Inspect inputs | `model_schema_get`                                                             | Always call before `model_run`                                                                                                                                              |
+| Generate       | `model_run`                                                                    | Pass reference images as asset IDs                                                                                                                                          |
+| Wait           | `jobs_wait`                                                                    | Any `job_id` returned without assets (`in_progress` after a timed-out wait, `queued` or `in-progress` after `wait=false`) goes in `job_ids`; never poll `job_get` in a loop |
+| Preview        | `asset_display`                                                                | Interactive GLB/FBX/VOX/OBJ viewer on MCP App hosts                                                                                                                         |
+| Download       | `asset_download`                                                               | Returns a URL; save with `curl -L`                                                                                                                                          |
 
 ## Worked example: concept image to game-ready mesh
 

--- a/skills/scenario-audio/SKILL.md
+++ b/skills/scenario-audio/SKILL.md
@@ -39,7 +39,7 @@ Per-family contracts: `scenario-elevenlabs` (speech, dubbing, re-voicing, music,
 1. `recommend` with `capability="txt2audio"` and the user's own words as `prompt` ("a game sound effect: a heavy wooden chest creaking open"). The ranking returns txt2audio models such as `model_elevenlabs-sound-effects-v2` (example only).
 2. `model_schema_get` with that `model_id`. Returns the exact fields: prompt plus controls such as duration or looping.
 3. `model_run` with the same `model_id` and parameters={"prompt": "heavy wooden treasure chest creaking open, single event, dry, no music"}.
-4. If status='in_progress', `jobs_wait` job_ids=["job_xxx"], re-calling with the returned pending_job_ids on timeout.
+4. `jobs_wait` job_ids=["job_xxx"] on any `job_id` returned without assets (`in_progress` after a timed-out wait, the backend's `queued` or `in-progress` after `wait=false`), re-calling with the returned pending_job_ids on timeout.
 5. `asset_display` asset_id="asset_xxx" to play it inline.
 6. `asset_download` with no `format`, then save the returned URL with `curl -L`.
 

--- a/skills/scenario-identity-library/SKILL.md
+++ b/skills/scenario-identity-library/SKILL.md
@@ -37,7 +37,7 @@ Scenario's Grid Maker packs approved shots into one sheet image: its id is the f
 ## Worked example: Nima, courier robot
 
 1. The interview yields the brief: rounded silhouette, copper shell, one cracked headlamp, canvas satchel, cel shading; views front, back, left, three-quarter.
-2. `recommend` with the brief's own words; `model_schema_get` confirms a true reference field (else the next candidate); `model_run` the hero, `jobs_wait` only on `in_progress`, gate per `scenario-quality-gate`, iterate to pass.
+2. `recommend` with the brief's own words; `model_schema_get` confirms a true reference field (else the next candidate); `model_run` the hero, `jobs_wait` whenever `model_run` returns a `job_id` without assets, gate per `scenario-quality-gate`, iterate to pass.
 3. `collection_create` `"character: Nima"`; `collection_add_assets` the hero, tagged `hero`.
 4. Three more views, baseline-plus-delta with the hero in the reference field, gated, filed on pass with their view tags.
 5. Run Grid Maker on the view-tagged members (this session already holds the ids; a just-filed asset can trail the `search` index) with `images` as [front, back, left, three-quarter] and `columns: 4`; tag the output `sheet` and file it.

--- a/skills/scenario/SKILL.md
+++ b/skills/scenario/SKILL.md
@@ -24,18 +24,18 @@ The server fills scope in only for read-only tools with one candidate remaining;
 
 ## Quick reference
 
-| Step              | Tool                                     | Notes                                                           |
-| ----------------- | ---------------------------------------- | --------------------------------------------------------------- |
-| Resolve scope     | `teams_list`, then `projects_list`       | Once per session; pass the ids on every call                    |
-| Find a model      | `search` or `recommend`                  | Free; `recommend` for a capability, `search` for a name         |
-| Get the schema    | `model_schema_get`                       | Always before `model_run`; check `runs_as` and caps             |
-| Generate          | `model_run`                              | Schema-conformant `parameters`; `dry_run` for cost              |
-| Wait              | `jobs_wait`                              | Only if `model_run` returns `in_progress`; never loop `job_get` |
-| View / save       | `asset_display` / `asset_download`       | Never paste raw asset URLs                                      |
-| Inspect an asset  | `asset_get`                              | Free; dimensions, duration, `firstFrame` / `lastFrame` ids      |
-| Upload inputs     | `upload_asset` + `upload_asset_complete` | Local files become asset_ids                                    |
-| Refine a prompt   | `prompt_spark`                           | Advisory rewrite; needs `model_id`                              |
-| Quota / debugging | `usage`, `diagnostics_run`               | CU consumption; `diagnose` MCP prompt                           |
+| Step              | Tool                                     | Notes                                                                        |
+| ----------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
+| Resolve scope     | `teams_list`, then `projects_list`       | Once per session; pass the ids on every call                                 |
+| Find a model      | `search` or `recommend`                  | Free; `recommend` for a capability, `search` for a name                      |
+| Get the schema    | `model_schema_get`                       | Always before `model_run`; check `runs_as` and caps                          |
+| Generate          | `model_run`                              | Schema-conformant `parameters`; `dry_run` for cost                           |
+| Wait              | `jobs_wait`                              | Whenever `model_run` returns a `job_id` without assets; never loop `job_get` |
+| View / save       | `asset_display` / `asset_download`       | Never paste raw asset URLs                                                   |
+| Inspect an asset  | `asset_get`                              | Free; dimensions, duration, `firstFrame` / `lastFrame` ids                   |
+| Upload inputs     | `upload_asset` + `upload_asset_complete` | Local files become asset_ids                                                 |
+| Refine a prompt   | `prompt_spark`                           | Advisory rewrite; needs `model_id`                                           |
+| Quota / debugging | `usage`, `diagnostics_run`               | CU consumption; `diagnose` MCP prompt                                        |
 
 A multi-step request ("product video with voiceover", "concept to 3D") goes to `plan_generation` (catalog-only, read lane): plain words in `description`, ordered steps out, each naming a tool and optional model hint; it runs nothing. Single-step: `recommend`.
 
@@ -47,7 +47,7 @@ Generating a stylized game prop image:
 2. `model_schema_get` on the pick: exact field names, types, required flags, defaults, and caps such as the prompt's `max_length` (an overrun is a 400, never a trim). File fields take asset ids even when named `...Url`, and `cost_impact: true` flags what moves the price.
 3. If the schema carries `runs_as` (`"lora"` or `"composition"`), never send that model's own id to `model_run`. Its `run_with.required_arguments` holds the real call: `model_id` there is the base model, and its `parameters` (the `loras` or `modelId` wiring) merge into inputs from the same schema. Sending `required_arguments` alone discards your prompt.
 4. Optional: `prompt_spark` rewrites a thin prompt into an on-model one; pass the discovered id (a LoRA's own, not its base) and the draft `prompt`. Skip deliberate prompts.
-5. `model_run` with `model_id` and schema-conformant `parameters`. If cost matters (the default assumption unless the user says otherwise), price first with `dry_run: true`, a top-level argument beside `model_id`: no job is created and the response's `creativeUnitsCost` is the exact payload's price; a `recommend` cost quote assumes defaults, and the schema's `cost_impact` fields move the real number. Then run: asset_ids come back, or `status="in_progress"` with a `job_id`.
+5. `model_run` with `model_id` and schema-conformant `parameters`. If cost matters (the default assumption unless the user says otherwise), price first with `dry_run: true`, a top-level argument beside `model_id`: no job is created and the response's `creativeUnitsCost` is the exact payload's price; a `recommend` cost quote assumes defaults, and the schema's `cost_impact` fields move the real number. Then run: asset_ids come back, or a `job_id` for `jobs_wait`. The `status` beside it is `in_progress` when the server's wait budget ran out; with `wait=false` it is the backend's live word at creation (`queued`, `in-progress`, `warming-up`), a spelling that is not a different state.
 6. `jobs_wait` with `job_ids=[...]` (up to 32); each completed row carries `assetIds` and `cuCost`, so no `job_get` follow-up; on timeout re-call with the returned `pending_job_ids` as `job_ids`. Failed jobs are reimbursed, except xAI generations stopped by moderation.
 7. `asset_display` shows the asset inline; `asset_download` returns a file URL (save with `curl -L`, it may redirect). `format` is an image conversion (`png`, `webp`, `jpg`, and `gif` to keep an animated GIF animated: the `png` default flattens it to one frame) and nothing else; omit it for video, 3D, and audio.
 


### PR DESCRIPTION
## Summary

`model_run` carries two status vocabularies, and four skills described only one of them.

- `wait=true` that outruns the server's wait budget returns `status: "in_progress"` (underscore), the MCP envelope word. This is the case the skills already taught.
- `wait=false` returns the backend job's live status at creation: `queued`, `in-progress`, `warming-up`, the same hyphenated vocabulary the `jobs_list` status filter enum exposes (`pending`, `queued`, `warming-up`, `in-progress`, `success`, `failure`, `canceled`, `finalizing`). The response is `model_id`, `job_id`, `status` and nothing else: no message tells the agent what to do next.

The `scenario` Wait row read "Only if `model_run` returns `in_progress`", and three siblings keyed their wait step on the same word next to a launch they make with `wait=false`. That path never returns `in_progress`, so an agent matching the sentence literally had grounds to skip `jobs_wait` on a `queued` or `in-progress` result.

Surfaced by the #111 validation run (three `wait=false` launches, three `status: "in-progress"`), where the report filed it as a follow-up on the `scenario` skill.

## Changes

- `skills/scenario/SKILL.md`: the Wait row runs `jobs_wait` whenever `model_run` returns a `job_id` without assets; step 5 names both spellings, `in_progress` for the timed-out wait and the backend's live word after `wait=false`, and says the hyphenated one is not a different state. The `jobs_wait` timeout row keeps `in_progress`, which is that tool's top-level status.
- `skills/scenario-audio/SKILL.md` step 4, `skills/scenario-3d/SKILL.md` Wait row: the same rule with both spellings named, since each skill teaches the `wait=false` launch.
- `skills/scenario-identity-library/SKILL.md` step 2: `jobs_wait` whenever `model_run` returns a `job_id` without assets.

## Validation

- `pnpm validate` passes on every commit (style, format, skill-files, groupings, manifest, readme, words, spell, spec).
- Bodies: `scenario` 1387 words, `scenario-audio` 968, `scenario-identity-library` 1012, `scenario-3d` 1001, all under the cap.
- Application test posted below: one live clean-room run of `scenario` (the `wait=false` launch came back `queued` and the agent still went to `jobs_wait`, 1 CU billed against a 1 CU quote) and plan-only runs of the three siblings, all pass with notes.
- No script touched, so no test suite change.

## Upstream

The public `model_run` reference names only `in_progress`, says `wait=false` "returns immediately with a job_id" without naming its status words, and its example response shows `"status": "succeeded"` where live job records read `success`. Reported to the MCP server maintainers with a suggested wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
